### PR TITLE
feat(api_sync,recording): display agent reply on RecordingScreen

### DIFF
--- a/lib/core/providers/agent_reply_provider.dart
+++ b/lib/core/providers/agent_reply_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Latest text reply from the personal-agent backend.
+///
+/// **Producer:** `SyncWorker` via `sync_provider.dart` — set on `ApiSuccess`
+/// with a `message` field in the response body.
+///
+/// **Consumer:** `RecordingScreen` — displays the reply in a dismissible card.
+final latestAgentReplyProvider = StateProvider<String?>((ref) => null);

--- a/lib/features/api_sync/sync_provider.dart
+++ b/lib/features/api_sync/sync_provider.dart
@@ -3,6 +3,7 @@ import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/network/api_client.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/providers/agent_reply_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/features/api_sync/api_config.dart';
@@ -29,6 +30,9 @@ final syncWorkerProvider = Provider<SyncWorker>((ref) {
     ttsService: ref.watch(ttsServiceProvider),
     getTtsEnabled: () => ref.read(appConfigProvider).ttsEnabled,
     audioFeedbackService: ref.watch(audioFeedbackServiceProvider),
+    onAgentReply: (reply) {
+      ref.read(latestAgentReplyProvider.notifier).state = reply;
+    },
   );
 
   worker.start();

--- a/lib/features/api_sync/sync_worker.dart
+++ b/lib/features/api_sync/sync_worker.dart
@@ -19,6 +19,7 @@ class SyncWorker {
     required this.ttsService,
     required this.getTtsEnabled,
     required this.audioFeedbackService,
+    this.onAgentReply,
   });
 
   final StorageService storageService;
@@ -28,6 +29,7 @@ class SyncWorker {
   final TtsService ttsService;
   final bool Function() getTtsEnabled;
   final AudioFeedbackService audioFeedbackService;
+  final void Function(String reply)? onAgentReply;
 
   SyncWorkerState _state = SyncWorkerState.idle;
   SyncWorkerState get state => _state;
@@ -128,7 +130,7 @@ class SyncWorker {
       case ApiSuccess(:final body):
         await storageService.markSent(item.id);
         unawaited(audioFeedbackService.playSuccess());
-        _maybeSpeak(body);
+        _handleReply(body);
       case ApiPermanentFailure(:final message):
         await storageService.markFailed(item.id, message);
         unawaited(audioFeedbackService.playError());
@@ -146,15 +148,17 @@ class SyncWorker {
     }
   }
 
-  void _maybeSpeak(String? body) {
-    if (!getTtsEnabled()) return;
+  void _handleReply(String? body) {
     if (body == null) return;
     try {
       final json = jsonDecode(body) as Map<String, dynamic>;
       final message = json['message'] as String?;
       if (message == null || message.isEmpty) return;
       final language = json['language'] as String?;
-      unawaited(ttsService.stop().then((_) => ttsService.speak(message, languageCode: language)));
+      if (getTtsEnabled()) {
+        unawaited(ttsService.stop().then((_) => ttsService.speak(message, languageCode: language)));
+      }
+      onAgentReply?.call(message);
     } catch (_) {
       // Non-JSON or unexpected shape — stay silent.
     }

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/providers/agent_reply_provider.dart';
 import 'package:voice_agent/core/providers/api_url_provider.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_session_state.dart';
@@ -46,11 +47,19 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
       unawaited(ref.read(handsFreeControllerProvider.notifier).reloadVadConfig());
     });
 
+    // Clear agent reply when hands-free starts capturing
+    ref.listen<HandsFreeSessionState>(handsFreeControllerProvider, (prev, next) {
+      if (next is HandsFreeCapturing) {
+        ref.read(latestAgentReplyProvider.notifier).state = null;
+      }
+    });
+
     final recState = ref.watch(recordingControllerProvider);
     final hfState = ref.watch(handsFreeControllerProvider);
     final recCtrl = ref.read(recordingControllerProvider.notifier);
     final hfCtrl = ref.read(handsFreeControllerProvider.notifier);
     final isApiConfigured = ref.watch(apiUrlConfiguredProvider);
+    final agentReply = ref.watch(latestAgentReplyProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Record')),
@@ -73,6 +82,9 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
               child: _buildRecordingArea(context, recState, recCtrl),
             ),
           ),
+          _AgentReplyCard(reply: agentReply, onDismiss: () {
+            ref.read(latestAgentReplyProvider.notifier).state = null;
+          }),
           _HandsFreeSection(
             hfState: hfState,
             onRetry: () => hfCtrl.startSession(),
@@ -129,6 +141,46 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
           ],
         ),
     };
+  }
+}
+
+// ── Agent reply card ─────────────────────────────────────────────────────────
+
+class _AgentReplyCard extends StatelessWidget {
+  const _AgentReplyCard({required this.reply, required this.onDismiss});
+
+  final String? reply;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 200),
+      child: reply != null
+          ? Card(
+              key: const Key('agent-reply-card'),
+              margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 200),
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 4, 12),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(child: Text(reply!)),
+                      IconButton(
+                        key: const Key('agent-reply-dismiss'),
+                        icon: const Icon(Icons.close),
+                        onPressed: onDismiss,
+                        tooltip: 'Dismiss agent reply',
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            )
+          : const SizedBox.shrink(),
+    );
   }
 }
 
