### PR TITLE
docs(p015): TTS response playback proposal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,14 @@ A1. /create-proposal          — write proposal in docs/proposals/{NNN}-{name}.
 A2. /proposal-review          — review proposal
 A3. Fix review issues          — address all P0/P1 issues found by the reviewer
 A4. Repeat A2–A3              — re-review until verdict: Ready
-A5. User approval             — wait for explicit user approval before proceeding
+A5. /codex-review             — ask Codex to review the proposal (round 1)
+A6. Fix Codex issues          — address issues raised by Codex
+A7. /codex-review (re-read)   — ask Codex to re-read the proposal and review again;
+                                explicitly instruct Codex to read the proposal file
+                                again before reviewing (it retains session context
+                                but must be told to re-read for the latest version)
+A8. Fix Codex issues          — address remaining issues from round 2
+A9. User approval             — wait for explicit user approval before proceeding
 ```
 
 #### Phase B — Proposal lands on main
@@ -145,8 +152,8 @@ D8. Approve and merge the PR to main
 - **Avoid generating commands that require human interaction.** Use non-interactive
   flags, write multiline content to temp files, and prefer `gh pr merge --auto`
   or direct merge over workflows that block on manual approval.
-- Phase A (proposal) requires user approval at step A5 — this is the only
-  mandatory human checkpoint. Everything after A5 is autonomous.
+- Phase A (proposal) requires user approval at step A9 — this is the only
+  mandatory human checkpoint. Everything after A9 is autonomous.
 
 **Not needed for:** bug fixes that don't change intended behavior, refactoring
 with no behavioral impact, test-only changes, documentation fixes. For these,

--- a/docs/proposals/015-tts-response-playback.md
+++ b/docs/proposals/015-tts-response-playback.md
@@ -78,21 +78,28 @@ TtsService {
 }
 ```
 
-`languageCode` is an **ISO 639-1 two-letter code** (e.g. `"pl"`, `"en"`, `"de"`).
-The same format is used everywhere: in the server response `"language"` field,
-in `AppConfig.language`, and as the argument to `flutter_tts`'s `setLanguage()`.
+`languageCode` is an **ISO 639-1 two-letter code** (e.g. `"pl"`, `"en"`, `"de"`)
+as sent by the server, or the `'auto'` sentinel when coming from `AppConfig.language`.
+It is **not** passed directly to `flutter_tts.setLanguage()` — see below.
 
 `isSpeaking` is intentionally excluded from the V1 interface — no caller in this
 proposal needs it, and adding it forces every stub to implement an async getter.
 
 The `FlutterTtsService` implementation uses the `flutter_tts` package
 (must be added to `pubspec.yaml` in T1).
+It accepts an optional `FlutterTts? tts` constructor parameter so unit tests can
+inject a mock and verify `setLanguage()` calls without hitting the real plugin.
 The language is set before each `speak()` call via `flutter_tts.setLanguage()`.
-Fallback priority: server `language` field → `config.language` (if not `'auto'`) →
-`Platform.localeName.split('_').first` (the device locale code, e.g. `"pl"` from `"pl_PL"`).
-The `'auto'` string must never be passed to `flutter_tts.setLanguage()` — it is not
-a valid BCP-47 tag and will silently fail. `FlutterTtsService.speak()` owns the
-`'auto'` → device locale resolution.
+
+Language resolution inside `FlutterTtsService.speak()`:
+- `'auto'` → `Platform.localeName` (full locale, e.g. `"pl_PL"`) — **not** stripped
+  to two letters, because `AVSpeechSynthesizer` on iOS needs the full tag to select
+  the correct voice.
+- Any other code (e.g. `"pl"`) → passed as-is to `flutter_tts.setLanguage()`.
+  On iOS this may silently fall back to the device default if the bare code is
+  not recognized (see Known Compromises).
+- `'auto'` must never reach `flutter_tts.setLanguage()` — `FlutterTtsService.speak()`
+  owns the `'auto'` → `Platform.localeName` resolution.
 
 The provider is placed at `core/tts/tts_provider.dart` (the same layer as
 `TtsService`) so that `features/api_sync/`, `features/recording/`, and
