### PR TITLE
feat(config): add Groq API key to AppConfig + Settings UI (P011 T1)

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -6,6 +6,7 @@ class AppConfig {
   const AppConfig({
     this.apiUrl,
     this.apiToken,
+    this.groqApiKey,
     this.autoSend = true,
     this.language = 'auto',
     this.keepHistory = true,
@@ -13,6 +14,7 @@ class AppConfig {
 
   final String? apiUrl;
   final String? apiToken;
+  final String? groqApiKey;
   final bool autoSend;
   final String language;
   final bool keepHistory;
@@ -20,6 +22,7 @@ class AppConfig {
   AppConfig copyWith({
     Object? apiUrl = _sentinel,
     Object? apiToken = _sentinel,
+    Object? groqApiKey = _sentinel,
     bool? autoSend,
     String? language,
     bool? keepHistory,
@@ -27,6 +30,8 @@ class AppConfig {
     return AppConfig(
       apiUrl: apiUrl == _sentinel ? this.apiUrl : apiUrl as String?,
       apiToken: apiToken == _sentinel ? this.apiToken : apiToken as String?,
+      groqApiKey:
+          groqApiKey == _sentinel ? this.groqApiKey : groqApiKey as String?,
       autoSend: autoSend ?? this.autoSend,
       language: language ?? this.language,
       keepHistory: keepHistory ?? this.keepHistory,

--- a/lib/core/config/app_config_provider.dart
+++ b/lib/core/config/app_config_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/core/config/app_config.dart';
 import 'package:voice_agent/core/config/app_config_service.dart';
@@ -17,9 +19,18 @@ class AppConfigNotifier extends StateNotifier<AppConfig> {
   }
 
   final AppConfigService _service;
+  final _loadCompleter = Completer<void>();
+
+  /// Completes when the initial async load from secure storage finishes.
+  /// Always completes — even if storage throws — so awaiting it never hangs.
+  Future<void> get loadCompleted => _loadCompleter.future;
 
   Future<void> _load() async {
-    state = await _service.load();
+    try {
+      state = await _service.load();
+    } finally {
+      if (!_loadCompleter.isCompleted) _loadCompleter.complete();
+    }
   }
 
   Future<void> updateApiUrl(String url) async {
@@ -45,5 +56,10 @@ class AppConfigNotifier extends StateNotifier<AppConfig> {
   Future<void> updateKeepHistory(bool value) async {
     await _service.saveKeepHistory(value);
     state = state.copyWith(keepHistory: value);
+  }
+
+  Future<void> updateGroqApiKey(String key) async {
+    await _service.saveGroqApiKey(key);
+    state = state.copyWith(groqApiKey: key);
   }
 }

--- a/lib/core/config/app_config_service.dart
+++ b/lib/core/config/app_config_service.dart
@@ -17,6 +17,7 @@ class AppConfigService {
 
   static const _apiUrlKey = 'api_url';
   static const _apiTokenKey = 'api_token';
+  static const _groqApiKeyKey = 'groq_api_key';
   static const _autoSendKey = 'auto_send';
   static const _languageKey = 'language';
   static const _keepHistoryKey = 'keep_history';
@@ -34,10 +35,17 @@ class AppConfigService {
     } catch (_) {
       // Secure storage may fail on some devices — treat as absent
     }
+    String? groqApiKey;
+    try {
+      groqApiKey = await _secureStorage.read(key: _groqApiKeyKey);
+    } catch (_) {
+      // Secure storage may fail on some devices — treat as absent
+    }
 
     return AppConfig(
       apiUrl: prefs.getString(_apiUrlKey),
       apiToken: token,
+      groqApiKey: groqApiKey,
       autoSend: prefs.getBool(_autoSendKey) ?? true,
       language: prefs.getString(_languageKey) ?? 'auto',
       keepHistory: prefs.getBool(_keepHistoryKey) ?? true,
@@ -51,6 +59,10 @@ class AppConfigService {
 
   Future<void> saveApiToken(String token) async {
     await _secureStorage.write(key: _apiTokenKey, value: token);
+  }
+
+  Future<void> saveGroqApiKey(String key) async {
+    await _secureStorage.write(key: _groqApiKeyKey, value: key);
   }
 
   Future<void> saveAutoSend(bool value) async {

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/config/app_config.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/network/api_client.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
@@ -18,8 +19,10 @@ class SettingsScreen extends ConsumerStatefulWidget {
 class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   late final TextEditingController _urlController;
   late final TextEditingController _tokenController;
+  late final TextEditingController _groqKeyController;
   String? _urlError;
   _TestStatus _testStatus = _TestStatus.idle;
+  ProviderSubscription<AppConfig>? _configSubscription;
 
   @override
   void initState() {
@@ -27,12 +30,28 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final config = ref.read(appConfigProvider);
     _urlController = TextEditingController(text: config.apiUrl ?? '');
     _tokenController = TextEditingController(text: config.apiToken ?? '');
+    _groqKeyController = TextEditingController(text: config.groqApiKey ?? '');
+    // listenManual is the correct API for initState — keeps controllers in sync
+    // when appConfigProvider emits the loaded value after async secure-storage read.
+    _configSubscription = ref.listenManual(appConfigProvider, (_, next) {
+      if (_urlController.text.isEmpty) {
+        _urlController.text = next.apiUrl ?? '';
+      }
+      if (_tokenController.text.isEmpty) {
+        _tokenController.text = next.apiToken ?? '';
+      }
+      if (_groqKeyController.text.isEmpty) {
+        _groqKeyController.text = next.groqApiKey ?? '';
+      }
+    });
   }
 
   @override
   void dispose() {
+    _configSubscription?.close();
     _urlController.dispose();
     _tokenController.dispose();
+    _groqKeyController.dispose();
     super.dispose();
   }
 
@@ -58,6 +77,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   void _onTokenFocusLost() {
     final token = _tokenController.text;
     ref.read(appConfigProvider.notifier).updateApiToken(token);
+  }
+
+  void _onGroqKeyFocusLost() {
+    final key = _groqKeyController.text;
+    ref.read(appConfigProvider.notifier).updateGroqApiKey(key);
   }
 
   Future<void> _testConnection() async {
@@ -163,6 +187,23 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             ),
           ),
           _buildSectionHeader('Transcription'),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Focus(
+              onFocusChange: (hasFocus) {
+                if (!hasFocus) _onGroqKeyFocusLost();
+              },
+              child: TextField(
+                controller: _groqKeyController,
+                decoration: const InputDecoration(
+                  labelText: 'Groq API Key',
+                  hintText: 'gsk_...',
+                  border: OutlineInputBorder(),
+                ),
+                obscureText: true,
+              ),
+            ),
+          ),
           ListTile(
             title: const Text('Language'),
             trailing: DropdownButton<String>(

--- a/test/core/config/app_config_service_test.dart
+++ b/test/core/config/app_config_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:voice_agent/core/config/app_config_service.dart';
@@ -6,6 +7,7 @@ void main() {
   group('AppConfigService', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
+      FlutterSecureStorage.setMockInitialValues({});
     });
 
     test('load returns defaults when storage is empty', () async {
@@ -17,6 +19,7 @@ void main() {
 
       expect(config.apiUrl, isNull);
       expect(config.apiToken, isNull);
+      expect(config.groqApiKey, isNull);
       expect(config.autoSend, isTrue);
       expect(config.language, 'auto');
       expect(config.keepHistory, isTrue);
@@ -64,6 +67,29 @@ void main() {
       final config = await service.load();
 
       expect(config.keepHistory, isFalse);
+    });
+
+    test('saveGroqApiKey then load round-trips', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final service = AppConfigService(prefs: prefs);
+
+      await service.saveGroqApiKey('gsk_test_key');
+      final config = await service.load();
+
+      expect(config.groqApiKey, 'gsk_test_key');
+    });
+
+    test('saveGroqApiKey with empty string stores empty string', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final service = AppConfigService(prefs: prefs);
+
+      await service.saveGroqApiKey('gsk_test_key');
+      await service.saveGroqApiKey('');
+      final config = await service.load();
+
+      expect(config.groqApiKey, '');
     });
 
     test('multiple saves preserve all values', () async {

--- a/test/features/settings/settings_model_test.dart
+++ b/test/features/settings/settings_model_test.dart
@@ -7,6 +7,7 @@ void main() {
       const config = AppConfig();
       expect(config.apiUrl, isNull);
       expect(config.apiToken, isNull);
+      expect(config.groqApiKey, isNull);
       expect(config.autoSend, isTrue);
       expect(config.language, 'auto');
       expect(config.keepHistory, isTrue);
@@ -36,6 +37,24 @@ void main() {
       expect(copy.apiUrl, 'https://test.com');
       expect(copy.autoSend, isFalse);
       expect(copy.language, 'pl');
+    });
+
+    test('copyWith updates groqApiKey', () {
+      const original = AppConfig();
+      final updated = original.copyWith(groqApiKey: 'gsk_test');
+      expect(updated.groqApiKey, 'gsk_test');
+    });
+
+    test('copyWith(groqApiKey: null) clears the key', () {
+      const original = AppConfig(groqApiKey: 'gsk_test');
+      final updated = original.copyWith(groqApiKey: null);
+      expect(updated.groqApiKey, isNull);
+    });
+
+    test('copyWith without groqApiKey preserves existing value', () {
+      const original = AppConfig(groqApiKey: 'gsk_test');
+      final updated = original.copyWith(autoSend: false);
+      expect(updated.groqApiKey, 'gsk_test');
     });
   });
 }

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/app/app.dart';
+import 'package:voice_agent/core/config/app_config.dart';
+import 'package:voice_agent/core/config/app_config_service.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/models/sync_queue_item.dart';
+import 'package:voice_agent/core/models/transcript.dart';
+import 'package:voice_agent/core/models/transcript_with_status.dart';
+import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/storage/storage_provider.dart';
+import 'package:voice_agent/core/storage/storage_service.dart';
+import 'package:voice_agent/features/api_sync/sync_provider.dart';
+
+class _StubStorage implements StorageService {
+  @override Future<String> getDeviceId() async => 'test';
+  @override Future<List<TranscriptWithStatus>> getTranscriptsWithStatus({int limit = 20, int offset = 0}) async => [];
+  @override Future<void> saveTranscript(Transcript t) async {}
+  @override Future<Transcript?> getTranscript(String id) async => null;
+  @override Future<List<Transcript>> getTranscripts({int limit = 50, int offset = 0}) async => [];
+  @override Future<void> deleteTranscript(String id) async {}
+  @override Future<void> enqueue(String transcriptId) async {}
+  @override Future<List<SyncQueueItem>> getPendingItems() async => []
+  ;
+  @override Future<void> markSending(String id) async {}
+  @override Future<void> markSent(String id) async {}
+  @override Future<void> markFailed(String id, String error) async {}
+  @override Future<void> markPendingForRetry(String id) async {}
+  @override Future<void> reactivateForResend(String transcriptId) async {}
+}
+
+class _NoOpConnectivity extends ConnectivityService {
+  @override
+  Stream<ConnectivityStatus> get statusStream => const Stream.empty();
+}
+
+/// A fake AppConfigService that returns a pre-seeded config synchronously.
+class _SeededConfigService extends AppConfigService {
+  _SeededConfigService(this._config);
+
+  final AppConfig _config;
+
+  @override
+  Future<AppConfig> load() async => _config;
+
+  @override
+  Future<void> saveGroqApiKey(String key) async {}
+
+  @override
+  Future<void> saveApiUrl(String url) async {}
+
+  @override
+  Future<void> saveApiToken(String token) async {}
+}
+
+List<Override> _baseOverrides() => [
+  storageServiceProvider.overrideWithValue(_StubStorage()),
+  connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
+];
+
+Future<void> _navigateToSettings(WidgetTester tester) async {
+  await tester.tap(find.byIcon(Icons.settings));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('SettingsScreen', () {
+    testWidgets('Groq API Key field appears in Transcription section',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: _baseOverrides(),
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await _navigateToSettings(tester);
+
+      expect(find.widgetWithText(TextField, 'Groq API Key'), findsOneWidget);
+    });
+
+    testWidgets('Groq API Key field is populated after async config load',
+        (tester) async {
+      final seededService = _SeededConfigService(
+        const AppConfig(groqApiKey: 'gsk_test_key'),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ..._baseOverrides(),
+            appConfigServiceProvider.overrideWithValue(seededService),
+          ],
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await _navigateToSettings(tester);
+
+      final groqField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Groq API Key'),
+      );
+      expect(groqField.controller?.text, 'gsk_test_key');
+    });
+
+    testWidgets('URL and token fields are populated after async config load',
+        (tester) async {
+      final seededService = _SeededConfigService(
+        const AppConfig(
+          apiUrl: 'https://example.com',
+          apiToken: 'token_123',
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ..._baseOverrides(),
+            appConfigServiceProvider.overrideWithValue(seededService),
+          ],
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await _navigateToSettings(tester);
+
+      final urlField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'API URL'),
+      );
+      expect(urlField.controller?.text, 'https://example.com');
+
+      final tokenField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'API Token'),
+      );
+      expect(tokenField.controller?.text, 'token_123');
+    });
+
+    testWidgets('Groq API Key field saves on focus lost', (tester) async {
+      String? savedKey;
+      final trackingService = _TrackingConfigService(
+        onSaveGroqApiKey: (k) => savedKey = k,
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ..._baseOverrides(),
+            appConfigServiceProvider.overrideWithValue(trackingService),
+          ],
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await _navigateToSettings(tester);
+
+      await tester.tap(find.widgetWithText(TextField, 'Groq API Key'));
+      await tester.pump();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Groq API Key'),
+        'gsk_new_key',
+      );
+
+      // Move focus away to trigger focus-lost save
+      await tester.tap(find.widgetWithText(TextField, 'API Token'));
+      await tester.pump();
+
+      expect(savedKey, 'gsk_new_key');
+    });
+  });
+}
+
+class _TrackingConfigService extends AppConfigService {
+  _TrackingConfigService({required this.onSaveGroqApiKey});
+
+  final void Function(String) onSaveGroqApiKey;
+
+  @override
+  Future<AppConfig> load() async => const AppConfig();
+
+  @override
+  Future<void> saveGroqApiKey(String key) async => onSaveGroqApiKey(key);
+
+  @override
+  Future<void> saveApiUrl(String url) async {}
+
+  @override
+  Future<void> saveApiToken(String token) async {}
+}


### PR DESCRIPTION
Part of Proposal 011 — Groq Cloud STT.

## Summary
- Add `groqApiKey: String?` to `AppConfig` with sentinel `copyWith`
- Add `saveGroqApiKey` / load in `AppConfigService` (flutter_secure_storage, key: `groq_api_key`)
- Add `loadCompleted` Completer and `updateGroqApiKey` to `AppConfigNotifier`
- Fix async-load latent bug for URL, token, and Groq key fields in `SettingsScreen` via `ref.listenManual`
- Add Groq API Key text field (obscured) in Transcription section, saves on focus-lost

## Test plan
- `AppConfigService`: round-trip save/load for `groqApiKey`, empty-string clear
- `AppConfig`: `copyWith` sentinel behaviour for `groqApiKey`
- `SettingsScreen`: field appears, populated after async load, URL/token regression, saves on focus-lost
- All 132 tests pass

Closes #72