### PR TITLE
fix(audio-feedback): loop from transcription until API response

### DIFF
--- a/lib/features/api_sync/sync_worker.dart
+++ b/lib/features/api_sync/sync_worker.dart
@@ -109,7 +109,6 @@ class SyncWorker {
     final item = items.first;
 
     await storageService.markSending(item.id);
-    unawaited(audioFeedbackService.startProcessingFeedback());
 
     final transcript = await storageService.getTranscript(item.transcriptId);
     if (transcript == null) {

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -331,6 +331,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     if (!mounted) return;
 
     if (sttText.trim().isEmpty) {
+      unawaited(_ref.read(audioFeedbackServiceProvider).stopLoop());
       _jobs[idx] =
           _jobs[idx].copyWith(state: const Rejected('Empty transcription'));
       state = _listeningOrBacklog();
@@ -362,7 +363,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
       try {
         await storage.enqueue(transcript.id);
         if (!mounted) return;
-        unawaited(_ref.read(audioFeedbackServiceProvider).playSuccess());
+        // Loop continues — sync_worker will play success/error on API response.
         _jobs[idx] = _jobs[idx].copyWith(state: Completed(transcript.id));
       } catch (e) {
         // Rollback: remove the transcript so it doesn't orphan.

--- a/lib/features/recording/presentation/recording_controller.dart
+++ b/lib/features/recording/presentation/recording_controller.dart
@@ -97,6 +97,7 @@ class RecordingController extends StateNotifier<RecordingState>
 
       if (transcriptResult.text.trim().isEmpty) {
         if (silentOnEmpty) {
+          unawaited(_ref.read(audioFeedbackServiceProvider).stopLoop());
           state = const RecordingState.idle();
         } else {
           unawaited(_ref.read(audioFeedbackServiceProvider).playError());
@@ -124,7 +125,7 @@ class RecordingController extends StateNotifier<RecordingState>
       try {
         await storage.enqueue(transcript.id);
         if (!mounted) return;
-        unawaited(_ref.read(audioFeedbackServiceProvider).playSuccess());
+        // Loop continues — sync_worker will play success/error on API response.
         state = const RecordingState.idle();
       } catch (e) {
         // Rollback: remove the transcript so it doesn't orphan.


### PR DESCRIPTION
## Summary

Audio feedback now follows a single continuous flow: **start → loop → success/error**.

- Loop begins at transcription start and continues through enqueue into sync
- Removed premature `playSuccess` after enqueue in both recording controllers
- Removed duplicate `startProcessingFeedback` from sync_worker (loop already running)
- Added `stopLoop` for empty transcription cases (no sync will follow)

**Before:** start+loop during STT → success → start+loop during sync → success/error (double emission)
**After:** start+loop during STT → loop continues → success/error on API response

## Test plan
- [ ] Record a message → hear start+loop → loop continues → success/error after server response
- [ ] Record silence (empty transcription) → hear start+loop → error sound (loop stops)
- [ ] `flutter test` — 291 tests pass