@@ -167,6 +174,11 @@ all other providers in this codebase. The provider lives in `core/tts/tts_provid
 
 ## Affected Mutation Points
 
+**New files:**
+- `core/tts/tts_service.dart` — `TtsService` abstract interface
+- `core/tts/flutter_tts_service.dart` — `FlutterTtsService` implementation
+- `core/tts/tts_provider.dart` — `Provider<TtsService>` with `ref.onDispose`
+
 **Needs change:**
 - `ApiSuccess` — add `body: String?`
 - `ApiClient.post()` — extract body via `jsonEncode` (if Map) or direct (if String)
@@ -207,13 +219,22 @@ all other providers in this codebase. The provider lives in `core/tts/tts_provid
   verify `AVAudioSession` works alongside the `record` package (see Risks)
 - Android: `flutter_tts` requires a TTS engine installed on device (normally present)
 - `core/tts/tts_service.dart` — abstraction (no `isSpeaking`; see Solution Design)
-- `core/tts/flutter_tts_service.dart` — implementation; `speak()` resolves `'auto'`
-  via `Platform.localeName.split('_').first` before calling `flutter_tts.setLanguage()`
+- `core/tts/flutter_tts_service.dart` — implementation; accepts optional `FlutterTts? tts`
+  constructor param for unit testing; `speak()` resolves `'auto'` via `Platform.localeName`
+  (full locale, e.g. `"pl_PL"`) before calling `flutter_tts.setLanguage()`
 - `core/tts/tts_provider.dart` — `Provider<TtsService>` with
   `ref.onDispose(() => tts.dispose())` to release the platform channel
 - `AppConfig.ttsEnabled` default `true`; SharedPreferences key: `'tts_enabled'`
-- Tests: unit test `FlutterTtsService.speak()` calls `setLanguage('pl')` not `'auto'`;
-  widget test toggle in Settings
+- **Widget test stub overrides (in T1, not T3):** once `ttsServiceProvider` exists,
+  every test that pumps `RecordingScreen` or the full `App` widget will instantiate
+  `FlutterTtsService` and crash. Add a no-op `_StubTtsService` override for
+  `ttsServiceProvider` to all affected test files in this task:
+  `recording_screen_mic_button_test.dart`, `recording_screen_test.dart`,
+  `recording_screen_hands_free_test.dart`, `hands_free_controller_test.dart`,
+  `settings_screen_test.dart`. This keeps `flutter test` green between T1 and T3.
+- Tests: unit test `FlutterTtsService.speak()` (with injected `MockFlutterTts`) calls
+  `setLanguage('pl')` not `'auto'`; unit test that `'auto'` resolves to `Platform.localeName`
+  (full locale) not a stripped two-letter code; widget test toggle in Settings
 
 ### T2 details
 
@@ -221,7 +242,9 @@ all other providers in this codebase. The provider lives in `core/tts/tts_provid
 - `ApiClient.post()`: extract body as described in § ApiSuccess with body
 - `SyncWorker` constructor: add `TtsService ttsService`
 - `ttsEnabled` reactivity: `syncWorkerProvider` passes `() => ref.read(appConfigProvider).ttsEnabled`
-  as the `getTtsEnabled` closure; never a stale `bool` constructor argument
+  as the `getTtsEnabled` closure; never a stale `bool` constructor argument. The closure
+  must capture `ref` (the live `ProviderRef`), not `ref.read(appConfigProvider).ttsEnabled`
+  (which would capture the value at construction time and go stale).
 - `features/api_sync/sync_provider.dart` — wire in `ttsServiceProvider`
 - Parsing in `_drain()`: `try { final json = jsonDecode(body!); ... } catch (_) {}`
   — `speak()` call is fire-and-forget (`unawaited`); `stop()` call is awaited first
@@ -262,14 +285,16 @@ all other providers in this codebase. The provider lives in `core/tts/tts_provid
   add stub `TtsService` override; add assertion for `stop()` on `EngineCapturing`
 - `test/features/recording/presentation/recording_screen_mic_button_test.dart` —
   add stub `TtsService` override in `_baseOverrides`
-- `test/features/settings/advanced_settings_screen_test.dart` —
+- `test/features/settings/settings_screen_test.dart` —
   add stub `TtsService` override in `_baseOverrides`
 - Any other test that pumps `RecordingScreen` must add the stub override
 
 ### New tests
 - Unit: `FlutterTtsService.speak("text", languageCode: "pl")` calls `setLanguage("pl")`
+  (uses injected `MockFlutterTts`)
 - Unit: `FlutterTtsService.speak("text")` with `config.language == "auto"` calls
