### PR TITLE
feat(settings): AdvancedSettingsScreen, VAD sliders, and _VadParamsStrip (#99)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -5,6 +5,7 @@ import 'package:voice_agent/features/history/history_screen.dart';
 import 'package:voice_agent/features/history/transcript_detail_screen.dart';
 import 'package:voice_agent/core/models/transcript_result.dart';
 import 'package:voice_agent/features/recording/presentation/recording_screen.dart';
+import 'package:voice_agent/features/settings/advanced_settings_screen.dart';
 import 'package:voice_agent/features/settings/settings_screen.dart';
 import 'package:voice_agent/features/transcript/transcript_review_screen.dart';
 
@@ -64,6 +65,13 @@ final router = GoRouter(
             GoRoute(
               path: '/settings',
               builder: (context, state) => const SettingsScreen(),
+              routes: [
+                GoRoute(
+                  path: 'advanced',
+                  builder: (context, state) =>
+                      const AdvancedSettingsScreen(),
+                ),
+              ],
             ),
           ],
         ),

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/providers/api_url_provider.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_session_state.dart';
 import 'package:voice_agent/features/recording/domain/recording_state.dart';
@@ -162,6 +163,7 @@ class _HandsFreeSection extends StatelessWidget {
               : (on) =>
                   on ? hfCtrl.startSession() : hfCtrl.stopSession(),
         ),
+        const _VadParamsStrip(),
         if (isOn) ...[
           _HfStatusStrip(hfState: hfState),
           if (jobs.isNotEmpty)
@@ -446,6 +448,50 @@ class _IdleView extends StatelessWidget {
           style: Theme.of(context).textTheme.bodyLarge,
         ),
       ],