@@ -306,6 +358,7 @@ class _MicButtonState extends ConsumerState<_MicButton> {
 
     if (recState is RecordingIdle) {
       if (hfState is HandsFreeStopping) return; // no-op — wait for stop
+      ref.read(latestAgentReplyProvider.notifier).state = null;
       await ref.read(ttsServiceProvider).stop();
       await hfCtrl.suspendForManualRecording();
       await recCtrl.startRecording();
@@ -327,6 +380,7 @@ class _MicButtonState extends ConsumerState<_MicButton> {
     _longPressActive = true;
     setState(() => _isPressAndHold = true);
 
+    ref.read(latestAgentReplyProvider.notifier).state = null;
     final recCtrl = ref.read(recordingControllerProvider.notifier);
     final hfCtrl = ref.read(handsFreeControllerProvider.notifier);
     await ref.read(ttsServiceProvider).stop();

--- a/test/features/api_sync/sync_worker_test.dart
+++ b/test/features/api_sync/sync_worker_test.dart
@@ -399,6 +399,106 @@ void main() {
     });
   });
 
+  group('onAgentReply callback', () {
+    test('is called with message on ApiSuccess', () async {
+      String? receivedReply;
+      worker = SyncWorker(
+        storageService: storage,
+        apiClient: apiClient,
+        apiConfig: const ApiConfig(url: 'https://example.com/api', token: 'tok'),
+        connectivityService: connectivity,
+        ttsService: tts,
+        getTtsEnabled: () => ttsEnabled,
+        audioFeedbackService: _StubAudioFeedbackService(),
+        onAgentReply: (reply) => receivedReply = reply,
+      );
+
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody = '{"message": "hello"}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 100));
+      worker.stop();
+
+      expect(receivedReply, 'hello');
+    });
+
+    test('is called even when ttsEnabled is false', () async {
+      String? receivedReply;
+      ttsEnabled = false;
+      worker = SyncWorker(
+        storageService: storage,
+        apiClient: apiClient,
+        apiConfig: const ApiConfig(url: 'https://example.com/api', token: 'tok'),
+        connectivityService: connectivity,
+        ttsService: tts,
+        getTtsEnabled: () => ttsEnabled,
+        audioFeedbackService: _StubAudioFeedbackService(),
+        onAgentReply: (reply) => receivedReply = reply,
+      );
+
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody = '{"message": "hello"}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 100));
+      worker.stop();
+
+      expect(receivedReply, 'hello');
+      expect(tts.log, isEmpty); // TTS not called
+    });
+
+    test('is NOT called on ApiPermanentFailure', () async {
+      String? receivedReply;
+      worker = SyncWorker(
+        storageService: storage,
+        apiClient: apiClient,
+        apiConfig: const ApiConfig(url: 'https://example.com/api', token: 'tok'),
+        connectivityService: connectivity,
+        ttsService: tts,
+        getTtsEnabled: () => ttsEnabled,
+        audioFeedbackService: _StubAudioFeedbackService(),
+        onAgentReply: (reply) => receivedReply = reply,
+      );
+
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextResult = const ApiPermanentFailure(statusCode: 400, message: 'Bad');
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 100));
+      worker.stop();
+
+      expect(receivedReply, isNull);
+    });
+
+    test('is NOT called when success body has no message field', () async {
+      String? receivedReply;
+      worker = SyncWorker(
+        storageService: storage,
+        apiClient: apiClient,
+        apiConfig: const ApiConfig(url: 'https://example.com/api', token: 'tok'),
+        connectivityService: connectivity,
+        ttsService: tts,
+        getTtsEnabled: () => ttsEnabled,
+        audioFeedbackService: _StubAudioFeedbackService(),
+        onAgentReply: (reply) => receivedReply = reply,
+      );
+
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody = '{"status": "ok"}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 100));
+      worker.stop();
+
+      expect(receivedReply, isNull);
+    });
+  });
+
   group('backoffForAttempt', () {
     test('attempt 0 returns zero', () {
       expect(SyncWorker.backoffForAttempt(0), Duration.zero);

--- a/test/features/recording/presentation/recording_screen_hands_free_test.dart
+++ b/test/features/recording/presentation/recording_screen_hands_free_test.dart
@@ -12,6 +12,7 @@ import 'package:voice_agent/core/models/transcript.dart';
 import 'package:voice_agent/core/models/transcript_result.dart';
 import 'package:voice_agent/core/models/transcript_with_status.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/providers/agent_reply_provider.dart';
 import 'package:voice_agent/core/providers/api_url_provider.dart';
 import 'package:voice_agent/features/api_sync/sync_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
@@ -212,6 +213,34 @@ void main() {
       await tester.pump();
 
       expect(find.byKey(const Key('hf-segment-list')), findsOneWidget);
+    });
+  });
+
+  group('agent reply clearing', () {
+    testWidgets('HandsFreeCapturing clears latestAgentReplyProvider',
+        (tester) async {
+      final engine = FakeHfEngine();
+      late ProviderContainer container;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...baseOverrides(engine),
+            latestAgentReplyProvider.overrideWith((_) => 'stale reply'),
+          ],
+          child: Builder(builder: (context) {
+            container = ProviderScope.containerOf(context);
+            return const App();
+          }),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(container.read(latestAgentReplyProvider), 'stale reply');
+
+      engine.emit(const EngineCapturing());
+      await tester.pumpAndSettle();
+
+      expect(container.read(latestAgentReplyProvider), isNull);
     });
   });
 