-  `setLanguage("<device-locale-code>")` not `setLanguage("auto")`
+  `setLanguage("pl_PL")` (full `Platform.localeName`), not `setLanguage("auto")` or
+  `setLanguage("pl")`
 - Unit: `SyncWorker` parses `{ "message": "ok", "language": "pl" }` → `stop()` then `speak("ok", languageCode: "pl")`
 - Unit: `SyncWorker` ignores body that is not JSON
 - Unit: `SyncWorker` ignores body with no `message` field (e.g. `{"status": "ok"}`)
@@ -284,7 +309,7 @@ all other providers in this codebase. The provider lives in `core/tts/tts_provid
 2. When the response contains `{ "message": "...", "language": "en" }`, TTS uses English.
    The `language` value is an ISO 639-1 two-letter code (`"pl"`, `"en"`, `"de"`, etc.).
 3. When the response omits `language` and `config.language` is `'auto'`, TTS uses the
-   device locale language code (e.g. `"pl"` for a device set to Polish).
+   full device locale tag (e.g. `"pl_PL"` for a device set to Polish).
 4. When the response has no `message` field or is not JSON, the app is silent.
 5. VAD detecting speech during TTS playback interrupts it immediately.
 6. Tapping or holding the mic icon during TTS interrupts playback and starts recording.
@@ -298,7 +323,6 @@ all other providers in this codebase. The provider lives in `core/tts/tts_provid
 | Risk | Mitigation |
 |------|------------|
 | iOS `AVAudioSession` conflict between TTS (`playback`) and microphone (`record`) | `stop()` is awaited at tap/long-press interruption points before `startRecording()`. VAD engine is already recording when TTS fires, so `stop()` there is fire-and-forget. Verify in manual testing on device. |
-| `flutter_tts` on iOS requires `NSSpeechRecognitionUsageDescription` in `Info.plist` | Added to T1 setup steps |
 | Concurrent TTS and microphone echo (VAD active while TTS plays) | TTS fires only after `SyncWorker` sends a segment; VAD stops TTS on `EngineCapturing` event |
 | Response body may be very large | Only `message` field is extracted; TTS has a natural per-utterance limit via `flutter_tts` |
 
@@ -309,6 +333,19 @@ all other providers in this codebase. The provider lives in `core/tts/tts_provid
 ### No TTS queuing (V1 pragmatism)
 A new response interrupts the previous one. If the user records two segments quickly,
 only the last response will be read aloud. Sufficient for MVP.
+
+### ISO 639-1 bare codes on iOS (V1 pragmatism)
+`flutter_tts.setLanguage("pl")` may silently fall back to the device default on iOS
+because `AVSpeechSynthesizer` prefers full BCP-47 tags (`"pl-PL"`). The `'auto'`
+path passes `Platform.localeName` (full locale) and is safe. Explicit codes from the
+server (`"pl"`, `"en"`) are passed as-is and are best-effort on iOS. Full locale-tag
+mapping is deferred to a future proposal.
+
+### _drain() re-entrancy (V1 pragmatism)
+`SyncWorker._drain()` has no re-entrancy guard. If two timer ticks overlap
+(e.g. a slow API response), a later drain may call `stop()` while a prior `speak()`
+is still in progress. The resulting interruption is acceptable for V1 (it matches the
+"no queuing" policy). A non-reentrant drain guard is deferred to a future proposal.
 
 ### System language as fallback for 'auto' (V1 pragmatism)
 If `config.language == 'auto'` and the server does not send `language`, the device


### PR DESCRIPTION
Finalizes the P015 TTS Response Playback proposal after multiple review rounds.

## Review history
- 2× /proposal-review rounds — all P0/P1/P2 issues fixed
- 2× /codex-review rounds — Codex verdict: Ready
- 1× additional /proposal-review — final P1 caught and fixed

## Key design decisions captured
- `FlutterTtsService` accepts `FlutterTts? tts` constructor param for unit testing
- `'auto'` language resolves to `Platform.localeName` (full locale e.g. `pl_PL`), not stripped two-letter code
- `getTtsEnabled` closure captures `ref` (not stale bool) for reactive config in `SyncWorker`
- T1 includes no-op stub `TtsService` overrides in all affected test files to keep `flutter test` green between T1 and T3
- `_drain()` re-entrancy and ISO bare codes on iOS documented as V1 Known Compromises

## CLAUDE.md changes
- Phase A extended with /codex-review rounds (A5–A8); user approval moved to A9