+    );
+  }
+}
+
+// ── VAD params strip ─────────────────────────────────────────────────────────
+
+/// Compact read-only summary of current VAD config shown below the Hands-free
+/// toggle. Always visible (not gated on isOn) so the user can see the active
+/// settings even when hands-free is off. Tapping navigates to Advanced Settings.
+class _VadParamsStrip extends ConsumerWidget {
+  const _VadParamsStrip();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final vad = ref.watch(appConfigProvider.select((c) => c.vadConfig));
+    final label =
+        'thr ${vad.positiveSpeechThreshold.toStringAsFixed(2)} · '
+        'hang ${vad.hangoverMs}ms · '
+        'min ${vad.minSpeechMs}ms · '
+        'pre ${vad.preRollMs}ms';
+    return InkWell(
+      key: const Key('vad-params-strip'),
+      onTap: () => context.push('/settings/advanced'),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                label,
+                key: const Key('vad-params-text'),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ),
+            Icon(
+              Icons.tune,
+              size: 16,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/settings/advanced_settings_screen.dart
+++ b/lib/features/settings/advanced_settings_screen.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
+
+class AdvancedSettingsScreen extends ConsumerStatefulWidget {
+  const AdvancedSettingsScreen({super.key});
+
+  @override
+  ConsumerState<AdvancedSettingsScreen> createState() =>
+      _AdvancedSettingsScreenState();
+}
+
+class _AdvancedSettingsScreenState
+    extends ConsumerState<AdvancedSettingsScreen> {
+  late VadConfig _draft;
+  bool _userHasEdited = false;
+  ProviderSubscription<VadConfig>? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    _draft = ref.read(appConfigProvider).vadConfig;
+    // listenManual keeps _draft in sync with async config load, but only
+    // until the user starts editing.
+    _sub = ref.listenManual(
+      appConfigProvider.select((c) => c.vadConfig),
+      (_, next) {
+        if (!_userHasEdited) {
+          setState(() => _draft = next);
+        }
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _sub?.close();
+    super.dispose();
+  }
+
+  void _onChangeEnd(VadConfig updated) {
+    _userHasEdited = true;
+    setState(() => _draft = updated);
+    ref.read(appConfigProvider.notifier).updateVadConfig(updated);
+  }
+
+  void _resetToDefaults() {
+    const defaults = VadConfig.defaults();
+    _userHasEdited = true;
+    setState(() => _draft = defaults);
+    ref.read(appConfigProvider.notifier).updateVadConfig(defaults);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Advanced (VAD)')),
+      body: ListView(
+        children: [
+          _VadSlider(
+            label: 'Speech threshold (positive)',
+            value: _draft.positiveSpeechThreshold,
+            min: 0.1,
+            max: 0.9,
+            divisions: 16,
+            format: (v) => v.toStringAsFixed(2),
+            onChangeEnd: (v) => _onChangeEnd(
+              _draft.copyWith(positiveSpeechThreshold: v),
+            ),
+          ),
+          _VadSlider(
+            label: 'Non-speech threshold (negative)',
+            value: _draft.negativeSpeechThreshold,
+            min: 0.1,
+            max: 0.8,
+            divisions: 14,
+            format: (v) => v.toStringAsFixed(2),
+            onChangeEnd: (v) => _onChangeEnd(
+              _draft.copyWith(negativeSpeechThreshold: v),
+            ),
+          ),
+          _VadSlider(
+            label: 'Hangover (ms)',
+            value: _draft.hangoverMs.toDouble(),
+            min: 100,
+            max: 2000,
+            divisions: 19,
+            format: (v) => '${v.round()}ms',
+            onChangeEnd: (v) => _onChangeEnd(
+              _draft.copyWith(hangoverMs: v.round()),
+            ),
+          ),
+          _VadSlider(
+            label: 'Min speech (ms)',
+            value: _draft.minSpeechMs.toDouble(),
+            min: 100,
+            max: 1000,
+            divisions: 9,
+            format: (v) => '${v.round()}ms',
+            onChangeEnd: (v) => _onChangeEnd(
+              _draft.copyWith(minSpeechMs: v.round()),
+            ),
+          ),
+          _VadSlider(
+            label: 'Pre-roll (ms)',
+            value: _draft.preRollMs.toDouble(),
+            min: 100,
+            max: 800,
+            divisions: 7,
+            format: (v) => '${v.round()}ms',
+            onChangeEnd: (v) => _onChangeEnd(
+              _draft.copyWith(preRollMs: v.round()),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: OutlinedButton(
+              key: const Key('reset-defaults'),
+              onPressed: _resetToDefaults,
+              child: const Text('Reset to defaults'),
+            ),
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+}
+
+class _VadSlider extends StatefulWidget {
+  const _VadSlider({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.divisions,
+    required this.format,
+    required this.onChangeEnd,
+  });
+
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final int divisions;
+  final String Function(double) format;
+  final ValueChanged<double> onChangeEnd;
+
+  @override
+  State<_VadSlider> createState() => _VadSliderState();
+}
+
+class _VadSliderState extends State<_VadSlider> {
+  late double _current;
+
+  @override
+  void initState() {
+    super.initState();
+    _current = widget.value;
+  }
+
+  @override
+  void didUpdateWidget(_VadSlider old) {
+    super.didUpdateWidget(old);
+    if (old.value != widget.value) {
+      _current = widget.value;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Flexible(child: Text(widget.label)),
+          Text(
+            widget.format(_current),
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.primary,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+          ),
+        ],
+      ),
+      subtitle: Slider(
+        value: _current,
+        min: widget.min,
+        max: widget.max,
+        divisions: widget.divisions,
+        onChanged: (v) => setState(() => _current = v),
+        onChangeEnd: widget.onChangeEnd,
+      ),
+    );
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:voice_agent/core/config/app_config.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/network/api_client.dart';
@@ -236,6 +237,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             onChanged: (v) {
               ref.read(appConfigProvider.notifier).updateKeepHistory(v);
             },
+          ),
+          _buildSectionHeader('Voice Activity Detection'),
+          ListTile(
+            key: const Key('advanced-vad-tile'),
+            title: const Text('Advanced (VAD)'),
+            subtitle: const Text('Speech detection tuning'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.push('/settings/advanced'),
           ),
           _buildSectionHeader('About'),
           ListTile(

--- a/test/features/settings/advanced_settings_screen_test.dart
+++ b/test/features/settings/advanced_settings_screen_test.dart
@@ -1,0 +1,305 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:voice_agent/app/app.dart';
+import 'package:voice_agent/core/config/app_config.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/config/app_config_service.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
+import 'package:voice_agent/core/models/sync_queue_item.dart';
+import 'package:voice_agent/core/models/transcript.dart';
+import 'package:voice_agent/core/models/transcript_with_status.dart';
+import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/providers/api_url_provider.dart';
+import 'package:voice_agent/core/storage/storage_provider.dart';
+import 'package:voice_agent/core/storage/storage_service.dart';
+import 'package:voice_agent/features/api_sync/sync_provider.dart';
+import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
+import 'package:voice_agent/core/models/transcript_result.dart';
+import 'package:voice_agent/features/recording/domain/recording_result.dart';
+import 'package:voice_agent/features/recording/domain/recording_service.dart';
+import 'package:voice_agent/features/recording/domain/stt_service.dart';
+import 'package:voice_agent/features/recording/domain/vad_service.dart';
+import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+import 'package:voice_agent/app/router.dart';
+import 'package:voice_agent/features/settings/advanced_settings_screen.dart';
+
+// ── Stubs ─────────────────────────────────────────────────────────────────────
+
+class _StubStorage implements StorageService {
+  @override Future<String> getDeviceId() async => 'test';
+  @override Future<List<TranscriptWithStatus>> getTranscriptsWithStatus({int limit = 20, int offset = 0}) async => [];
+  @override Future<void> saveTranscript(Transcript t) async {}
+  @override Future<Transcript?> getTranscript(String id) async => null;
+  @override Future<List<Transcript>> getTranscripts({int limit = 50, int offset = 0}) async => [];
+  @override Future<void> deleteTranscript(String id) async {}
+  @override Future<void> enqueue(String transcriptId) async {}
+  @override Future<List<SyncQueueItem>> getPendingItems() async => [];
+  @override Future<void> markSending(String id) async {}
+  @override Future<void> markSent(String id) async {}
+  @override Future<void> markFailed(String id, String error) async {}
+  @override Future<void> markPendingForRetry(String id) async {}
+  @override Future<void> reactivateForResend(String transcriptId) async {}
+}
+
+class _NoOpConnectivity extends ConnectivityService {
+  @override
+  Stream<ConnectivityStatus> get statusStream => const Stream.empty();
+}
+
+class _IdleHfEngine implements HandsFreeEngine {
+  final _ctrl = StreamController<HandsFreeEngineEvent>.broadcast();
+  @override Future<bool> hasPermission() async => true;
+  @override Stream<HandsFreeEngineEvent> start({required VadConfig config}) => _ctrl.stream;
+  @override Future<void> stop() async {}
+  @override void dispose() => _ctrl.close();
+}
+
+class _NoOpRecordingService implements RecordingService {
+  @override Future<bool> requestPermission() async => true;
+  @override Future<void> start({required String outputPath}) async {}
+  @override Future<RecordingResult> stop() async =>
+      RecordingResult(filePath: '/tmp/x.wav', duration: Duration.zero, sampleRate: 16000);
+  @override Future<void> cancel() async {}
+  @override Stream<Duration> get elapsed => const Stream.empty();
+  @override bool get isRecording => false;
+}
+
+class _NoOpSttService implements SttService {
+  @override Future<bool> isModelLoaded() async => true;
+  @override Future<void> loadModel() async {}
+  @override Future<TranscriptResult> transcribe(String path, {String? languageCode}) =>
+      Completer<TranscriptResult>().future;
+}
+
+class _SeededConfigService extends AppConfigService {
+  _SeededConfigService(this._config);
+  final AppConfig _config;
+  VadConfig? savedVadConfig;
+
+  @override Future<AppConfig> load() async => _config;
+  @override Future<void> saveApiUrl(String url) async {}
+  @override Future<void> saveApiToken(String token) async {}
+  @override Future<void> saveGroqApiKey(String key) async {}
+  @override Future<void> saveAutoSend(bool value) async {}
+  @override Future<void> saveLanguage(String language) async {}
+  @override Future<void> saveKeepHistory(bool value) async {}
+  @override Future<void> saveVadConfig(VadConfig config) async {
+    savedVadConfig = config;
+  }
+}
+
+List<Override> _baseOverrides({AppConfigService? configService}) => [
+  storageServiceProvider.overrideWithValue(_StubStorage()),
+  connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
+  apiUrlConfiguredProvider.overrideWithValue(true),
+  handsFreeEngineProvider.overrideWithValue(_IdleHfEngine()),
+  recordingServiceProvider.overrideWithValue(_NoOpRecordingService()),
+  sttServiceProvider.overrideWithValue(_NoOpSttService()),
+  if (configService != null)
+    appConfigServiceProvider.overrideWithValue(configService),
+];
+
+/// Pumps [AdvancedSettingsScreen] directly inside a minimal scaffold+router
+/// so tests don't need to navigate through the full SettingsScreen.
+Future<void> _pumpAdvanced(
+  WidgetTester tester, {
+  AppConfigService? configService,
+}) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (_, __) => const AdvancedSettingsScreen(),
+      ),
+    ],
+  );
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: _baseOverrides(configService: configService),
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  group('SettingsScreen — Advanced VAD navigation', () {
+    testWidgets(
+        'tapping Advanced (VAD) tile in settings navigates to AdvancedSettingsScreen',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: _baseOverrides(),
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Navigate to settings tab
+      await tester.tap(find.byIcon(Icons.settings));
+      await tester.pumpAndSettle();
+
+      // Scroll until the tile is visible in the settings ListView
+      await tester.drag(
+        find.byType(ListView).last,
+        const Offset(0, -400),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('advanced-vad-tile')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text('Advanced (VAD)'),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('AdvancedSettingsScreen', () {
+    testWidgets('renders default VadConfig values in sliders', (tester) async {
+      await _pumpAdvanced(tester);
+
+      expect(find.text('0.40'), findsOneWidget);
+      expect(find.text('0.35'), findsOneWidget);
+      expect(find.text('500ms'), findsOneWidget);
+      expect(find.text('400ms'), findsOneWidget);
+      expect(find.text('300ms'), findsOneWidget);
+    });
+
+    testWidgets('renders seeded VadConfig values in sliders', (tester) async {
+      const seededVad = VadConfig(
+        positiveSpeechThreshold: 0.6,
+        negativeSpeechThreshold: 0.5,
+        hangoverMs: 800,
+        minSpeechMs: 600,
+        preRollMs: 400,
+      );
+      await _pumpAdvanced(
+        tester,
+        configService:
+            _SeededConfigService(const AppConfig(vadConfig: seededVad)),
+      );
+
+      expect(find.text('0.60'), findsOneWidget);
+      expect(find.text('0.50'), findsOneWidget);
+      expect(find.text('800ms'), findsOneWidget);
+      expect(find.text('600ms'), findsOneWidget);
+      expect(find.text('400ms'), findsOneWidget);
+    });
+
+    testWidgets('Reset to defaults button is present', (tester) async {
+      await _pumpAdvanced(tester);
+
+      expect(find.byKey(const Key('reset-defaults')), findsOneWidget);
+    });
+
+    testWidgets('Reset to defaults button calls updateVadConfig with defaults',
+        (tester) async {
+      const seededVad = VadConfig(
+        positiveSpeechThreshold: 0.7,
+        negativeSpeechThreshold: 0.6,
+        hangoverMs: 1000,
+        minSpeechMs: 700,
+        preRollMs: 500,
+      );
+      final service =
+          _SeededConfigService(const AppConfig(vadConfig: seededVad));
+      await _pumpAdvanced(tester, configService: service);
+
+      await tester.tap(find.byKey(const Key('reset-defaults')));
+      await tester.pumpAndSettle();
+
+      expect(service.savedVadConfig, const VadConfig.defaults());
+      // UI reflects defaults immediately
+      expect(find.text('0.40'), findsOneWidget);
+      expect(find.text('500ms'), findsOneWidget);
+    });
+
+    testWidgets('async config load updates sliders before user edits',
+        (tester) async {
+      // Simulate async load: configService returns non-default values
+      const seededVad = VadConfig(
+        positiveSpeechThreshold: 0.65,
+        negativeSpeechThreshold: 0.55,
+        hangoverMs: 900,
+        minSpeechMs: 650,
+        preRollMs: 350,
+      );
+      final service =
+          _SeededConfigService(const AppConfig(vadConfig: seededVad));
+      await _pumpAdvanced(tester, configService: service);
+
+      // Values from seeded config should appear (loaded async)
+      expect(find.text('0.65'), findsOneWidget);
+      expect(find.text('900ms'), findsOneWidget);
+    });
+  });
+
+  group('_VadParamsStrip on RecordingScreen', () {
+    testWidgets('VAD strip shows current VadConfig values', (tester) async {
+      const seededVad = VadConfig(
+        positiveSpeechThreshold: 0.55,
+        negativeSpeechThreshold: 0.45,
+        hangoverMs: 600,
+        minSpeechMs: 500,
+        preRollMs: 200,
+      );
+      final service =
+          _SeededConfigService(const AppConfig(vadConfig: seededVad));
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: _baseOverrides(configService: service),
+          child: const App(),
+        ),
+      );
+      // Ensure we're on the record screen regardless of prior router state.
+      router.go('/record');
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('vad-params-strip')), findsOneWidget);
+
+      final text = tester.widget<Text>(
+        find.byKey(const Key('vad-params-text')),
+      );
+      expect(text.data, contains('0.55'));
+      expect(text.data, contains('600ms'));
+      expect(text.data, contains('500ms'));
+      expect(text.data, contains('200ms'));
+    });
+
+    testWidgets('tapping VAD strip navigates to AdvancedSettingsScreen',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: _baseOverrides(),
+          child: const App(),
+        ),
+      );
+      router.go('/record');
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('vad-params-strip')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text('Advanced (VAD)'),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `AdvancedSettingsScreen` with 5 configurable VAD parameter sliders (positive/negative speech thresholds, hangover, min speech, pre-roll) and a Reset to defaults button
- Add `/settings/advanced` child route under `/settings` in the router
- Add Advanced (VAD) tile in `SettingsScreen` linking to the new screen
- Add `_VadParamsStrip` ConsumerWidget below the Hands-free toggle in `RecordingScreen` — always visible, shows current VAD params, tapping navigates to Advanced Settings

## Test plan

- [ ] 8 new widget tests in `test/features/settings/advanced_settings_screen_test.dart`
- [ ] Navigation from SettingsScreen to AdvancedSettingsScreen
- [ ] Default and seeded VadConfig values render correctly in sliders
- [ ] Reset to defaults button calls updateVadConfig with VadConfig.defaults()
- [ ] Async config load updates sliders before user edits
- [ ] VAD strip shows current VadConfig values
- [ ] Tapping VAD strip navigates to AdvancedSettingsScreen
- [ ] `flutter test` — 244/244 passing
- [ ] `flutter analyze` — no issues

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)