### PR TITLE
feat(api_sync): auto-retry with backoff + permanent failure discrimination (P018-T2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,7 +446,7 @@ TranscriptResult {
 
 Passed via GoRouter `extra` to `/record/review`.
 
-### StorageService Contract (004 → 003, 005, 007)
+### StorageService Contract (004 → 003, 005, 007, 018)
 
 ```
 StorageService {
@@ -458,9 +458,11 @@ StorageService {
   getPendingItems() → List<SyncQueueItem>
   markSending(String id)
   markSent(String id)            // DELETES the sync_queue row
-  markFailed(String id, String error)
-  markPendingForRetry(String id)
+  markFailed(String id, String error, {int? overrideAttempts})  // P018-T2
+  markPendingForRetry(String id) // clears error_message (P018-T2)
+  getFailedItems({int? maxAttempts}) → List<SyncQueueItem>      // P018-T2
   getDeviceId() → String
+  recoverStaleSending() → int   // P018-T1: resets sending→pending
 }
 ```
 

--- a/lib/core/storage/sqlite_storage_service.dart
+++ b/lib/core/storage/sqlite_storage_service.dart
@@ -208,13 +208,17 @@ class SqliteStorageService implements StorageService {
   }
 
   @override
-  Future<void> markFailed(String id, String error) async {
+  Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {
+    final values = <String, Object?>{
+      'status': SyncStatus.failed.name,
+      'error_message': error,
+    };
+    if (overrideAttempts != null) {
+      values['attempts'] = overrideAttempts;
+    }
     await _db.update(
       'sync_queue',
-      {
-        'status': SyncStatus.failed.name,
-        'error_message': error,
-      },
+      values,
       where: 'id = ?',
       whereArgs: [id],
     );
@@ -224,10 +228,25 @@ class SqliteStorageService implements StorageService {
   Future<void> markPendingForRetry(String id) async {
     await _db.update(
       'sync_queue',
-      {'status': SyncStatus.pending.name},
+      {'status': SyncStatus.pending.name, 'error_message': null},
       where: 'id = ? AND status = ?',
       whereArgs: [id, SyncStatus.failed.name],
     );
+  }
+
+  @override
+  Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async {
+    final rows = await _db.query(
+      'sync_queue',
+      where: maxAttempts != null
+          ? 'status = ? AND attempts < ?'
+          : 'status = ?',
+      whereArgs: maxAttempts != null
+          ? [SyncStatus.failed.name, maxAttempts]
+          : [SyncStatus.failed.name],
+      orderBy: 'last_attempt_at ASC',
+    );
+    return rows.map(SyncQueueItem.fromMap).toList();
   }
 
   @override

--- a/lib/core/storage/storage_service.dart
+++ b/lib/core/storage/storage_service.dart
@@ -20,8 +20,9 @@ abstract class StorageService {
   Future<List<SyncQueueItem>> getPendingItems();
   Future<void> markSending(String id);
   Future<void> markSent(String id); // deletes the sync_queue row
-  Future<void> markFailed(String id, String error);
+  Future<void> markFailed(String id, String error, {int? overrideAttempts});
   Future<void> markPendingForRetry(String id);
+  Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts});
 
   /// Reactivate a failed sync queue entry for the given transcript.
   /// Resets status to pending, attempts to 0, clears error.

--- a/lib/features/api_sync/sync_worker.dart
+++ b/lib/features/api_sync/sync_worker.dart
@@ -132,7 +132,10 @@ class SyncWorker {
         unawaited(audioFeedbackService.playSuccess());
         _handleReply(body);
       case ApiPermanentFailure(:final message):
-        await storageService.markFailed(item.id, message);
+        // Exhaust retry budget — permanent failures should never be auto-retried
+        await storageService.markFailed(
+          item.id, message, overrideAttempts: _maxRetries,
+        );
         unawaited(audioFeedbackService.playError());
       case ApiTransientFailure(:final reason):
         final attempts = item.attempts + 1; // markSending already incremented
@@ -165,19 +168,14 @@ class SyncWorker {
   }
 
   Future<void> _promoteEligibleRetries() async {
-    // Query failed items and check backoff eligibility
-    // For simplicity, we get all failed items via a raw approach:
-    // getPendingItems only returns pending, so we need to check failed items
-    // through the storage service. Since StorageService doesn't expose
-    // getFailedItems(), we rely on the fact that markPendingForRetry
-    // only transitions failed items. We call it for items we know failed
-    // from previous drain cycles.
-    //
-    // In practice, the worker tracks which items it failed and when,
-    // but for MVP we skip the promotion step and let failed items stay
-    // failed until an external trigger (e.g., user resend from history).
-    //
-    // TODO: Add getFailedItems() to StorageService for proper backoff promotion
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final failed = await storageService.getFailedItems(maxAttempts: _maxRetries);
+    for (final item in failed) {
+      final delay = backoffForAttempt(item.attempts);
+      if ((item.lastAttemptAt ?? 0) + delay.inMilliseconds <= now) {
+        await storageService.markPendingForRetry(item.id);
+      }
+    }
   }
 
   static Duration backoffForAttempt(int attempt) {

--- a/test/app/app_test.dart
+++ b/test/app/app_test.dart
@@ -35,13 +35,15 @@ class _StubStorageService implements StorageService {
   @override
   Future<void> markSent(String id) async {}
   @override
-  Future<void> markFailed(String id, String error) async {}
+  Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {}
   @override
   Future<void> markPendingForRetry(String id) async {}
   @override
   Future<void> reactivateForResend(String transcriptId) async {}
   @override
   Future<int> recoverStaleSending() async => 0;
+  @override
+  Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
 }
 
 class _NoOpConnectivity extends ConnectivityService {

--- a/test/app/router_test.dart
+++ b/test/app/router_test.dart
@@ -28,7 +28,7 @@ class _StubStorageService implements StorageService {
   @override
   Future<void> markSent(String id) async {}
   @override
-  Future<void> markFailed(String id, String error) async {}
+  Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {}
   @override
   Future<void> markPendingForRetry(String id) async {}
   @override
@@ -40,6 +40,8 @@ class _StubStorageService implements StorageService {
   }) async => [];
   @override
   Future<int> recoverStaleSending() async => 0;
+  @override
+  Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
 }
 
 void main() {

--- a/test/core/storage/sqlite_storage_service_test.dart
+++ b/test/core/storage/sqlite_storage_service_test.dart
@@ -352,6 +352,167 @@ void main() {
     });
   });
 
+  group('markFailed with overrideAttempts', () {
+    final transcript = Transcript(
+      id: 'tx-override',
+      text: 'override test',
+      deviceId: 'dev',
+      createdAt: 1000,
+    );
+
+    test('sets attempts to overrideAttempts value', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-override');
+
+      final items = await storage.getPendingItems();
+      final queueId = items.first.id;
+
+      await storage.markSending(queueId);
+      await storage.markFailed(queueId, 'permanent', overrideAttempts: 10);
+
+      final failed = await storage.getFailedItems();
+      expect(failed.length, 1);
+      expect(failed.first.attempts, 10);
+      expect(failed.first.errorMessage, 'permanent');
+    });
+
+    test('without overrideAttempts preserves current attempts', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-override');
+
+      final items = await storage.getPendingItems();
+      final queueId = items.first.id;
+
+      await storage.markSending(queueId); // attempts becomes 1
+      await storage.markFailed(queueId, 'transient error');
+
+      final failed = await storage.getFailedItems();
+      expect(failed.length, 1);
+      expect(failed.first.attempts, 1); // unchanged by markFailed
+    });
+  });
+
+  group('markPendingForRetry clears error_message', () {
+    final transcript = Transcript(
+      id: 'tx-retry',
+      text: 'retry test',
+      deviceId: 'dev',
+      createdAt: 1000,
+    );
+
+    test('error_message is null after markPendingForRetry', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-retry');
+
+      final items = await storage.getPendingItems();
+      final queueId = items.first.id;
+
+      await storage.markSending(queueId);
+      await storage.markFailed(queueId, 'some error');
+
+      // Verify error is set
+      final failed = await storage.getFailedItems();
+      expect(failed.first.errorMessage, 'some error');
+
+      await storage.markPendingForRetry(queueId);
+
+      final pending = await storage.getPendingItems();
+      expect(pending.length, 1);
+      expect(pending.first.errorMessage, isNull);
+    });
+  });
+
+  group('getFailedItems', () {
+    final transcript = Transcript(
+      id: 'tx-fail',
+      text: 'fail test',
+      deviceId: 'dev',
+      createdAt: 1000,
+    );
+
+    test('returns only failed items', () async {
+      await storage.saveTranscript(transcript);
+      final t2 = Transcript(id: 'tx-2', text: 'two', deviceId: 'dev', createdAt: 2000);
+      await storage.saveTranscript(t2);
+
+      await storage.enqueue('tx-fail');
+      await storage.enqueue('tx-2');
+
+      final items = await storage.getPendingItems();
+      // Fail only the first
+      final q1 = items.firstWhere((i) => i.transcriptId == 'tx-fail');
+      await storage.markSending(q1.id);
+      await storage.markFailed(q1.id, 'err');
+
+      final failed = await storage.getFailedItems();
+      expect(failed.length, 1);
+      expect(failed.first.transcriptId, 'tx-fail');
+    });
+
+    test('respects maxAttempts filter', () async {
+      await storage.saveTranscript(transcript);
+      final t2 = Transcript(id: 'tx-2', text: 'two', deviceId: 'dev', createdAt: 2000);
+      await storage.saveTranscript(t2);
+
+      await storage.enqueue('tx-fail');
+      await storage.enqueue('tx-2');
+
+      final items = await storage.getPendingItems();
+      final q1 = items.firstWhere((i) => i.transcriptId == 'tx-fail');
+      final q2 = items.firstWhere((i) => i.transcriptId == 'tx-2');
+
+      // Fail q1 with low attempts (retryable)
+      await storage.markSending(q1.id);
+      await storage.markFailed(q1.id, 'transient');
+
+      // Fail q2 with overrideAttempts=10 (permanent)
+      await storage.markSending(q2.id);
+      await storage.markFailed(q2.id, 'permanent', overrideAttempts: 10);
+
+      // With maxAttempts=10 → only q1 (attempts=1 < 10) is returned
+      final retryable = await storage.getFailedItems(maxAttempts: 10);
+      expect(retryable.length, 1);
+      expect(retryable.first.transcriptId, 'tx-fail');
+
+      // Without maxAttempts → both returned
+      final all = await storage.getFailedItems();
+      expect(all.length, 2);
+    });
+
+    test('orders by last_attempt_at ascending', () async {
+      await storage.saveTranscript(transcript);
+      final t2 = Transcript(id: 'tx-2', text: 'two', deviceId: 'dev', createdAt: 2000);
+      await storage.saveTranscript(t2);
+
+      await storage.enqueue('tx-fail');
+      await storage.enqueue('tx-2');
+
+      final items = await storage.getPendingItems();
+      final q1 = items.firstWhere((i) => i.transcriptId == 'tx-fail');
+      final q2 = items.firstWhere((i) => i.transcriptId == 'tx-2');
+
+      // Fail q2 first, then q1 — q2 should appear first in results
+      await storage.markSending(q2.id);
+      await storage.markFailed(q2.id, 'err');
+      await Future.delayed(const Duration(milliseconds: 10));
+      await storage.markSending(q1.id);
+      await storage.markFailed(q1.id, 'err');
+
+      final failed = await storage.getFailedItems();
+      expect(failed.length, 2);
+      expect(failed[0].transcriptId, 'tx-2'); // earlier last_attempt_at
+      expect(failed[1].transcriptId, 'tx-fail');
+    });
+
+    test('returns empty when no failed items', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-fail');
+
+      final failed = await storage.getFailedItems();
+      expect(failed, isEmpty);
+    });
+  });
+
   group('recoverStaleSending', () {
     final transcript = Transcript(
       id: 'tx-stale',

--- a/test/features/api_sync/sync_worker_test.dart
+++ b/test/features/api_sync/sync_worker_test.dart
@@ -80,8 +80,8 @@ class FakeStorageService implements StorageService {
   }
 
   @override
-  Future<void> markFailed(String id, String error) async {
-    calls.add('markFailed:$id:$error');
+  Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {
+    calls.add('markFailed:$id:$error${overrideAttempts != null ? ':override=$overrideAttempts' : ''}');
     final idx = queueItems.indexWhere((i) => i.id == id);
     if (idx >= 0) {
       final item = queueItems[idx];
@@ -89,7 +89,7 @@ class FakeStorageService implements StorageService {
         id: item.id,
         transcriptId: item.transcriptId,
         status: SyncStatus.failed,
-        attempts: item.attempts,
+        attempts: overrideAttempts ?? item.attempts,
         lastAttemptAt: item.lastAttemptAt,
         errorMessage: error,
         createdAt: item.createdAt,
@@ -109,9 +109,19 @@ class FakeStorageService implements StorageService {
         status: SyncStatus.pending,
         attempts: item.attempts,
         lastAttemptAt: item.lastAttemptAt,
+        errorMessage: null,
         createdAt: item.createdAt,
       );
     }
+  }
+
+  @override
+  Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async {
+    return queueItems.where((i) {
+      if (i.status != SyncStatus.failed) return false;
+      if (maxAttempts != null && i.attempts >= maxAttempts) return false;
+      return true;
+    }).toList();
   }
 
   @override
@@ -499,6 +509,127 @@ void main() {
       worker.stop();
 
       expect(receivedReply, isNull);
+    });
+  });
+
+  group('permanent failure discrimination', () {
+    test('permanent failure sets overrideAttempts to exhaust budget', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextResult = const ApiPermanentFailure(
+        statusCode: 400,
+        message: 'Validation error',
+      );
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 100));
+      worker.stop();
+
+      // Verify markFailed was called with overrideAttempts
+      expect(
+        storage.calls.any((c) => c.contains('override=10')),
+        isTrue,
+      );
+      // Item should have attempts=10
+      expect(storage.queueItems.first.attempts, 10);
+    });
+
+    test('permanent failure is excluded from retry promotion', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextResult = const ApiPermanentFailure(
+        statusCode: 400,
+        message: 'Bad request',
+      );
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+
+      // After drain, item is failed with attempts=10
+      expect(storage.queueItems.first.status, SyncStatus.failed);
+      expect(storage.queueItems.first.attempts, 10);
+
+      // getFailedItems with maxAttempts=10 should exclude it
+      final retryable = await storage.getFailedItems(maxAttempts: 10);
+      expect(retryable, isEmpty);
+
+      worker.stop();
+    });
+
+    test('transient failure without overrideAttempts leaves retry budget intact', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextResult = const ApiTransientFailure(reason: 'timeout');
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 100));
+      worker.stop();
+
+      // Should NOT have overrideAttempts in the call
+      expect(
+        storage.calls.any((c) => c.contains('override=')),
+        isFalse,
+      );
+      // Attempts = 1 (from markSending increment)
+      expect(storage.queueItems.first.attempts, 1);
+    });
+  });
+
+  group('retry promotion (_promoteEligibleRetries)', () {
+    test('promotes failed item whose backoff has elapsed', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+
+      // Manually simulate a failed item with old lastAttemptAt
+      final idx = storage.queueItems.indexWhere((i) => i.transcriptId == 'tx-1');
+      storage.queueItems[idx] = SyncQueueItem(
+        id: storage.queueItems[idx].id,
+        transcriptId: 'tx-1',
+        status: SyncStatus.failed,
+        attempts: 1,
+        lastAttemptAt: DateTime.now().millisecondsSinceEpoch - 60000, // 60s ago
+        errorMessage: 'timeout',
+        createdAt: 1000,
+      );
+
+      // Don't let drain actually re-process it — just check promotion
+      apiClient.nextResult = const ApiSuccess();
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 100));
+      worker.stop();
+
+      // Should have been promoted to pending
+      expect(
+        storage.calls.any((c) => c.startsWith('markPendingForRetry:')),
+        isTrue,
+      );
+    });
+
+    test('does not promote item whose backoff has not elapsed', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+
+      // Simulate failed item with very recent lastAttemptAt
+      final idx = storage.queueItems.indexWhere((i) => i.transcriptId == 'tx-1');
+      storage.queueItems[idx] = SyncQueueItem(
+        id: storage.queueItems[idx].id,
+        transcriptId: 'tx-1',
+        status: SyncStatus.failed,
+        attempts: 1,
+        lastAttemptAt: DateTime.now().millisecondsSinceEpoch, // just now
+        errorMessage: 'timeout',
+        createdAt: 1000,
+      );
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 100));
+      worker.stop();
+
+      // Should NOT have been promoted
+      expect(
+        storage.calls.any((c) => c.startsWith('markPendingForRetry:')),
+        isFalse,
+      );
     });
   });
 

