### PR TITLE
feat(core/storage): recover stale sending items on startup

### DIFF
--- a/lib/core/storage/sqlite_storage_service.dart
+++ b/lib/core/storage/sqlite_storage_service.dart
@@ -232,6 +232,15 @@ class SqliteStorageService implements StorageService {
     );
   }
 
+  @override
+  Future<int> recoverStaleSending() async {
+    return await _db.rawUpdate(
+      'UPDATE sync_queue SET status = ?, error_message = NULL '
+      'WHERE status = ?',
+      [SyncStatus.pending.name, SyncStatus.sending.name],
+    );
+  }
+
   // -- Device --
 
   @override

--- a/lib/core/storage/storage_service.dart
+++ b/lib/core/storage/storage_service.dart
@@ -29,6 +29,10 @@ abstract class StorageService {
   /// Invariant: at most one sync_queue row per transcript.
   Future<void> reactivateForResend(String transcriptId);
 
+  /// Reset all `sending` items to `pending` on app startup.
+  /// Returns the number of recovered rows.
+  Future<int> recoverStaleSending();
+
   // -- Device --
   Future<String> getDeviceId();
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/app/app.dart';
@@ -8,6 +9,11 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   final storage = await SqliteStorageService.initialize();
+
+  final recovered = await storage.recoverStaleSending();
+  if (kDebugMode && recovered > 0) {
+    debugPrint('Recovered $recovered stale sending items');
+  }
 
   runApp(
     ProviderScope(

--- a/test/app/app_test.dart
+++ b/test/app/app_test.dart
@@ -40,6 +40,8 @@ class _StubStorageService implements StorageService {
   Future<void> markPendingForRetry(String id) async {}
   @override
   Future<void> reactivateForResend(String transcriptId) async {}
+  @override
+  Future<int> recoverStaleSending() async => 0;
 }
 
 class _NoOpConnectivity extends ConnectivityService {

--- a/test/app/router_test.dart
+++ b/test/app/router_test.dart
@@ -38,6 +38,8 @@ class _StubStorageService implements StorageService {
     int limit = 20,
     int offset = 0,
   }) async => [];
+  @override
+  Future<int> recoverStaleSending() async => 0;
 }
 
 void main() {

--- a/test/core/storage/sqlite_storage_service_test.dart
+++ b/test/core/storage/sqlite_storage_service_test.dart
@@ -351,4 +351,74 @@ void main() {
       expect(items.length, 1, reason: 'Should never create duplicates');
     });
   });
+
+  group('recoverStaleSending', () {
+    final transcript = Transcript(
+      id: 'tx-stale',
+      text: 'stale test',
+      deviceId: 'dev',
+      createdAt: 1000,
+    );
+
+    test('resets sending items to pending', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-stale');
+
+      final items = await storage.getPendingItems();
+      final queueId = items.first.id;
+
+      await storage.markSending(queueId);
+
+      // Verify it's no longer pending
+      expect(await storage.getPendingItems(), isEmpty);
+
+      // Recover
+      final count = await storage.recoverStaleSending();
+      expect(count, 1);
+
+      // Now it's pending again
+      final recovered = await storage.getPendingItems();
+      expect(recovered.length, 1);
+      expect(recovered.first.status, SyncStatus.pending);
+      expect(recovered.first.errorMessage, isNull);
+    });
+
+    test('does not affect pending or failed items', () async {
+      await storage.saveTranscript(transcript);
+      final t2 = Transcript(id: 'tx-2', text: 'two', deviceId: 'dev', createdAt: 2000);
+      final t3 = Transcript(id: 'tx-3', text: 'three', deviceId: 'dev', createdAt: 3000);
+      await storage.saveTranscript(t2);
+      await storage.saveTranscript(t3);
+
+      await storage.enqueue('tx-stale'); // will stay pending
+      await storage.enqueue('tx-2'); // will become failed
+      await storage.enqueue('tx-3'); // will become sending (target for recovery)
+
+      final items = await storage.getPendingItems();
+      // Mark tx-2 as failed
+      final q2 = items.firstWhere((i) => i.transcriptId == 'tx-2');
+      await storage.markSending(q2.id);
+      await storage.markFailed(q2.id, 'err');
+
+      // Mark tx-3 as sending
+      final items2 = await storage.getPendingItems();
+      final q3 = items2.firstWhere((i) => i.transcriptId == 'tx-3');
+      await storage.markSending(q3.id);
+
+      final count = await storage.recoverStaleSending();
+      expect(count, 1); // only tx-3
+
+      // tx-stale still pending (unchanged)
+      final pending = await storage.getPendingItems();
+      expect(pending.length, 2); // tx-stale (original) + tx-3 (recovered)
+    });
+
+    test('returns 0 when no sending items exist', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-stale');
+
+      final count = await storage.recoverStaleSending();
+      expect(count, 0);
+    });
+  });
 }

