### PR TITLE
feat(p013-t2): thread VadConfig through HandsFreeEngine pipeline

### DIFF
--- a/lib/features/recording/data/hands_free_orchestrator.dart
+++ b/lib/features/recording/data/hands_free_orchestrator.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:path_provider/path_provider.dart';
 import 'package:record/record.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
 import 'package:voice_agent/features/recording/domain/vad_service.dart';
 
@@ -21,13 +22,11 @@ class HandsFreeOrchestrator implements HandsFreeEngine {
   // ── Tuning constants ────────────────────────────────────────────────────────
   static const _sampleRate = 16000;
   static const _bytesPerSample = 2;
-  static const _preRollMs = 300;
-  static const _hangoverMs = 500;
-  static const _minSpeechMs = 400;
   static const _maxSegmentMs = 30000;
   static const _cooldownMs = 1000;
 
   // ── Runtime state ───────────────────────────────────────────────────────────
+  VadConfig? _config;
   StreamController<HandsFreeEngineEvent>? _controller;
   StreamSubscription<Uint8List>? _audioSub;
 
@@ -73,7 +72,8 @@ class HandsFreeOrchestrator implements HandsFreeEngine {
   Future<bool> hasPermission() => _audioRecorder.hasPermission();
 
   @override
-  Stream<HandsFreeEngineEvent> start() {
+  Stream<HandsFreeEngineEvent> start({required VadConfig config}) {
+    _config = config;
     _controller = StreamController<HandsFreeEngineEvent>();
     _phase = _Phase.listening;
     _doStart(); // fire-and-forget
@@ -126,17 +126,18 @@ class HandsFreeOrchestrator implements HandsFreeEngine {
 
   Future<void> _doStart() async {
     try {
-      await _vadService.init();
+      final config = _config!;
+      await _vadService.init(config);
       _frameSize = _vadService.frameSize;
       _msPerFrame = _frameSize * 1000 ~/ (_sampleRate * _bytesPerSample);
       _hangoverFrameThreshold =
-          (_hangoverMs + _msPerFrame - 1) ~/ _msPerFrame;
+          (config.hangoverMs + _msPerFrame - 1) ~/ _msPerFrame;
       _minSpeechFrameThreshold =
-          (_minSpeechMs + _msPerFrame - 1) ~/ _msPerFrame;
+          (config.minSpeechMs + _msPerFrame - 1) ~/ _msPerFrame;
       _maxSpeechFrameThreshold =
           (_maxSegmentMs + _msPerFrame - 1) ~/ _msPerFrame;
       _preRollCapacity =
-          (_preRollMs + _msPerFrame - 1) ~/ _msPerFrame;
+          (config.preRollMs + _msPerFrame - 1) ~/ _msPerFrame;
 
       final audioStream = await _audioRecorder.startStream(
         const RecordConfig(

--- a/lib/features/recording/data/vad_service_impl.dart
+++ b/lib/features/recording/data/vad_service_impl.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:vad/vad.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
 import 'package:voice_agent/features/recording/domain/vad_service.dart';
 
 /// Production [VadService] backed by Silero VAD v5 via ONNX Runtime FFI.
@@ -20,6 +21,7 @@ class VadServiceImpl implements VadService {
   static const _frameSamples = 512; // 32 ms at 16 kHz
 
   VadIterator? _iterator;
+  VadConfig _config = const VadConfig.defaults();
 
   /// Result captured from the most recent [VadEventType.frameProcessed] event.
   VadLabel? _lastLabel;
@@ -28,7 +30,8 @@ class VadServiceImpl implements VadService {
   int get frameSize => _frameSamples * 2; // 1024 bytes
 
   @override
-  Future<void> init() async {
+  Future<void> init(VadConfig config) async {
+    _config = config;
     final tempDir = await getTemporaryDirectory();
     final modelDir = '${tempDir.path}/silero_vad/';
     await Directory(modelDir).create(recursive: true);
@@ -44,8 +47,8 @@ class VadServiceImpl implements VadService {
         isDebug: false,
         sampleRate: 16000,
         frameSamples: _frameSamples,
-        positiveSpeechThreshold: 0.4,
-        negativeSpeechThreshold: 0.35,
+        positiveSpeechThreshold: _config.positiveSpeechThreshold,
+        negativeSpeechThreshold: _config.negativeSpeechThreshold,
         // Let VadIterator manage its own buffers with short thresholds so
         // internal speech buffers don't grow unbounded. The orchestrator owns
         // all segmentation state; we use only the frameProcessed events.
@@ -64,7 +67,9 @@ class VadServiceImpl implements VadService {
   void _onEvent(VadEvent event) {
     if (event.type == VadEventType.frameProcessed) {
       final prob = event.probabilities?.isSpeech ?? 0.0;
-      _lastLabel = prob >= 0.5 ? VadLabel.speech : VadLabel.nonSpeech;
+      _lastLabel = prob >= _config.positiveSpeechThreshold
+          ? VadLabel.speech
+          : VadLabel.nonSpeech;
     }
   }
 

--- a/lib/features/recording/domain/hands_free_engine.dart
+++ b/lib/features/recording/domain/hands_free_engine.dart
@@ -1,3 +1,5 @@
+import 'package:voice_agent/core/config/vad_config.dart';
+
 /// Phase events emitted by [HandsFreeEngine] in real time.
 ///
 /// The controller subscribes to [HandsFreeEngine.start] and maps these events
@@ -56,7 +58,7 @@ abstract interface class HandsFreeEngine {
   /// Returns a stream of [HandsFreeEngineEvent]s that the controller maps to
   /// [HandsFreeSessionState] updates. The stream is closed when [stop]
   /// completes.
-  Stream<HandsFreeEngineEvent> start();
+  Stream<HandsFreeEngineEvent> start({required VadConfig config});
 
   /// Stop the audio stream, release VAD resources, and flush the pre-roll
   /// buffer. Ongoing WAV writes are awaited before the stream closes.

--- a/lib/features/recording/domain/vad_service.dart
+++ b/lib/features/recording/domain/vad_service.dart
@@ -1,5 +1,7 @@
 import 'dart:typed_data';
 
+import 'package:voice_agent/core/config/vad_config.dart';
+
 /// Classifies a fixed-size PCM-16 LE frame as speech or non-speech.
 ///
 /// Implementations wrap a native VAD library (Silero VAD via ONNX Runtime FFI).
@@ -11,7 +13,7 @@ abstract interface class VadService {
   ///
   /// Must be called before [classify]. May be called again after [dispose]
   /// to reinitialise. Throws [VadException] if initialisation fails.
-  Future<void> init();
+  Future<void> init(VadConfig config);
 
   /// Classify a single PCM frame.
   ///

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -107,7 +107,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     _jobCounter = 0;
     _engine = engine;
 
-    final stream = engine.start();
+    final stream = engine.start(config: _ref.read(appConfigProvider).vadConfig);
     _engineSub = stream.listen(
       _onEngineEvent,
       onError: (Object e) => _terminateWithError('Engine error: $e'),

--- a/test/features/recording/data/hands_free_orchestrator_test.dart
+++ b/test/features/recording/data/hands_free_orchestrator_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:record/record.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
 import 'package:voice_agent/features/recording/data/hands_free_orchestrator.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
 import 'package:voice_agent/features/recording/domain/vad_service.dart';
@@ -112,7 +113,7 @@ void main() {
     test('start() emits EngineListening', () async {
       orch = make([]);
       final events = <HandsFreeEngineEvent>[];
-      final sub = orch.start().listen(events.add);
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
 
       await waitFor<EngineListening>(events);
       await orch.stop();
@@ -124,7 +125,7 @@ void main() {
     test('stop() is idempotent', () async {
       orch = make([]);
       final events = <HandsFreeEngineEvent>[];
-      final sub = orch.start().listen(events.add);
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
       // Wait for the engine to be fully started before stopping.
       await waitFor<EngineListening>(events);
       await orch.stop();
@@ -138,7 +139,7 @@ void main() {
       bool done = false;
       final events = <HandsFreeEngineEvent>[];
       final sub =
-          orch.start().listen(events.add, onDone: () => done = true);
+          orch.start(config: const VadConfig.defaults()).listen(events.add, onDone: () => done = true);
       await waitFor<EngineListening>(events);
       await orch.stop();
       // Give the done callback time to fire.
@@ -170,7 +171,7 @@ void main() {
       orch = make(List.filled(speechFrames, VadLabel.speech));
 
       final events = <HandsFreeEngineEvent>[];
-      final sub = orch.start().listen(events.add);
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
       await waitFor<EngineListening>(events);
 
       final half = Uint8List(_frameSize ~/ 2);
@@ -196,7 +197,7 @@ void main() {
       orch = make(labels);
 
       final events = <HandsFreeEngineEvent>[];
-      final sub = orch.start().listen(events.add);
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
       await waitFor<EngineListening>(events);
 
       recorder.push(pcm(total));
@@ -212,7 +213,7 @@ void main() {
       // Push 1.5 frames — the 0.5 frame remainder stays in buffer.
       orch = make([VadLabel.nonSpeech]);
       final events = <HandsFreeEngineEvent>[];
-      final sub = orch.start().listen(events.add);
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
       await waitFor<EngineListening>(events);
 
       recorder.push(Uint8List((_frameSize * 1.5).toInt()));
@@ -238,7 +239,7 @@ void main() {
       orch = make(labels);
 
       final events = <HandsFreeEngineEvent>[];
-      final sub = orch.start().listen(events.add);
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
       await waitFor<EngineListening>(events);
 
       recorder.push(pcm(labels.length));
@@ -263,7 +264,7 @@ void main() {
       orch = make(labels);
 
       final events = <HandsFreeEngineEvent>[];
-      final sub = orch.start().listen(events.add);
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
       await waitFor<EngineListening>(events);
 
       recorder.push(pcm(labels.length));
@@ -295,7 +296,7 @@ void main() {
         orch = make(labels);
 
         final events = <HandsFreeEngineEvent>[];
-        final sub = orch.start().listen(events.add);
+        final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
         await waitFor<EngineListening>(events);
 
         // Push all frames in one chunk for speed.
@@ -329,7 +330,7 @@ void main() {
         orch = make(labels);
 
         final events = <HandsFreeEngineEvent>[];
-        final sub = orch.start().listen(events.add);
+        final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
         await waitFor<EngineListening>(events);
 
         recorder.push(pcm(labels.length));
@@ -357,7 +358,7 @@ void main() {
       orch = make(List.filled(5, VadLabel.nonSpeech));
 
       final events = <HandsFreeEngineEvent>[];
-      final sub = orch.start().listen(events.add);
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
       await waitFor<EngineListening>(events);
 
       recorder.push(pcm(5));
@@ -378,7 +379,7 @@ void main() {
       orch = make(labels);
 
       final events = <HandsFreeEngineEvent>[];
-      final sub = orch.start().listen(events.add);
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
       await waitFor<EngineListening>(events);
 
       recorder.push(pcm(labels.length));

--- a/test/features/recording/data/vad_service_impl_test.dart
+++ b/test/features/recording/data/vad_service_impl_test.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
 import 'package:voice_agent/features/recording/data/vad_service_impl.dart';
 import 'package:voice_agent/features/recording/domain/vad_service.dart';
 
@@ -26,7 +27,7 @@ void main() {
         VadLabel.nonSpeech,
         VadLabel.speech,
       ]);
-      await svc.init();
+      await svc.init(const VadConfig.defaults());
       final frame = Uint8List(1024);
 
       expect(await svc.classify(frame), VadLabel.speech);
@@ -36,7 +37,7 @@ void main() {
 
     test('returns nonSpeech when sequence exhausted', () async {
       final svc = FakeVadService([VadLabel.speech]);
-      await svc.init();
+      await svc.init(const VadConfig.defaults());
       final frame = Uint8List(1024);
 
       await svc.classify(frame); // consumes the one speech label
@@ -47,7 +48,7 @@ void main() {
     test('init sets initCalled flag', () async {
       final svc = FakeVadService([]);
       expect(svc.initCalled, isFalse);
-      await svc.init();
+      await svc.init(const VadConfig.defaults());
       expect(svc.initCalled, isTrue);
     });
 
@@ -64,7 +65,7 @@ void main() {
 
     test('empty label list always returns nonSpeech', () async {
       final svc = FakeVadService([]);
-      await svc.init();
+      await svc.init(const VadConfig.defaults());
       final frame = Uint8List(1024);
       for (var i = 0; i < 5; i++) {
         expect(await svc.classify(frame), VadLabel.nonSpeech);

--- a/test/features/recording/data/vad_service_stub.dart
+++ b/test/features/recording/data/vad_service_stub.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:voice_agent/core/config/vad_config.dart';
 import 'package:voice_agent/features/recording/domain/vad_service.dart';
 
 /// Deterministic [VadService] stub for unit tests.
@@ -18,7 +19,7 @@ class FakeVadService implements VadService {
   final int frameSize = 1024;
 
   @override
-  Future<void> init() async {
+  Future<void> init(VadConfig config) async {
     initCalled = true;
   }
 

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -12,6 +12,7 @@ import 'package:voice_agent/core/models/transcript_result.dart';
 import 'package:voice_agent/core/models/transcript_with_status.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_session_state.dart';
 import 'package:voice_agent/features/recording/domain/recording_result.dart';
@@ -40,7 +41,7 @@ class FakeHandsFreeEngine implements HandsFreeEngine {
   Future<bool> hasPermission() async => permissionGranted;
 
   @override
-  Stream<HandsFreeEngineEvent> start() {
+  Stream<HandsFreeEngineEvent> start({required VadConfig config}) {
     started = true;
     return _controller.stream;
   }

--- a/test/features/recording/presentation/recording_screen_hands_free_test.dart
+++ b/test/features/recording/presentation/recording_screen_hands_free_test.dart
@@ -16,6 +16,7 @@ import 'package:voice_agent/core/providers/api_url_provider.dart';
 import 'package:voice_agent/features/api_sync/sync_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
 import 'package:voice_agent/features/recording/domain/recording_result.dart';
 import 'package:voice_agent/features/recording/domain/recording_service.dart';
@@ -77,7 +78,7 @@ class FakeHfEngine implements HandsFreeEngine {
   @override
   Future<bool> hasPermission() async => true;
   @override
-  Stream<HandsFreeEngineEvent> start() {
+  Stream<HandsFreeEngineEvent> start({required VadConfig config}) {
     started = true;
     return _ctrl.stream;
   }


### PR DESCRIPTION
## Summary

- `VadService.init()` now accepts `VadConfig config`; implementation stores it and passes `positiveSpeechThreshold`/`negativeSpeechThreshold` to `VadIterator.create()` and uses `positiveSpeechThreshold` in `_onEvent`
- `HandsFreeEngine.start()` now accepts `{required VadConfig config}`
- `HandsFreeOrchestrator` removes `_preRollMs`/`_hangoverMs`/`_minSpeechMs` static consts; reads them from config in `_doStart()`; retains `_maxSegmentMs` and `_cooldownMs`
- `HandsFreeController` reads `appConfigProvider.vadConfig` and passes it to `engine.start()`
- All test stubs and call sites updated

Part of Proposal 013 — VAD Advanced Settings. Closes #98.
