### PR TITLE
feat(settings): add personal-agent URL guidance

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -120,12 +120,21 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         children: [
           _buildSectionHeader('API Configuration'),
           Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Text(
+              'Connect to a personal-agent backend for knowledge extraction and spoken replies.',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+          Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: TextField(
               controller: _urlController,
               decoration: InputDecoration(
                 labelText: 'API URL',
-                hintText: 'https://your-api.com/endpoint',
+                hintText: 'http://192.168.x.x:8888/api/v1/voice/transcript',
+                helperText: 'Personal agent: http://<host>:8888/api/v1/voice/transcript',
+                helperMaxLines: 2,
                 border: const OutlineInputBorder(),
                 errorText: _urlError,
               ),

--- a/test/features/settings/advanced_settings_screen_test.dart
+++ b/test/features/settings/advanced_settings_screen_test.dart
@@ -149,7 +149,7 @@ void main() {
       // Scroll until the tile is visible in the settings ListView
       await tester.drag(
         find.byType(ListView).last,
-        const Offset(0, -400),
+        const Offset(0, -500),
       );
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
- Add personal-agent URL guidance to settings screen (P017 T1)
- Description text above URL field explains the personal-agent connection
- Hint text shows expected URL format: `http://192.168.x.x:8888/api/v1/voice/transcript`
- Helper text provides URL template
- Adjust test scroll offset to accommodate new description widget

Closes #133
