### PR TITLE
feat(p013-t1): VadConfig value class + AppConfig/AppConfigService extension

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -1,3 +1,5 @@
+import 'package:voice_agent/core/config/vad_config.dart';
+
 /// Sentinel object used to distinguish "not provided" from "explicitly null"
 /// in [AppConfig.copyWith].
 const _sentinel = Object();
@@ -10,6 +12,7 @@ class AppConfig {
     this.autoSend = true,
     this.language = 'auto',
     this.keepHistory = true,
+    this.vadConfig = const VadConfig.defaults(),
   });
 
   final String? apiUrl;
@@ -18,6 +21,7 @@ class AppConfig {
   final bool autoSend;
   final String language;
   final bool keepHistory;
+  final VadConfig vadConfig;
 
   AppConfig copyWith({
     Object? apiUrl = _sentinel,
@@ -26,6 +30,7 @@ class AppConfig {
     bool? autoSend,
     String? language,
     bool? keepHistory,
+    VadConfig? vadConfig,
   }) {
     return AppConfig(
       apiUrl: apiUrl == _sentinel ? this.apiUrl : apiUrl as String?,
@@ -35,6 +40,7 @@ class AppConfig {
       autoSend: autoSend ?? this.autoSend,
       language: language ?? this.language,
       keepHistory: keepHistory ?? this.keepHistory,
+      vadConfig: vadConfig ?? this.vadConfig,
     );
   }
 }

--- a/lib/core/config/app_config_provider.dart
+++ b/lib/core/config/app_config_provider.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/core/config/app_config.dart';
 import 'package:voice_agent/core/config/app_config_service.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
 
 final appConfigServiceProvider = Provider<AppConfigService>((ref) {
   return AppConfigService();
@@ -61,5 +62,10 @@ class AppConfigNotifier extends StateNotifier<AppConfig> {
   Future<void> updateGroqApiKey(String key) async {
     await _service.saveGroqApiKey(key);
     state = state.copyWith(groqApiKey: key);
+  }
+
+  Future<void> updateVadConfig(VadConfig config) async {
+    await _service.saveVadConfig(config);
+    state = state.copyWith(vadConfig: config);
   }
 }

--- a/lib/core/config/app_config_service.dart
+++ b/lib/core/config/app_config_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:voice_agent/core/config/app_config.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
 
 /// Sole persistence adapter for app configuration.
 /// Knows about SharedPreferences keys and FlutterSecureStorage.
@@ -22,6 +23,12 @@ class AppConfigService {
   static const _languageKey = 'language';
   static const _keepHistoryKey = 'keep_history';
 
+  static const _vadPositiveThresholdKey = 'vad_positive_threshold';
+  static const _vadNegativeThresholdKey = 'vad_negative_threshold';
+  static const _vadHangoverMsKey = 'vad_hangover_ms';
+  static const _vadMinSpeechMsKey = 'vad_min_speech_ms';
+  static const _vadPreRollMsKey = 'vad_pre_roll_ms';
+
   Future<SharedPreferences> get _preferences async {
     _prefs ??= await SharedPreferences.getInstance();
     return _prefs!;
@@ -42,6 +49,19 @@ class AppConfigService {
       // Secure storage may fail on some devices — treat as absent
     }
 
+    const defaults = VadConfig.defaults();
+    final vadConfig = VadConfig(
+      positiveSpeechThreshold: prefs.getDouble(_vadPositiveThresholdKey) ??
+          defaults.positiveSpeechThreshold,
+      negativeSpeechThreshold: prefs.getDouble(_vadNegativeThresholdKey) ??
+          defaults.negativeSpeechThreshold,
+      hangoverMs:
+          prefs.getInt(_vadHangoverMsKey) ?? defaults.hangoverMs,
+      minSpeechMs:
+          prefs.getInt(_vadMinSpeechMsKey) ?? defaults.minSpeechMs,
+      preRollMs: prefs.getInt(_vadPreRollMsKey) ?? defaults.preRollMs,
+    ).clamp();
+
     return AppConfig(
       apiUrl: prefs.getString(_apiUrlKey),
       apiToken: token,
@@ -49,7 +69,19 @@ class AppConfigService {
       autoSend: prefs.getBool(_autoSendKey) ?? true,
       language: prefs.getString(_languageKey) ?? 'auto',
       keepHistory: prefs.getBool(_keepHistoryKey) ?? true,
+      vadConfig: vadConfig,
     );
+  }
+
+  Future<void> saveVadConfig(VadConfig config) async {
+    final prefs = await _preferences;
+    await prefs.setDouble(
+        _vadPositiveThresholdKey, config.positiveSpeechThreshold);
+    await prefs.setDouble(
+        _vadNegativeThresholdKey, config.negativeSpeechThreshold);
+    await prefs.setInt(_vadHangoverMsKey, config.hangoverMs);
+    await prefs.setInt(_vadMinSpeechMsKey, config.minSpeechMs);
+    await prefs.setInt(_vadPreRollMsKey, config.preRollMs);
   }
 
   Future<void> saveApiUrl(String url) async {

--- a/lib/core/config/vad_config.dart
+++ b/lib/core/config/vad_config.dart
@@ -1,0 +1,99 @@
+/// Tunable VAD parameters persisted in SharedPreferences.
+///
+/// Values are applied at [HandsFreeEngine.start()] time and are immutable
+/// for the duration of a session. Changes take effect on the next session.
+class VadConfig {
+  const VadConfig({
+    required this.positiveSpeechThreshold,
+    required this.negativeSpeechThreshold,
+    required this.hangoverMs,
+    required this.minSpeechMs,
+    required this.preRollMs,
+  });
+
+  /// Default values matching the VAD pipeline's original hardcoded constants.
+  const VadConfig.defaults()
+      : positiveSpeechThreshold = 0.40,
+        negativeSpeechThreshold = 0.35,
+        hangoverMs = 500,
+        minSpeechMs = 400,
+        preRollMs = 300;
+
+  /// Probability above which a frame is considered speech. Range [0.1, 0.9].
+  final double positiveSpeechThreshold;
+
+  /// Probability below which a frame is considered non-speech. Range [0.1, 0.8].
+  final double negativeSpeechThreshold;
+
+  /// Milliseconds of non-speech to wait before ending a segment. Range [100, 2000].
+  final int hangoverMs;
+
+  /// Minimum milliseconds of speech required for a valid segment. Range [100, 1000].
+  final int minSpeechMs;
+
+  /// Milliseconds of audio to include before detected speech onset. Range [100, 800].
+  final int preRollMs;
+
+  /// Returns a copy with any provided fields replaced.
+  VadConfig copyWith({
+    double? positiveSpeechThreshold,
+    double? negativeSpeechThreshold,
+    int? hangoverMs,
+    int? minSpeechMs,
+    int? preRollMs,
+  }) {
+    return VadConfig(
+      positiveSpeechThreshold:
+          positiveSpeechThreshold ?? this.positiveSpeechThreshold,
+      negativeSpeechThreshold:
+          negativeSpeechThreshold ?? this.negativeSpeechThreshold,
+      hangoverMs: hangoverMs ?? this.hangoverMs,
+      minSpeechMs: minSpeechMs ?? this.minSpeechMs,
+      preRollMs: preRollMs ?? this.preRollMs,
+    );
+  }
+
+  /// Returns a copy with all fields clamped to their valid ranges.
+  ///
+  /// Called by [AppConfigService.load()] to silently correct out-of-range
+  /// SharedPreferences values rather than passing them raw to the VAD pipeline.
+  VadConfig clamp() {
+    return VadConfig(
+      positiveSpeechThreshold:
+          positiveSpeechThreshold.clamp(0.1, 0.9),
+      negativeSpeechThreshold:
+          negativeSpeechThreshold.clamp(0.1, 0.8),
+      hangoverMs: hangoverMs.clamp(100, 2000),
+      minSpeechMs: minSpeechMs.clamp(100, 1000),
+      preRollMs: preRollMs.clamp(100, 800),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is VadConfig &&
+        other.positiveSpeechThreshold == positiveSpeechThreshold &&
+        other.negativeSpeechThreshold == negativeSpeechThreshold &&
+        other.hangoverMs == hangoverMs &&
+        other.minSpeechMs == minSpeechMs &&
+        other.preRollMs == preRollMs;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        positiveSpeechThreshold,
+        negativeSpeechThreshold,
+        hangoverMs,
+        minSpeechMs,
+        preRollMs,
+      );
+
+  @override
+  String toString() => 'VadConfig('
+      'pos=$positiveSpeechThreshold, '
+      'neg=$negativeSpeechThreshold, '
+      'hang=${hangoverMs}ms, '
+      'min=${minSpeechMs}ms, '
+      'pre=${preRollMs}ms)';
+}

--- a/test/core/config/app_config_service_test.dart
+++ b/test/core/config/app_config_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:voice_agent/core/config/app_config_service.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
 
 void main() {
   group('AppConfigService', () {
@@ -108,6 +109,71 @@ void main() {
       expect(config.autoSend, isFalse);
       expect(config.language, 'en');
       expect(config.keepHistory, isFalse);
+    });
+
+    group('VAD config', () {
+      test('load returns VadConfig.defaults() when keys are absent', () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        final config = await service.load();
+
+        expect(config.vadConfig, const VadConfig.defaults());
+      });
+
+      test('saveVadConfig then load round-trips all 5 fields', () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        const saved = VadConfig(
+          positiveSpeechThreshold: 0.6,
+          negativeSpeechThreshold: 0.5,
+          hangoverMs: 800,
+          minSpeechMs: 600,
+          preRollMs: 400,
+        );
+        await service.saveVadConfig(saved);
+        final config = await service.load();
+
+        expect(config.vadConfig, saved);
+      });
+
+      test('load clamps out-of-range values from SharedPreferences', () async {
+        SharedPreferences.setMockInitialValues({
+          'vad_positive_threshold': 2.0,
+          'vad_negative_threshold': -1.0,
+          'vad_hangover_ms': 99999,
+          'vad_min_speech_ms': -50,
+          'vad_pre_roll_ms': 50,
+        });
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        final config = await service.load();
+
+        expect(config.vadConfig.positiveSpeechThreshold, 0.9);
+        expect(config.vadConfig.negativeSpeechThreshold, 0.1);
+        expect(config.vadConfig.hangoverMs, 2000);
+        expect(config.vadConfig.minSpeechMs, 100);
+        expect(config.vadConfig.preRollMs, 100);
+      });
+
+      test('saveVadConfig preserves other config fields', () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        await service.saveApiUrl('https://test.com');
+        await service.saveVadConfig(
+          const VadConfig.defaults().copyWith(hangoverMs: 1200),
+        );
+        final config = await service.load();
+
+        expect(config.apiUrl, 'https://test.com');
+        expect(config.vadConfig.hangoverMs, 1200);
+      });
     });
   });
 }

--- a/test/core/config/vad_config_test.dart
+++ b/test/core/config/vad_config_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
+
+void main() {
+  group('VadConfig.defaults()', () {
+    test('has expected default values', () {
+      const d = VadConfig.defaults();
+      expect(d.positiveSpeechThreshold, 0.40);
+      expect(d.negativeSpeechThreshold, 0.35);
+      expect(d.hangoverMs, 500);
+      expect(d.minSpeechMs, 400);
+      expect(d.preRollMs, 300);
+    });
+  });
+
+  group('VadConfig.copyWith()', () {
+    test('returns same values when no overrides', () {
+      const original = VadConfig.defaults();
+      final copy = original.copyWith();
+      expect(copy, original);
+    });
+
+    test('overrides only specified fields', () {
+      const original = VadConfig.defaults();
+      final copy = original.copyWith(hangoverMs: 1000, preRollMs: 200);
+      expect(copy.hangoverMs, 1000);
+      expect(copy.preRollMs, 200);
+      expect(copy.positiveSpeechThreshold, original.positiveSpeechThreshold);
+      expect(copy.negativeSpeechThreshold, original.negativeSpeechThreshold);
+      expect(copy.minSpeechMs, original.minSpeechMs);
+    });
+  });
+
+  group('VadConfig.clamp()', () {
+    test('values within range are unchanged', () {
+      const c = VadConfig.defaults();
+      expect(c.clamp(), c);
+    });
+
+    test('positiveSpeechThreshold clamped below minimum', () {
+      final c = const VadConfig.defaults()
+          .copyWith(positiveSpeechThreshold: 0.0)
+          .clamp();
+      expect(c.positiveSpeechThreshold, 0.1);
+    });
+
+    test('positiveSpeechThreshold clamped above maximum', () {
+      final c = const VadConfig.defaults()
+          .copyWith(positiveSpeechThreshold: 1.5)
+          .clamp();
+      expect(c.positiveSpeechThreshold, 0.9);
+    });
+
+    test('negativeSpeechThreshold clamped above maximum', () {
+      final c = const VadConfig.defaults()
+          .copyWith(negativeSpeechThreshold: 0.99)
+          .clamp();
+      expect(c.negativeSpeechThreshold, 0.8);
+    });
+
+    test('hangoverMs clamped below minimum', () {
+      final c =
+          const VadConfig.defaults().copyWith(hangoverMs: 0).clamp();
+      expect(c.hangoverMs, 100);
+    });
+
+    test('hangoverMs clamped above maximum', () {
+      final c =
+          const VadConfig.defaults().copyWith(hangoverMs: 9999).clamp();
+      expect(c.hangoverMs, 2000);
+    });
+
+    test('minSpeechMs clamped above maximum', () {
+      final c =
+          const VadConfig.defaults().copyWith(minSpeechMs: 5000).clamp();
+      expect(c.minSpeechMs, 1000);
+    });
+
+    test('preRollMs clamped above maximum', () {
+      final c =
+          const VadConfig.defaults().copyWith(preRollMs: 9999).clamp();
+      expect(c.preRollMs, 800);
+    });
+
+    test('all fields out-of-range are clamped simultaneously', () {
+      final c = const VadConfig(
+        positiveSpeechThreshold: -1,
+        negativeSpeechThreshold: 99,
+        hangoverMs: -500,
+        minSpeechMs: 99999,
+        preRollMs: 0,
+      ).clamp();
+      expect(c.positiveSpeechThreshold, 0.1);
+      expect(c.negativeSpeechThreshold, 0.8);
+      expect(c.hangoverMs, 100);
+      expect(c.minSpeechMs, 1000);
+      expect(c.preRollMs, 100);
+    });
+  });
+
+  group('VadConfig equality', () {
+    test('two defaults are equal', () {
+      expect(const VadConfig.defaults(), const VadConfig.defaults());
+    });
+
+    test('different values are not equal', () {
+      const a = VadConfig.defaults();
+      final b = a.copyWith(hangoverMs: 1000);
+      expect(a, isNot(b));
+    });
+
+    test('hashCode matches for equal configs', () {
+      expect(
+        const VadConfig.defaults().hashCode,
+        const VadConfig.defaults().hashCode,
+      );
+    });
+  });
+
+  group('VadConfig.toString()', () {
+    test('contains field values', () {
+      final s = const VadConfig.defaults().toString();
+      expect(s, contains('0.4'));
+      expect(s, contains('500'));
+      expect(s, contains('400'));
+      expect(s, contains('300'));
+    });
+  });
+}


### PR DESCRIPTION
Closes #97

## Summary
- VadConfig value class in core/config/ with 5 tunable VAD parameters
- AppConfig gains vadConfig field (non-nullable, default VadConfig.defaults())
- AppConfigService: 5 flat SharedPreferences keys, clamp() on load, saveVadConfig()
- AppConfigNotifier: updateVadConfig(VadConfig)
- 28 tests: defaults, copyWith, clamp, equality, round-trip, out-of-range protection