--- a/test/features/api_sync/sync_worker_test.dart
+++ b/test/features/api_sync/sync_worker_test.dart
@@ -125,6 +125,9 @@ class FakeStorageService implements StorageService {
 
   @override
   Future<void> reactivateForResend(String transcriptId) async {}
+
+  @override
+  Future<int> recoverStaleSending() async => 0;
 }
 
 class FakeApiClient extends ApiClient {

--- a/test/features/history/history_notifier_test.dart
+++ b/test/features/history/history_notifier_test.dart
@@ -53,6 +53,8 @@ class FakeStorageService implements StorageService {
   Future<void> markPendingForRetry(String id) async {}
   @override
   Future<String> getDeviceId() async => 'test-device';
+  @override
+  Future<int> recoverStaleSending() async => 0;
 }
 
 void main() {

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -181,6 +181,8 @@ class FakeStorageService implements StorageService {
   Future<void> markPendingForRetry(String id) async {}
   @override
   Future<void> reactivateForResend(String transcriptId) async {}
+  @override
+  Future<int> recoverStaleSending() async => 0;
 }
 
 // ── _FixedConfigService ───────────────────────────────────────────────────────

--- a/test/features/recording/presentation/recording_controller_test.dart
+++ b/test/features/recording/presentation/recording_controller_test.dart
@@ -151,6 +151,9 @@ class FakeStorageService implements StorageService {
   Future<List<TranscriptWithStatus>> getTranscriptsWithStatus(
           {int limit = 20, int offset = 0}) async =>
       [];
+
+  @override
+  Future<int> recoverStaleSending() async => 0;
 }
 
 class _StubAudioFeedbackService implements AudioFeedbackService {

--- a/test/features/recording/presentation/recording_screen_hands_free_test.dart
+++ b/test/features/recording/presentation/recording_screen_hands_free_test.dart
@@ -60,6 +60,7 @@ class _StubStorage implements StorageService {
   @override Future<void> markFailed(String id, String error) async {}
   @override Future<void> markPendingForRetry(String id) async {}
   @override Future<void> reactivateForResend(String transcriptId) async {}
+  @override Future<int> recoverStaleSending() async => 0;
 }
 
 class _NoOpConnectivity extends ConnectivityService {

--- a/test/features/recording/presentation/recording_screen_mic_button_test.dart
+++ b/test/features/recording/presentation/recording_screen_mic_button_test.dart
@@ -48,6 +48,7 @@ class _StubStorage implements StorageService {
   @override Future<void> markFailed(String id, String error) async {}
   @override Future<void> markPendingForRetry(String id) async {}
   @override Future<void> reactivateForResend(String transcriptId) async {}
+  @override Future<int> recoverStaleSending() async => 0;
 }
 
 class _NoOpConnectivity extends ConnectivityService {

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -44,6 +44,7 @@ class _StubStorage implements StorageService {
   @override Future<void> markFailed(String id, String error) async {}
   @override Future<void> markPendingForRetry(String id) async {}
   @override Future<void> reactivateForResend(String transcriptId) async {}
+  @override Future<int> recoverStaleSending() async => 0;
 }
 
 class _NoOpConnectivity extends ConnectivityService {

--- a/test/features/settings/advanced_settings_screen_test.dart
+++ b/test/features/settings/advanced_settings_screen_test.dart
@@ -42,6 +42,7 @@ class _StubStorage implements StorageService {
   @override Future<void> markFailed(String id, String error) async {}
   @override Future<void> markPendingForRetry(String id) async {}
   @override Future<void> reactivateForResend(String transcriptId) async {}
+  @override Future<int> recoverStaleSending() async => 0;
 }
 
 class _NoOpConnectivity extends ConnectivityService {

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -32,6 +32,7 @@ class _StubStorage implements StorageService {
   @override Future<void> markFailed(String id, String error) async {}
   @override Future<void> markPendingForRetry(String id) async {}
   @override Future<void> reactivateForResend(String transcriptId) async {}
+  @override Future<int> recoverStaleSending() async => 0;
 }
 
 class _NoOpConnectivity extends ConnectivityService {


### PR DESCRIPTION
## Summary
- Add `recoverStaleSending()` to `StorageService` interface and `SqliteStorageService`
- Call it in `main.dart` after DB initialization with `kDebugMode`-guarded logging
- Update all 11 test fakes with no-op stub
- Add 3 integration tests for recovery behavior

Closes #139
