### PR TITLE
fix(recording): cap HF error text; reload VAD config on change

### DIFF
--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
 import 'package:voice_agent/core/models/transcript.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
@@ -103,17 +104,9 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     }
     _engine = null;
     _engineSub = null;
+    if (!mounted) return;
 
-    final config = _ref.read(appConfigProvider).vadConfig;
-    final engine = _ref.read(handsFreeEngineProvider);
-    _engine = engine;
-    final stream = engine.start(config: config);
-    _engineSub = stream.listen(
-      _onEngineEvent,
-      onError: (Object e) => _terminateWithError('Engine error: $e'),
-      onDone: _onEngineDone,
-      cancelOnError: false,
-    );
+    _startEngine(_ref.read(appConfigProvider).vadConfig);
     state = _listeningOrBacklog();
   }
 
@@ -123,16 +116,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   Future<void> resumeAfterManualRecording() async {
     if (!_suspendedForManualRecording) return;
     _suspendedForManualRecording = false;
-    final config = _ref.read(appConfigProvider).vadConfig;
-    final engine = _ref.read(handsFreeEngineProvider);
-    _engine = engine;
-    final stream = engine.start(config: config);
-    _engineSub = stream.listen(
-      _onEngineEvent,
-      onError: (Object e) => _terminateWithError('Engine error: $e'),
-      onDone: _onEngineDone,
-      cancelOnError: false,
-    );
+    _startEngine(_ref.read(appConfigProvider).vadConfig);
     state = _listeningOrBacklog();
   }
 
@@ -181,9 +165,15 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     // All guards passed — start engine.
     _jobs.clear();
     _jobCounter = 0;
-    _engine = engine;
+    _startEngine(_ref.read(appConfigProvider).vadConfig);
+  }
 
-    final stream = engine.start(config: _ref.read(appConfigProvider).vadConfig);
+  // ── Helpers — engine lifecycle ────────────────────────────────────────────
+
+  void _startEngine(VadConfig config) {
+    final engine = _ref.read(handsFreeEngineProvider);
+    _engine = engine;
+    final stream = engine.start(config: config);
     _engineSub = stream.listen(
       _onEngineEvent,
       onError: (Object e) => _terminateWithError('Engine error: $e'),

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -85,6 +85,38 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     state = _listeningOrBacklog();
   }
 
+  /// Restarts the VAD engine with the current [appConfigProvider] VAD config.
+  ///
+  /// Called when the user changes VAD parameters in Advanced Settings.
+  /// No-op when idle, in error, or suspended for manual recording (the new
+  /// config will be picked up automatically by [resumeAfterManualRecording]).
+  Future<void> reloadVadConfig() async {
+    if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
+    if (_suspendedForManualRecording) return;
+
+    if (state is HandsFreeCapturing) {
+      await _engine?.interruptCapture();
+    } else {
+      await _engineSub?.cancel();
+      _engineSub = null;
+      await _engine?.stop();
+    }
+    _engine = null;
+    _engineSub = null;
+
+    final config = _ref.read(appConfigProvider).vadConfig;
+    final engine = _ref.read(handsFreeEngineProvider);
+    _engine = engine;
+    final stream = engine.start(config: config);
+    _engineSub = stream.listen(
+      _onEngineEvent,
+      onError: (Object e) => _terminateWithError('Engine error: $e'),
+      onDone: _onEngineDone,
+      cancelOnError: false,
+    );
+    state = _listeningOrBacklog();
+  }
+
   /// Restarts the VAD engine after manual recording completes.
   ///
   /// Does NOT clear [_jobs] or [_jobCounter] — the backlog is preserved.

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -43,9 +43,7 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
     });
 
     ref.listen(appConfigProvider.select((c) => c.vadConfig), (prev, next) {
-      if (prev != next) {
-        unawaited(ref.read(handsFreeControllerProvider.notifier).reloadVadConfig());
-      }
+      unawaited(ref.read(handsFreeControllerProvider.notifier).reloadVadConfig());
     });
 
     final recState = ref.watch(recordingControllerProvider);

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -42,6 +42,12 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
       }
     });
 
+    ref.listen(appConfigProvider.select((c) => c.vadConfig), (prev, next) {
+      if (prev != next) {
+        unawaited(ref.read(handsFreeControllerProvider.notifier).reloadVadConfig());
+      }
+    });
+
     final recState = ref.watch(recordingControllerProvider);
     final hfState = ref.watch(handsFreeControllerProvider);
     final recCtrl = ref.read(recordingControllerProvider.notifier);
@@ -242,6 +248,8 @@ class _ErrorStrip extends StatelessWidget {
           Text(
             message,
             key: const Key('hf-error-message'),
+            maxLines: 3,
+            overflow: TextOverflow.ellipsis,
             style: Theme.of(context)
                 .textTheme
                 .bodyMedium


### PR DESCRIPTION
## Summary

- **Overflow fix**: `_ErrorStrip` displayed the raw exception message (including FFI stack traces) without line limit, causing the body Column to overflow by 631 px. Added `maxLines: 3, overflow: TextOverflow.ellipsis` to cap height.
- **VAD reload**: Added `HandsFreeController.reloadVadConfig()` that stops and restarts the VAD engine with fresh config. A `ref.listen` in `RecordingScreen` triggers this automatically when the user saves a change in Advanced (VAD) Settings — no app restart needed.

## Test plan
- [ ] Trigger a hands-free audio error (e.g. revoke mic permission) — error strip stays 3 lines max, no overflow
- [ ] Open Advanced (VAD) Settings, change Hangover slider — VAD engine restarts immediately, strip at bottom updates, new config active
- [ ] Change VAD params during active capture — current segment is interrupted, engine restarts with new config
- [ ] `flutter test` — all 291 tests pass