--- a/test/features/history/history_notifier_test.dart
+++ b/test/features/history/history_notifier_test.dart
@@ -48,13 +48,15 @@ class FakeStorageService implements StorageService {
   @override
   Future<void> markSent(String id) async {}
   @override
-  Future<void> markFailed(String id, String error) async {}
+  Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {}
   @override
   Future<void> markPendingForRetry(String id) async {}
   @override
   Future<String> getDeviceId() async => 'test-device';
   @override
   Future<int> recoverStaleSending() async => 0;
+  @override
+  Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
 }
 
 void main() {

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -176,13 +176,15 @@ class FakeStorageService implements StorageService {
   @override
   Future<void> markSent(String id) async {}
   @override
-  Future<void> markFailed(String id, String error) async {}
+  Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {}
   @override
   Future<void> markPendingForRetry(String id) async {}
   @override
   Future<void> reactivateForResend(String transcriptId) async {}
   @override
   Future<int> recoverStaleSending() async => 0;
+  @override
+  Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
 }
 
 // ── _FixedConfigService ───────────────────────────────────────────────────────

--- a/test/features/recording/presentation/recording_controller_test.dart
+++ b/test/features/recording/presentation/recording_controller_test.dart
@@ -139,7 +139,7 @@ class FakeStorageService implements StorageService {
   Future<void> markSent(String id) async {}
 
   @override
-  Future<void> markFailed(String id, String error) async {}
+  Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {}
 
   @override
   Future<void> markPendingForRetry(String id) async {}
@@ -154,6 +154,9 @@ class FakeStorageService implements StorageService {
 
   @override
   Future<int> recoverStaleSending() async => 0;
+
+  @override
+  Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
 }
 
 class _StubAudioFeedbackService implements AudioFeedbackService {

--- a/test/features/recording/presentation/recording_screen_hands_free_test.dart
+++ b/test/features/recording/presentation/recording_screen_hands_free_test.dart
@@ -57,10 +57,11 @@ class _StubStorage implements StorageService {
   @override Future<List<SyncQueueItem>> getPendingItems() async => [];
   @override Future<void> markSending(String id) async {}
   @override Future<void> markSent(String id) async {}
-  @override Future<void> markFailed(String id, String error) async {}
+  @override Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {}
   @override Future<void> markPendingForRetry(String id) async {}
   @override Future<void> reactivateForResend(String transcriptId) async {}
   @override Future<int> recoverStaleSending() async => 0;
+  @override Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
 }
 
 class _NoOpConnectivity extends ConnectivityService {

--- a/test/features/recording/presentation/recording_screen_mic_button_test.dart
+++ b/test/features/recording/presentation/recording_screen_mic_button_test.dart
@@ -45,10 +45,11 @@ class _StubStorage implements StorageService {
   @override Future<List<SyncQueueItem>> getPendingItems() async => [];
   @override Future<void> markSending(String id) async {}
   @override Future<void> markSent(String id) async {}
-  @override Future<void> markFailed(String id, String error) async {}
+  @override Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {}
   @override Future<void> markPendingForRetry(String id) async {}
   @override Future<void> reactivateForResend(String transcriptId) async {}
   @override Future<int> recoverStaleSending() async => 0;
+  @override Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
 }
 
 class _NoOpConnectivity extends ConnectivityService {

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -41,10 +41,11 @@ class _StubStorage implements StorageService {
   @override Future<List<SyncQueueItem>> getPendingItems() async => [];
   @override Future<void> markSending(String id) async {}
   @override Future<void> markSent(String id) async {}
-  @override Future<void> markFailed(String id, String error) async {}
+  @override Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {}
   @override Future<void> markPendingForRetry(String id) async {}
   @override Future<void> reactivateForResend(String transcriptId) async {}
   @override Future<int> recoverStaleSending() async => 0;
+  @override Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
 }
 
 class _NoOpConnectivity extends ConnectivityService {

--- a/test/features/settings/advanced_settings_screen_test.dart
+++ b/test/features/settings/advanced_settings_screen_test.dart
@@ -39,10 +39,11 @@ class _StubStorage implements StorageService {
   @override Future<List<SyncQueueItem>> getPendingItems() async => [];
   @override Future<void> markSending(String id) async {}
   @override Future<void> markSent(String id) async {}
-  @override Future<void> markFailed(String id, String error) async {}
+  @override Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {}
   @override Future<void> markPendingForRetry(String id) async {}
   @override Future<void> reactivateForResend(String transcriptId) async {}
   @override Future<int> recoverStaleSending() async => 0;
+  @override Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
 }
 
 class _NoOpConnectivity extends ConnectivityService {

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -29,10 +29,11 @@ class _StubStorage implements StorageService {
   ;
   @override Future<void> markSending(String id) async {}
   @override Future<void> markSent(String id) async {}
-  @override Future<void> markFailed(String id, String error) async {}
+  @override Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {}
   @override Future<void> markPendingForRetry(String id) async {}
   @override Future<void> reactivateForResend(String transcriptId) async {}
   @override Future<int> recoverStaleSending() async => 0;
+  @override Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
 }
 
 class _NoOpConnectivity extends ConnectivityService {


### PR DESCRIPTION
## Summary
- Implement P018-T2: auto-retry with exponential backoff and permanent failure discrimination
- SyncWorker distinguishes permanent (4xx except 408/429) from transient failures using ApiResult types
- Permanent failures exhaust retry budget via overrideAttempts pattern (ADR-DATA-006)
- Added getFailedItems({int? maxAttempts}) query to StorageService
- markFailed now accepts optional overrideAttempts; markPendingForRetry clears error_message
- Updated CLAUDE.md StorageService Contract section

## Test plan
- [x] 12 new tests: storage (getFailedItems, markFailed w/ overrideAttempts, markPendingForRetry clears error), sync_worker (permanent failure discrimination, retry promotion)
- [x] All 316 tests pass (flutter test)
- [x] Static analysis clean (flutter analyze)
- [x] All 10 test fakes updated with new StorageService interface

Closes #146

Generated with [Claude Code](https://claude.com/claude-code)
