### PR TITLE
feat(recording): guard recording start for missing Groq key (P011 T3)

### DIFF
--- a/lib/features/recording/domain/recording_state.dart
+++ b/lib/features/recording/domain/recording_state.dart
@@ -11,6 +11,7 @@ sealed class RecordingState {
   const factory RecordingState.error(
     String message, {
     bool requiresSettings,
+    bool requiresAppSettings,
   }) = RecordingError;
 }
 
@@ -32,7 +33,16 @@ class RecordingCompleted extends RecordingState {
 }
 
 class RecordingError extends RecordingState {
-  const RecordingError(this.message, {this.requiresSettings = false});
+  const RecordingError(
+    this.message, {
+    this.requiresSettings = false,
+    this.requiresAppSettings = false,
+  }) : assert(
+          !(requiresSettings && requiresAppSettings),
+          'requiresSettings and requiresAppSettings are mutually exclusive',
+        );
+
   final String message;
   final bool requiresSettings;
+  final bool requiresAppSettings;
 }

--- a/lib/features/recording/presentation/recording_controller.dart
+++ b/lib/features/recording/presentation/recording_controller.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/features/recording/domain/recording_service.dart';
 import 'package:voice_agent/features/recording/domain/recording_state.dart';
 import 'package:voice_agent/features/recording/domain/stt_exception.dart';
@@ -10,13 +11,14 @@ import 'package:voice_agent/features/recording/domain/stt_service.dart';
 
 class RecordingController extends StateNotifier<RecordingState>
     with WidgetsBindingObserver {
-  RecordingController(this._service, this._sttService)
+  RecordingController(this._service, this._sttService, this._ref)
       : super(const RecordingState.idle()) {
     WidgetsBinding.instance.addObserver(this);
   }
 
   final RecordingService _service;
   final SttService _sttService;
+  final Ref _ref;
   StreamSubscription<Duration>? _elapsedSub;
   Duration _currentElapsed = Duration.zero;
 
@@ -35,6 +37,17 @@ class RecordingController extends StateNotifier<RecordingState>
       state = const RecordingState.error(
         'Microphone permission denied. Please enable it in app settings.',
         requiresSettings: true,
+      );
+      return;
+    }
+
+    // Await the initial config load so we read the persisted key, not the default null.
+    await _ref.read(appConfigProvider.notifier).loadCompleted;
+    final config = _ref.read(appConfigProvider);
+    if (config.groqApiKey == null || config.groqApiKey!.isEmpty) {
+      state = const RecordingState.error(
+        'Groq API key not set.',
+        requiresAppSettings: true,
       );
       return;
     }

--- a/lib/features/recording/presentation/recording_providers.dart
+++ b/lib/features/recording/presentation/recording_providers.dart
@@ -19,5 +19,6 @@ final recordingControllerProvider =
   return RecordingController(
     ref.watch(recordingServiceProvider),
     ref.watch(sttServiceProvider),
+    ref,
   );
 });

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -71,7 +71,12 @@ class RecordingScreen extends ConsumerWidget {
           ],
         ),
       RecordingCompleted() => const SizedBox.shrink(), // handled by listener
