### PR TITLE
feat(recording): T4 press-and-hold mic button

### DIFF
--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -281,10 +281,13 @@ class _MicButton extends ConsumerStatefulWidget {
 }
 
 class _MicButtonState extends ConsumerState<_MicButton> {
-  /// True between [onLongPressStart] and [onLongPressEnd].
+  /// True between [_onLongPressStart] and [_onLongPressEnd].
   /// Prevents the trailing [onTap] that Flutter fires after a long press.
-  // ignore: prefer_final_fields — T4 sets this to true in onLongPressStart
   bool _longPressActive = false;
+
+  /// True when the current recording was started by a long press.
+  /// Drives the orange button colour. Cleared when state returns to idle or error.
+  bool _isPressAndHold = false;
 
   Future<void> _onTap() async {
     if (_longPressActive) return; // trailing tap from a long press — ignore
@@ -305,26 +308,65 @@ class _MicButtonState extends ConsumerState<_MicButton> {
     // RecordingError → handled by error view in _buildRecordingArea
   }
 
+  Future<void> _onLongPressStart(LongPressStartDetails _) async {
+    final recState = ref.read(recordingControllerProvider);
+    final hfState = ref.read(handsFreeControllerProvider);
+
+    // Only start if idle and engine not stopping.
+    if (recState is! RecordingIdle) return;
+    if (hfState is HandsFreeStopping) return;
+
+    _longPressActive = true;
+    setState(() => _isPressAndHold = true);
+
+    final recCtrl = ref.read(recordingControllerProvider.notifier);
+    final hfCtrl = ref.read(handsFreeControllerProvider.notifier);
+    await hfCtrl.suspendForManualRecording();
+    await recCtrl.startRecording();
+  }
+
+  Future<void> _onLongPressEnd(LongPressEndDetails _) async {
+    _longPressActive = false;
+
+    final recState = ref.read(recordingControllerProvider);
+    if (recState is! RecordingActive) return;
+
+    await ref
+        .read(recordingControllerProvider.notifier)
+        .stopAndTranscribe(silentOnEmpty: true);
+  }
+
   @override
   Widget build(BuildContext context) {
     final recState = ref.watch(recordingControllerProvider);
     final isRecording = recState is RecordingActive;
     final isTranscribing = recState is RecordingTranscribing;
 
-    final color = isRecording
-        ? Colors.red
-        : isTranscribing
-            ? Colors.grey
-            : Colors.green;
+    // Clear press-and-hold flag when recording returns to idle or errors out.
+    ref.listen<RecordingState>(recordingControllerProvider, (_, next) {
+      if ((next is RecordingIdle || next is RecordingError) && _isPressAndHold) {
+        setState(() => _isPressAndHold = false);
+      }
+    });
+
+    final color = isTranscribing
+        ? Colors.grey
+        : isRecording && _isPressAndHold
+            ? Colors.orange
+            : isRecording
+                ? Colors.red
+                : Colors.green;
 
     final label = isRecording
-        ? 'Tap to stop'
+        ? (_isPressAndHold ? 'Release to stop' : 'Tap to stop')
         : isTranscribing
             ? 'Transcribing...'
             : 'Tap to record';
 
     return GestureDetector(
       onTap: _onTap,
+      onLongPressStart: _onLongPressStart,
+      onLongPressEnd: _onLongPressEnd,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/test/features/recording/presentation/recording_screen_mic_button_test.dart
+++ b/test/features/recording/presentation/recording_screen_mic_button_test.dart
@@ -1,0 +1,225 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/app/app.dart';
+import 'package:voice_agent/core/config/app_config.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/config/app_config_service.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
+import 'package:voice_agent/core/models/sync_queue_item.dart';
+import 'package:voice_agent/core/models/transcript.dart';
+import 'package:voice_agent/core/models/transcript_result.dart';
+import 'package:voice_agent/core/models/transcript_with_status.dart';
+import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/providers/api_url_provider.dart';
+import 'package:voice_agent/core/storage/storage_provider.dart';
+import 'package:voice_agent/features/api_sync/sync_provider.dart';
+import 'package:voice_agent/core/storage/storage_service.dart';
+import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
+import 'package:voice_agent/features/recording/domain/recording_result.dart';
+import 'package:voice_agent/features/recording/domain/recording_service.dart';
+import 'package:voice_agent/features/recording/domain/recording_state.dart';
+import 'package:voice_agent/features/recording/domain/stt_service.dart';
+import 'package:voice_agent/features/recording/presentation/recording_controller.dart';
+import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+
+// ── Stubs ────────────────────────────────────────────────────────────────────
+
+class _StubStorage implements StorageService {
+  @override Future<String> getDeviceId() async => 'test-device';
+  @override Future<List<TranscriptWithStatus>> getTranscriptsWithStatus(
+      {int limit = 20, int offset = 0}) async => [];
+  @override Future<void> saveTranscript(Transcript t) async {}
+  @override Future<Transcript?> getTranscript(String id) async => null;
+  @override Future<List<Transcript>> getTranscripts(
+      {int limit = 50, int offset = 0}) async => [];
+  @override Future<void> deleteTranscript(String id) async {}
+  @override Future<void> enqueue(String transcriptId) async {}
+  @override Future<List<SyncQueueItem>> getPendingItems() async => [];
+  @override Future<void> markSending(String id) async {}
+  @override Future<void> markSent(String id) async {}
+  @override Future<void> markFailed(String id, String error) async {}
+  @override Future<void> markPendingForRetry(String id) async {}
+  @override Future<void> reactivateForResend(String transcriptId) async {}
+}
+
+class _NoOpConnectivity extends ConnectivityService {
+  @override
+  Stream<ConnectivityStatus> get statusStream => const Stream.empty();
+}
+
+class _IdleHfEngine implements HandsFreeEngine {
+  final _ctrl = StreamController<HandsFreeEngineEvent>.broadcast();
+  @override Future<bool> hasPermission() async => true;
+  @override Stream<HandsFreeEngineEvent> start({required VadConfig config}) => _ctrl.stream;
+  @override Future<void> stop() async {}
+  @override Future<void> interruptCapture() async {}
+  @override void dispose() => _ctrl.close();
+}
+
+class _FixedConfigService extends AppConfigService {
+  _FixedConfigService(this._config);
+  final AppConfig _config;
+  @override
+  Future<AppConfig> load() async => _config;
+}
+
+class _NoOpRecordingService implements RecordingService {
+  @override Future<bool> requestPermission() async => true;
+  @override Future<void> start({required String outputPath}) async {}
+  @override Future<RecordingResult> stop() async =>
+      RecordingResult(filePath: '/tmp/x.wav', duration: Duration.zero, sampleRate: 16000);
+  @override Future<void> cancel() async {}
+  @override Stream<Duration> get elapsed => const Stream.empty();
+  @override bool get isRecording => false;
+}
+
+class _NoOpSttService implements SttService {
+  @override Future<bool> isModelLoaded() async => true;
+  @override Future<void> loadModel() async {}
+  @override Future<TranscriptResult> transcribe(String path, {String? languageCode}) async =>
+      const TranscriptResult(text: '', segments: [], detectedLanguage: 'en', audioDurationMs: 0);
+}
+
+/// [RecordingController] that bypasses path_provider and async I/O.
+/// [startRecording] immediately sets state to [RecordingActive].
+/// [stopAndTranscribe] immediately sets state to [RecordingIdle].
+class _FakeRecordingController extends RecordingController {
+  _FakeRecordingController(super.svc, super.stt, super.ref);
+
+  @override
+  Future<void> startRecording() async {
+    state = const RecordingState.recording();
+  }
+
+  @override
+  Future<void> stopAndTranscribe({bool silentOnEmpty = false}) async {
+    state = const RecordingState.idle();
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+List<Override> get _baseOverrides => [
+  storageServiceProvider.overrideWithValue(_StubStorage()),
+  connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
+  apiUrlConfiguredProvider.overrideWithValue(true),
+  appConfigServiceProvider.overrideWithValue(
+    _FixedConfigService(const AppConfig(groqApiKey: 'gsk_test_key')),
+  ),
+  handsFreeEngineProvider.overrideWithValue(_IdleHfEngine()),
+  recordingServiceProvider.overrideWithValue(_NoOpRecordingService()),
+  sttServiceProvider.overrideWithValue(_NoOpSttService()),
+  recordingControllerProvider.overrideWith((ref) => _FakeRecordingController(
+    ref.read(recordingServiceProvider),
+    ref.read(sttServiceProvider),
+    ref,
+  )),
+];
+
+Future<void> pumpApp(WidgetTester tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: _baseOverrides,
+      child: const App(),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  setUpAll(() => WidgetsFlutterBinding.ensureInitialized());
+
+  group('tap-to-record', () {
+    testWidgets('idle → tap → button turns red', (tester) async {
+      await pumpApp(tester);
+
+      await tester.tap(find.byKey(const Key('record-button')));
+      await tester.pumpAndSettle();
+
+      final container = tester.widget<AnimatedContainer>(
+        find.byKey(const Key('record-button')),
+      );
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, equals(Colors.red));
+    });
+
+    testWidgets('idle → tap → shows "Tap to stop" label', (tester) async {
+      await pumpApp(tester);
+
+      await tester.tap(find.byKey(const Key('record-button')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Tap to stop'), findsOneWidget);
+      expect(find.text('Tap to record'), findsNothing);
+    });
+  });
+
+  group('press-and-hold', () {
+    testWidgets('long press start → label changes to "Release to stop"', (tester) async {
+      await pumpApp(tester);
+
+      // Hold the gesture without releasing so the button stays in press-and-hold state.
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byKey(const Key('record-button'))),
+      );
+      // Wait past Flutter's long-press threshold (500ms default).
+      await tester.pump(const Duration(milliseconds: 600));
+      // Give async work (startRecording) time to complete.
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump();
+
+      expect(find.text('Release to stop'), findsOneWidget);
+
+      // Clean up: release gesture.
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('long press start → button turns orange', (tester) async {
+      await pumpApp(tester);
+
+      // Hold the gesture without releasing so the button stays in press-and-hold state.
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byKey(const Key('record-button'))),
+      );
+      // Wait past Flutter's long-press threshold (500ms default).
+      await tester.pump(const Duration(milliseconds: 600));
+      // Give async work (startRecording) time to complete.
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump();
+
+      final container = tester.widget<AnimatedContainer>(
+        find.byKey(const Key('record-button')),
+      );
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, equals(Colors.orange));
+
+      // Clean up: release gesture.
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('empty transcription after long press → no error shown', (tester) async {
+      await pumpApp(tester);
+
+      // Start long press (onLongPressStart → RecordingActive)
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byKey(const Key('record-button'))),
+      );
+      await tester.pump(const Duration(milliseconds: 600)); // pass Flutter's long-press threshold
+
+      // Release (onLongPressEnd → stopAndTranscribe(silentOnEmpty: true))
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // silentOnEmpty → RecordingIdle, no error
+      expect(find.byIcon(Icons.error), findsNothing);
+      expect(find.text('Tap to record'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #91

## Summary

- Add press-and-hold gesture to mic button: `_onLongPressStart`/`_onLongPressEnd` handlers
- `_longPressActive` guard suppresses trailing `onTap` event Flutter fires after long press
- `_isPressAndHold` flag drives orange button color during press-and-hold mode
- `_onLongPressEnd` calls `stopAndTranscribe(silentOnEmpty: true)` so releasing on silence returns to idle without an error
- `ref.listen` clears `_isPressAndHold` when state transitions to `RecordingIdle` or `RecordingError`
- Add `recording_screen_mic_button_test.dart`: 5 widget tests covering tap-to-record and press-and-hold flows

## Test plan
- [x] `flutter analyze` passes (0 issues)
- [x] `flutter test` passes (248 tests)
- [x] Tap → red button, 'Tap to stop' label
- [x] Long press held → orange button, 'Release to stop' label
- [x] Long press + release (empty) → idle, no error shown