### PR TITLE
fix(tts): prefer premium/enhanced iOS voice over synthetic default

### DIFF
--- a/lib/core/tts/flutter_tts_service.dart
+++ b/lib/core/tts/flutter_tts_service.dart
@@ -4,9 +4,12 @@ import 'package:flutter_tts/flutter_tts.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 
 class FlutterTtsService implements TtsService {
-  FlutterTtsService({FlutterTts? tts}) : _tts = tts ?? FlutterTts();
+  FlutterTtsService({FlutterTts? tts, bool? isIOS})
+      : _tts = tts ?? FlutterTts(),
+        _isIOS = isIOS ?? Platform.isIOS;
 
   final FlutterTts _tts;
+  final bool _isIOS;
 
   // Cache best voice per resolved language string to avoid repeated getVoices()
   // calls. null value means "looked up, nothing better than system default".
@@ -16,7 +19,7 @@ class FlutterTtsService implements TtsService {
   Future<void> speak(String text, {String? languageCode}) async {
     final lang = _resolveLanguage(languageCode);
     await _tts.setLanguage(lang);
-    if (Platform.isIOS) {
+    if (_isIOS) {
       final voice = await _bestVoice(lang);
       if (voice != null) await _tts.setVoice(voice);
     }
@@ -49,38 +52,44 @@ class FlutterTtsService implements TtsService {
   Future<Map<String, String>?> _bestVoice(String lang) async {
     if (_voiceCache.containsKey(lang)) return _voiceCache[lang];
 
-    // Match on the primary language tag (e.g. "pl" from "pl_PL" or "pl-PL").
-    final langPrefix = lang.split(RegExp(r'[_\-]')).first.toLowerCase();
+    try {
+      // Match on the primary language tag (e.g. "pl" from "pl_PL" or "pl-PL").
+      final langPrefix = lang.split(RegExp(r'[_\-]')).first.toLowerCase();
 
-    final dynamic raw = await _tts.getVoices;
-    final voices = raw as List?;
-    if (voices == null) {
+      final dynamic raw = await _tts.getVoices;
+      final voices = raw as List?;
+      if (voices == null) {
+        _voiceCache[lang] = null;
+        return null;
+      }
+
+      Map<String, String>? premium;
+      Map<String, String>? enhanced;
+      Map<String, String>? normal;
+
+      for (final entry in voices) {
+        final voice = Map<String, String>.from(entry as Map);
+        final name = (voice['name'] ?? '').toLowerCase();
+        final locale = (voice['locale'] ?? '').toLowerCase();
+
+        if (!locale.startsWith(langPrefix)) continue;
+
+        if (name.contains('premium')) {
+          premium ??= voice;
+        } else if (name.contains('enhanced')) {
+          enhanced ??= voice;
+        } else {
+          normal ??= voice;
+        }
+      }
+
+      final best = premium ?? enhanced ?? normal;
+      _voiceCache[lang] = best;
+      return best;
+    } catch (_) {
+      // Platform call failed — fall back to AVSpeechSynthesizer default.
       _voiceCache[lang] = null;
       return null;
     }
-
-    Map<String, String>? premium;
-    Map<String, String>? enhanced;
-    Map<String, String>? normal;
-
-    for (final entry in voices) {
-      final voice = Map<String, String>.from(entry as Map);
-      final name = (voice['name'] ?? '').toLowerCase();
-      final locale = (voice['locale'] ?? '').toLowerCase();
-
-      if (!locale.startsWith(langPrefix)) continue;
-
-      if (name.contains('premium')) {
-        premium ??= voice;
-      } else if (name.contains('enhanced')) {
-        enhanced ??= voice;
-      } else {
-        normal ??= voice;
-      }
-    }
-
-    final best = premium ?? enhanced ?? normal;
-    _voiceCache[lang] = best;
-    return best;
   }
 }

--- a/lib/core/tts/flutter_tts_service.dart
+++ b/lib/core/tts/flutter_tts_service.dart
@@ -8,10 +8,18 @@ class FlutterTtsService implements TtsService {
 
   final FlutterTts _tts;
 
+  // Cache best voice per resolved language string to avoid repeated getVoices()
+  // calls. null value means "looked up, nothing better than system default".
+  final Map<String, Map<String, String>?> _voiceCache = {};
+
   @override
   Future<void> speak(String text, {String? languageCode}) async {
     final lang = _resolveLanguage(languageCode);
     await _tts.setLanguage(lang);
+    if (Platform.isIOS) {
+      final voice = await _bestVoice(lang);
+      if (voice != null) await _tts.setVoice(voice);
+    }
     await _tts.speak(text);
   }
 
@@ -33,5 +41,46 @@ class FlutterTtsService implements TtsService {
     }
     // Explicit code (e.g. "pl", "en") — passed as-is; best-effort on iOS.
     return code;
+  }
+
+  /// Returns the best available iOS voice for [lang], preferring premium >
+  /// enhanced > normal quality. Returns null when no voice matches or voices
+  /// cannot be listed (falls back to AVSpeechSynthesizer default selection).
+  Future<Map<String, String>?> _bestVoice(String lang) async {
+    if (_voiceCache.containsKey(lang)) return _voiceCache[lang];
+
+    // Match on the primary language tag (e.g. "pl" from "pl_PL" or "pl-PL").
+    final langPrefix = lang.split(RegExp(r'[_\-]')).first.toLowerCase();
+
+    final dynamic raw = await _tts.getVoices;
+    final voices = raw as List?;
+    if (voices == null) {
+      _voiceCache[lang] = null;
+      return null;
+    }
+
+    Map<String, String>? premium;
+    Map<String, String>? enhanced;
+    Map<String, String>? normal;
+
+    for (final entry in voices) {
+      final voice = Map<String, String>.from(entry as Map);
+      final name = (voice['name'] ?? '').toLowerCase();
+      final locale = (voice['locale'] ?? '').toLowerCase();
+
+      if (!locale.startsWith(langPrefix)) continue;
+
+      if (name.contains('premium')) {
+        premium ??= voice;
+      } else if (name.contains('enhanced')) {
+        enhanced ??= voice;
+      } else {
+        normal ??= voice;
+      }
+    }
+
+    final best = premium ?? enhanced ?? normal;
+    _voiceCache[lang] = best;
+    return best;
   }
 }

--- a/test/core/tts/flutter_tts_service_test.dart
+++ b/test/core/tts/flutter_tts_service_test.dart
@@ -9,7 +9,14 @@ import 'package:voice_agent/core/tts/flutter_tts_service.dart';
 class _MockFlutterTts implements FlutterTts {
   final List<String> setLanguageCalls = [];
   final List<String> speakCalls = [];
+  final List<Map<String, String>> setVoiceCalls = [];
   int stopCount = 0;
+
+  /// Voices returned by [getVoices]. Override in each test.
+  List<dynamic> voiceList = [];
+
+  /// When non-null, [getVoices] throws this.
+  Object? getVoicesError;
 
   @override
   Future<dynamic> setLanguage(String language) async {
@@ -27,6 +34,18 @@ class _MockFlutterTts implements FlutterTts {
   Future<dynamic> stop() async {
     stopCount++;
     return 1;
+  }
+
+  @override
+  Future<dynamic> setVoice(Map<String, String> voice) async {
+    setVoiceCalls.add(voice);
+    return 1;
+  }
+
+  @override
+  Future<dynamic> get getVoices async {
+    if (getVoicesError != null) throw getVoicesError!;
+    return voiceList;
   }
 
   // Unused FlutterTts members — not needed for these tests.
@@ -78,6 +97,138 @@ void main() {
       await svc.stop();
 
       expect(mock.stopCount, 1);
+    });
+  });
+
+  group('FlutterTtsService voice selection (iOS)', () {
+    // Helper: build a service with isIOS=true so _bestVoice() is exercised.
+    FlutterTtsService _svc(_MockFlutterTts mock) =>
+        FlutterTtsService(tts: mock, isIOS: true);
+
+    test('picks premium voice over enhanced and normal', () async {
+      final mock = _MockFlutterTts()
+        ..voiceList = [
+          {'name': 'com.apple.voice.normal.pl-PL.Zosia', 'locale': 'pl-PL'},
+          {'name': 'com.apple.voice.enhanced.pl-PL.Ewa', 'locale': 'pl-PL'},
+          {'name': 'com.apple.voice.premium.pl-PL.Zosia', 'locale': 'pl-PL'},
+        ];
+      final svc = _svc(mock);
+
+      await svc.speak('Cześć', languageCode: 'pl');
+
+      expect(mock.setVoiceCalls, hasLength(1));
+      expect(mock.setVoiceCalls.first['name'],
+          contains('premium'));
+    });
+
+    test('picks enhanced when no premium available', () async {
+      final mock = _MockFlutterTts()
+        ..voiceList = [
+          {'name': 'com.apple.voice.normal.pl-PL.Ewa', 'locale': 'pl-PL'},
+          {'name': 'com.apple.voice.enhanced.pl-PL.Zosia', 'locale': 'pl-PL'},
+        ];
+      final svc = _svc(mock);
+
+      await svc.speak('Cześć', languageCode: 'pl');
+
+      expect(mock.setVoiceCalls.first['name'], contains('enhanced'));
+    });
+
+    test('picks normal when only normal voices available', () async {
+      final mock = _MockFlutterTts()
+        ..voiceList = [
+          {'name': 'com.apple.ttsbundle.pl-PL-Zosia', 'locale': 'pl-PL'},
+        ];
+      final svc = _svc(mock);
+
+      await svc.speak('Cześć', languageCode: 'pl');
+
+      expect(mock.setVoiceCalls, hasLength(1));
+      expect(mock.setVoiceCalls.first['name'], contains('pl-PL'));
+    });
+
+    test('does not call setVoice when no voice matches language', () async {
+      final mock = _MockFlutterTts()
+        ..voiceList = [
+          {'name': 'com.apple.voice.premium.en-US.Zoe', 'locale': 'en-US'},
+        ];
+      final svc = _svc(mock);
+
+      await svc.speak('Cześć', languageCode: 'pl');
+
+      expect(mock.setVoiceCalls, isEmpty);
+    });
+
+    test('does not call setVoice when voice list is empty', () async {
+      final mock = _MockFlutterTts()..voiceList = [];
+      final svc = _svc(mock);
+
+      await svc.speak('Hello', languageCode: 'en');
+
+      expect(mock.setVoiceCalls, isEmpty);
+    });
+
+    test('caches result — getVoices called only once per language', () async {
+      final mock = _MockFlutterTts()
+        ..voiceList = [
+          {'name': 'com.apple.voice.premium.en-US.Zoe', 'locale': 'en-US'},
+        ];
+      // Wrap getVoices call tracking via voiceList side-effect isn't possible,
+      // so we verify via a second speak() not throwing and setVoice being called twice.
+      final svc = _svc(mock);
+
+      await svc.speak('First', languageCode: 'en');
+      // Clear setVoiceCalls to distinguish second call.
+      final firstVoice = mock.setVoiceCalls.first;
+      mock.setVoiceCalls.clear();
+      // Simulate getVoices returning empty on second call to prove it's cached.
+      mock.voiceList = [];
+
+      await svc.speak('Second', languageCode: 'en');
+
+      // If cached, the same voice should be used again despite empty voiceList.
+      expect(mock.setVoiceCalls, hasLength(1));
+      expect(mock.setVoiceCalls.first, equals(firstVoice));
+    });
+
+    test('falls back silently when getVoices throws', () async {
+      final mock = _MockFlutterTts()
+        ..getVoicesError = Exception('platform error');
+      final svc = _svc(mock);
+
+      // Should not throw — speak() completes normally without setVoice.
+      await expectLater(
+        svc.speak('Hello', languageCode: 'en'),
+        completes,
+      );
+      expect(mock.setVoiceCalls, isEmpty);
+      expect(mock.speakCalls, ['Hello']);
+    });
+
+    test('language prefix matching works for locale with underscore', () async {
+      final mock = _MockFlutterTts()
+        ..voiceList = [
+          {'name': 'com.apple.voice.premium.pl-PL.Zosia', 'locale': 'pl-PL'},
+        ];
+      final svc = _svc(mock);
+
+      // "pl_PL" (underscore) should still match "pl-PL" locale.
+      await svc.speak('Cześć', languageCode: 'pl_PL');
+
+      expect(mock.setVoiceCalls, hasLength(1));
+    });
+
+    test('does not call setVoice on non-iOS', () async {
+      final mock = _MockFlutterTts()
+        ..voiceList = [
+          {'name': 'com.apple.voice.premium.en-US.Zoe', 'locale': 'en-US'},
+        ];
+      // Default isIOS = Platform.isIOS — in test host (macOS/Linux) this is false.
+      final svc = FlutterTtsService(tts: mock, isIOS: false);
+
+      await svc.speak('Hello', languageCode: 'en');
+
+      expect(mock.setVoiceCalls, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Problem

flutter_tts never called \`setVoice()\`, so AVSpeechSynthesizer always picked the basic synthetic voice — even when the user had downloaded Premium or Enhanced voices in iOS Settings → Accessibility → Spoken Content → Voices.

## Fix

Added \`_bestVoice(lang)\` in \`FlutterTtsService\`:
1. Calls \`getVoices()\` to list all voices available on the device
2. Filters by language prefix (e.g. \`pl\` from \`pl_PL\`)
3. Picks: **premium > enhanced > normal**
4. Caches result per language — no repeated platform calls
5. iOS only; Android path unchanged
6. Falls back silently to system default when nothing better is found

## User action required

To get improved quality: iOS Settings → Accessibility → Spoken Content → Voices → select language → download Enhanced or Premium voice.