--- a/test/features/recording/presentation/recording_screen_mic_button_test.dart
+++ b/test/features/recording/presentation/recording_screen_mic_button_test.dart
@@ -13,6 +13,7 @@ import 'package:voice_agent/core/models/transcript.dart';
 import 'package:voice_agent/core/models/transcript_result.dart';
 import 'package:voice_agent/core/models/transcript_with_status.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/providers/agent_reply_provider.dart';
 import 'package:voice_agent/core/providers/api_url_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/features/api_sync/sync_provider.dart';
@@ -278,6 +279,64 @@ void main() {
       // silentOnEmpty → RecordingIdle, no error
       expect(find.byIcon(Icons.error), findsNothing);
       expect(find.text('Tap to record'), findsOneWidget);
+    });
+  });
+
+  group('Agent reply clearing', () {
+    testWidgets('tap clears latestAgentReplyProvider', (tester) async {
+      late ProviderContainer container;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ..._baseOverrides,
+            latestAgentReplyProvider.overrideWith((_) => 'old reply'),
+          ],
+          child: Builder(builder: (context) {
+            container = ProviderScope.containerOf(context);
+            return const App();
+          }),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Verify reply card is visible
+      expect(find.byKey(const Key('agent-reply-card')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('record-button')));
+      await tester.pumpAndSettle();
+
+      expect(container.read(latestAgentReplyProvider), isNull);
+    });
+
+    testWidgets('long-press clears latestAgentReplyProvider', (tester) async {
+      late ProviderContainer container;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ..._baseOverrides,
+            latestAgentReplyProvider.overrideWith((_) => 'old reply'),
+          ],
+          child: Builder(builder: (context) {
+            container = ProviderScope.containerOf(context);
+            return const App();
+          }),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('agent-reply-card')), findsOneWidget);
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byKey(const Key('record-button'))),
+      );
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump();
+
+      expect(container.read(latestAgentReplyProvider), isNull);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
     });
   });
 

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:voice_agent/core/models/sync_queue_item.dart';
 import 'package:voice_agent/core/models/transcript.dart';
 import 'package:voice_agent/core/models/transcript_with_status.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/providers/agent_reply_provider.dart';
 import 'package:voice_agent/core/providers/api_url_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
@@ -224,6 +225,63 @@ void main() {
       expect(find.text('Open Settings'), findsNothing);
     },
   );
+
+  group('Agent reply card', () {
+    testWidgets('shows card when latestAgentReplyProvider is non-null',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ..._baseOverrides,
+            apiUrlConfiguredProvider.overrideWithValue(true),
+            latestAgentReplyProvider.overrideWith((_) => 'Agent reply text'),
+          ],
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('agent-reply-card')), findsOneWidget);
+      expect(find.text('Agent reply text'), findsOneWidget);
+    });
+
+    testWidgets('hides card when latestAgentReplyProvider is null',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ..._baseOverrides,
+            apiUrlConfiguredProvider.overrideWithValue(true),
+          ],
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('agent-reply-card')), findsNothing);
+    });
+
+    testWidgets('dismiss button clears the reply card', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ..._baseOverrides,
+            apiUrlConfiguredProvider.overrideWithValue(true),
+            latestAgentReplyProvider.overrideWith((_) => 'Dismiss me'),
+          ],
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('agent-reply-card')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('agent-reply-dismiss')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('agent-reply-card')), findsNothing);
+    });
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add agent reply display on RecordingScreen (P017 T2)
- New `latestAgentReplyProvider` in `core/providers/` for cross-feature communication (ADR-ARCH-008)
- Refactor `SyncWorker._maybeSpeak` → `_handleReply` with `onAgentReply` callback
- Reply card with dismiss button, clearing on tap/long-press/hands-free capture start
- 10 new tests across 4 test files (301 total, all passing)

## Changes
- `lib/core/providers/agent_reply_provider.dart` — new `StateProvider<String?>`
- `lib/features/api_sync/sync_worker.dart` — `onAgentReply` callback + `_handleReply` refactor
- `lib/features/api_sync/sync_provider.dart` — wire callback
- `lib/features/recording/presentation/recording_screen.dart` — reply card + clearing logic

Closes #134