-      RecordingError(:final message, :final requiresSettings) => Column(
+      RecordingError(
+        :final message,
+        :final requiresSettings,
+        :final requiresAppSettings,
+      ) =>
+        Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             const Icon(Icons.error, size: 64, color: Colors.red),
@@ -85,7 +90,13 @@ class RecordingScreen extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 24),
-            if (requiresSettings)
+            if (requiresAppSettings)
+              FilledButton.icon(
+                onPressed: () => context.go('/settings'),
+                icon: const Icon(Icons.settings),
+                label: const Text('Go to Settings'),
+              )
+            else if (requiresSettings)
               FilledButton.icon(
                 onPressed: openAppSettings,
                 icon: const Icon(Icons.settings),

--- a/test/features/recording/presentation/recording_controller_test.dart
+++ b/test/features/recording/presentation/recording_controller_test.dart
@@ -1,13 +1,24 @@
 import 'dart:async';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:voice_agent/core/config/app_config.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/config/app_config_service.dart';
+import 'package:voice_agent/core/models/transcript_result.dart';
 import 'package:voice_agent/features/recording/domain/recording_result.dart';
 import 'package:voice_agent/features/recording/domain/recording_service.dart';
 import 'package:voice_agent/features/recording/domain/recording_state.dart';
 import 'package:voice_agent/features/recording/domain/stt_exception.dart';
 import 'package:voice_agent/features/recording/domain/stt_service.dart';
-import 'package:voice_agent/core/models/transcript_result.dart';
 import 'package:voice_agent/features/recording/presentation/recording_controller.dart';
+import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
 
 class FakeRecordingService implements RecordingService {
   bool _isRecording = false;
@@ -79,21 +90,67 @@ class FakeSttService implements SttService {
   }
 }
 
+class _FixedConfigService extends AppConfigService {
+  _FixedConfigService(this._config);
+
+  final AppConfig _config;
+
+  @override
+  Future<AppConfig> load() async => _config;
+
+  @override
+  Future<void> saveGroqApiKey(String key) async {}
+
+  @override
+  Future<void> saveApiUrl(String url) async {}
+
+  @override
+  Future<void> saveApiToken(String token) async {}
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/// Creates a [ProviderContainer] pre-wired with the given fakes.
+/// [config] defaults to one with a valid Groq key so most tests pass the guard.
+ProviderContainer _makeContainer({
+  required FakeRecordingService fakeService,
+  required FakeSttService fakeStt,
+  AppConfig config = const AppConfig(groqApiKey: 'test-key'),
+}) {
+  return ProviderContainer(
+    overrides: [
+      appConfigServiceProvider.overrideWithValue(_FixedConfigService(config)),
+      recordingServiceProvider.overrideWithValue(fakeService),
+      sttServiceProvider.overrideWithValue(fakeStt),
+    ],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late FakeRecordingService fakeService;
   late FakeSttService fakeStt;
+  late ProviderContainer container;
   late RecordingController controller;
 
   setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    FlutterSecureStorage.setMockInitialValues({});
     fakeService = FakeRecordingService();
     fakeStt = FakeSttService();
-    controller = RecordingController(fakeService, fakeStt);
+    container = _makeContainer(fakeService: fakeService, fakeStt: fakeStt);
+    controller = container.read(recordingControllerProvider.notifier);
   });
 
   tearDown(() {
-    controller.dispose();
+    container.dispose();
   });
 
   test('initial state is idle', () {
@@ -119,7 +176,6 @@ void main() {
 
     await controller.stopAndTranscribe();
 
-    // Should have gone through: transcribing, completed
     expect(states.any((s) => s is RecordingTranscribing), isTrue);
     expect(controller.state, isA<RecordingCompleted>());
     expect(
@@ -165,6 +221,44 @@ void main() {
       (controller.state as RecordingError).message,
       'custom message',
     );
+  });
+
+  test(
+      'startRecording emits RecordingError(requiresAppSettings) when Groq key missing',
+      () async {
+    final noKeyContainer = _makeContainer(
+      fakeService: fakeService,
+      fakeStt: fakeStt,
+      config: const AppConfig(groqApiKey: null),
+    );
+    addTearDown(noKeyContainer.dispose);
+    final ctrl = noKeyContainer.read(recordingControllerProvider.notifier);
+
+    await ctrl.startRecording();
+
+    expect(ctrl.state, isA<RecordingError>());
+    final error = ctrl.state as RecordingError;
+    expect(error.requiresAppSettings, isTrue);
+    expect(error.requiresSettings, isFalse);
+    expect(error.message, 'Groq API key not set.');
+  });
+
+  test(
+      'startRecording emits RecordingError(requiresAppSettings) when Groq key empty',
+      () async {
+    final noKeyContainer = _makeContainer(
+      fakeService: fakeService,
+      fakeStt: fakeStt,
+      config: const AppConfig(groqApiKey: ''),
+    );
+    addTearDown(noKeyContainer.dispose);
+    final ctrl = noKeyContainer.read(recordingControllerProvider.notifier);
+
+    await ctrl.startRecording();
+
+    expect(ctrl.state, isA<RecordingError>());
+    final error = ctrl.state as RecordingError;
+    expect(error.requiresAppSettings, isTrue);
   });
 
   test('RecordingState sealed class exhaustiveness', () {

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -5,11 +5,18 @@ import 'package:voice_agent/app/app.dart';
 import 'package:voice_agent/core/models/sync_queue_item.dart';
 import 'package:voice_agent/core/models/transcript.dart';
 import 'package:voice_agent/core/models/transcript_with_status.dart';
+import 'package:voice_agent/core/network/connectivity_service.dart';
 import 'package:voice_agent/core/providers/api_url_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
 import 'package:voice_agent/features/api_sync/sync_provider.dart';
-import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/models/transcript_result.dart';
+import 'package:voice_agent/features/recording/domain/recording_result.dart';
+import 'package:voice_agent/features/recording/domain/recording_service.dart';
+import 'package:voice_agent/features/recording/domain/recording_state.dart';
+import 'package:voice_agent/features/recording/domain/stt_service.dart';
+import 'package:voice_agent/features/recording/presentation/recording_controller.dart';
+import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 
 class _StubStorage implements StorageService {
   @override Future<String> getDeviceId() async => 'test';
@@ -89,4 +96,133 @@ void main() {
       findsNothing,
     );
   });
+
+  testWidgets(
+    'RecordingError(requiresAppSettings) shows "Go to Settings", hides "Open Settings"',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ..._baseOverrides,
+            apiUrlConfiguredProvider.overrideWithValue(true),
+            recordingControllerProvider.overrideWith(
+              (ref) => _ErrorController(
+                ref,
+                const RecordingError('key not set', requiresAppSettings: true),
+              ),
+            ),
+          ],
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Go to Settings'), findsOneWidget);
+      expect(find.text('Open Settings'), findsNothing);
+      expect(find.text('Try Again'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'RecordingError(requiresSettings) shows "Open Settings", hides "Go to Settings"',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ..._baseOverrides,
+            apiUrlConfiguredProvider.overrideWithValue(true),
+            recordingControllerProvider.overrideWith(
+              (ref) => _ErrorController(
+                ref,
+                const RecordingError(
+                  'permission denied',
+                  requiresSettings: true,
+                ),
+              ),
+            ),
+          ],
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Open Settings'), findsOneWidget);
+      expect(find.text('Go to Settings'), findsNothing);
+      expect(find.text('Try Again'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'RecordingError(no flags) shows "Try Again", hides both Settings buttons',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ..._baseOverrides,
+            apiUrlConfiguredProvider.overrideWithValue(true),
+            recordingControllerProvider.overrideWith(
+              (ref) => _ErrorController(
+                ref,
+                const RecordingError('something went wrong'),
+              ),
+            ),
+          ],
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Try Again'), findsOneWidget);
+      expect(find.text('Go to Settings'), findsNothing);
+      expect(find.text('Open Settings'), findsNothing);
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stubs needed for _ErrorController
+// ---------------------------------------------------------------------------
+
+class _NoOpRecordingService implements RecordingService {
+  @override
+  Future<bool> requestPermission() async => true;
+  @override
+  Future<void> start({required String outputPath}) async {}
+  @override
+  Future<RecordingResult> stop() async => RecordingResult(
+        filePath: '/tmp/x.wav',
+        duration: Duration.zero,
+        sampleRate: 16000,
+      );
+  @override
+  Future<void> cancel() async {}
+  @override
+  Stream<Duration> get elapsed => const Stream.empty();
+  @override
+  bool get isRecording => false;
+}
+
+class _NoOpSttService implements SttService {
+  @override
+  Future<bool> isModelLoaded() async => true;
+  @override
+  Future<void> loadModel() async {}
+  @override
+  Future<TranscriptResult> transcribe(String path, {String? languageCode}) =>
+      Future.value(
+        const TranscriptResult(
+          text: '',
+          segments: [],
+          detectedLanguage: 'en',
+          audioDurationMs: 0,
+        ),
+      );
+}
+
+/// Controller that starts in a fixed [RecordingError] state.
+class _ErrorController extends RecordingController {
+  _ErrorController(Ref ref, RecordingError error)
+      : super(_NoOpRecordingService(), _NoOpSttService(), ref) {
+    state = error;
+  }
 }


### PR DESCRIPTION
Part of Proposal 011 — Groq Cloud STT.

## Summary
- Add `requiresAppSettings: bool` to `RecordingError` (default `false`, mutually exclusive with `requiresSettings`, enforced by `assert`)
- `RecordingController` accepts `Ref`; `startRecording()` awaits `loadCompleted` then checks `groqApiKey` — emits `RecordingError(requiresAppSettings: true)` if missing/empty
- `RecordingScreen` error branch: three-way check (`requiresAppSettings` → "Go to Settings" navigates to `/settings`; `requiresSettings` → "Open Settings" opens OS settings; else → "Try Again")
- Refactor controller unit tests from direct construction to `ProviderContainer` with overrides

## Test plan
- 2 new controller tests: missing key and empty key guard paths
- 3 new widget tests: all three `RecordingError` button permutations
- All 144 tests pass

Closes #74
