### PR TITLE
feat(core/config): add background activation config fields

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -15,6 +15,11 @@ class AppConfig {
     this.vadConfig = const VadConfig.defaults(),
     this.ttsEnabled = true,
     this.audioFeedbackEnabled = true,
+    this.backgroundListeningEnabled = false,
+    this.wakeWordEnabled = false,
+    this.picovoiceAccessKey,
+    this.wakeWordKeyword = 'jarvis',
+    this.wakeWordSensitivity = 0.5,
   });
 
   final String? apiUrl;
@@ -26,6 +31,11 @@ class AppConfig {
   final VadConfig vadConfig;
   final bool ttsEnabled;
   final bool audioFeedbackEnabled;
+  final bool backgroundListeningEnabled;
+  final bool wakeWordEnabled;
+  final String? picovoiceAccessKey;
+  final String wakeWordKeyword;
+  final double wakeWordSensitivity;
 
   AppConfig copyWith({
     Object? apiUrl = _sentinel,
@@ -37,6 +47,11 @@ class AppConfig {
     VadConfig? vadConfig,
     bool? ttsEnabled,
     bool? audioFeedbackEnabled,
+    bool? backgroundListeningEnabled,
+    bool? wakeWordEnabled,
+    Object? picovoiceAccessKey = _sentinel,
+    String? wakeWordKeyword,
+    double? wakeWordSensitivity,
   }) {
     return AppConfig(
       apiUrl: apiUrl == _sentinel ? this.apiUrl : apiUrl as String?,
@@ -49,6 +64,14 @@ class AppConfig {
       vadConfig: vadConfig ?? this.vadConfig,
       ttsEnabled: ttsEnabled ?? this.ttsEnabled,
       audioFeedbackEnabled: audioFeedbackEnabled ?? this.audioFeedbackEnabled,
+      backgroundListeningEnabled:
+          backgroundListeningEnabled ?? this.backgroundListeningEnabled,
+      wakeWordEnabled: wakeWordEnabled ?? this.wakeWordEnabled,
+      picovoiceAccessKey: picovoiceAccessKey == _sentinel
+          ? this.picovoiceAccessKey
+          : picovoiceAccessKey as String?,
+      wakeWordKeyword: wakeWordKeyword ?? this.wakeWordKeyword,
+      wakeWordSensitivity: wakeWordSensitivity ?? this.wakeWordSensitivity,
     );
   }
 }

--- a/lib/core/config/app_config_provider.dart
+++ b/lib/core/config/app_config_provider.dart
@@ -78,4 +78,29 @@ class AppConfigNotifier extends StateNotifier<AppConfig> {
     await _service.saveAudioFeedbackEnabled(value);
     state = state.copyWith(audioFeedbackEnabled: value);
   }
+
+  Future<void> updateBackgroundListeningEnabled(bool value) async {
+    await _service.saveBackgroundListeningEnabled(value);
+    state = state.copyWith(backgroundListeningEnabled: value);
+  }
+
+  Future<void> updateWakeWordEnabled(bool value) async {
+    await _service.saveWakeWordEnabled(value);
+    state = state.copyWith(wakeWordEnabled: value);
+  }
+
+  Future<void> updatePicovoiceAccessKey(String key) async {
+    await _service.savePicovoiceAccessKey(key);
+    state = state.copyWith(picovoiceAccessKey: key);
+  }
+
+  Future<void> updateWakeWordKeyword(String keyword) async {
+    await _service.saveWakeWordKeyword(keyword);
+    state = state.copyWith(wakeWordKeyword: keyword);
+  }
+
+  Future<void> updateWakeWordSensitivity(double value) async {
+    await _service.saveWakeWordSensitivity(value);
+    state = state.copyWith(wakeWordSensitivity: value);
+  }
 }

--- a/lib/core/config/app_config_service.dart
+++ b/lib/core/config/app_config_service.dart
@@ -26,6 +26,12 @@ class AppConfigService {
   static const _ttsEnabledKey = 'tts_enabled';
   static const _audioFeedbackEnabledKey = 'audio_feedback_enabled';
 
+  static const _backgroundListeningEnabledKey = 'background_listening_enabled';
+  static const _wakeWordEnabledKey = 'wake_word_enabled';
+  static const _picovoiceAccessKeyKey = 'picovoice_access_key';
+  static const _wakeWordKeywordKey = 'wake_word_keyword';
+  static const _wakeWordSensitivityKey = 'wake_word_sensitivity';
+
   static const _vadPositiveThresholdKey = 'vad_positive_threshold';
   static const _vadNegativeThresholdKey = 'vad_negative_threshold';
   static const _vadHangoverMsKey = 'vad_hangover_ms';
@@ -48,6 +54,13 @@ class AppConfigService {
     String? groqApiKey;
     try {
       groqApiKey = await _secureStorage.read(key: _groqApiKeyKey);
+    } catch (_) {
+      // Secure storage may fail on some devices — treat as absent
+    }
+    String? picovoiceAccessKey;
+    try {
+      picovoiceAccessKey =
+          await _secureStorage.read(key: _picovoiceAccessKeyKey);
     } catch (_) {
       // Secure storage may fail on some devices — treat as absent
     }
@@ -75,6 +88,13 @@ class AppConfigService {
       vadConfig: vadConfig,
       ttsEnabled: prefs.getBool(_ttsEnabledKey) ?? true,
       audioFeedbackEnabled: prefs.getBool(_audioFeedbackEnabledKey) ?? true,
+      backgroundListeningEnabled:
+          prefs.getBool(_backgroundListeningEnabledKey) ?? false,
+      wakeWordEnabled: prefs.getBool(_wakeWordEnabledKey) ?? false,
+      picovoiceAccessKey: picovoiceAccessKey,
+      wakeWordKeyword: prefs.getString(_wakeWordKeywordKey) ?? 'jarvis',
+      wakeWordSensitivity:
+          prefs.getDouble(_wakeWordSensitivityKey) ?? 0.5,
     );
   }
 
@@ -125,5 +145,29 @@ class AppConfigService {
   Future<void> saveAudioFeedbackEnabled(bool value) async {
     final prefs = await _preferences;
     await prefs.setBool(_audioFeedbackEnabledKey, value);
+  }
+
+  Future<void> saveBackgroundListeningEnabled(bool value) async {
+    final prefs = await _preferences;
+    await prefs.setBool(_backgroundListeningEnabledKey, value);
+  }
+
+  Future<void> saveWakeWordEnabled(bool value) async {
+    final prefs = await _preferences;
+    await prefs.setBool(_wakeWordEnabledKey, value);
+  }
+
+  Future<void> savePicovoiceAccessKey(String key) async {
+    await _secureStorage.write(key: _picovoiceAccessKeyKey, value: key);
+  }
+
+  Future<void> saveWakeWordKeyword(String keyword) async {
+    final prefs = await _preferences;
+    await prefs.setString(_wakeWordKeywordKey, keyword);
+  }
+
+  Future<void> saveWakeWordSensitivity(double value) async {
+    final prefs = await _preferences;
+    await prefs.setDouble(_wakeWordSensitivityKey, value);
   }
 }

--- a/test/core/config/app_config_service_test.dart
+++ b/test/core/config/app_config_service_test.dart
@@ -1,10 +1,50 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:voice_agent/core/config/app_config.dart';
 import 'package:voice_agent/core/config/app_config_service.dart';
 import 'package:voice_agent/core/config/vad_config.dart';
 
 void main() {
+  group('AppConfig.copyWith', () {
+    test('picovoiceAccessKey sentinel allows setting to null', () {
+      const config = AppConfig(picovoiceAccessKey: 'key');
+      final updated = config.copyWith(picovoiceAccessKey: null);
+      expect(updated.picovoiceAccessKey, isNull);
+    });
+
+    test('picovoiceAccessKey omitted preserves value', () {
+      const config = AppConfig(picovoiceAccessKey: 'key');
+      final updated = config.copyWith(backgroundListeningEnabled: true);
+      expect(updated.picovoiceAccessKey, 'key');
+    });
+
+    test('new fields have correct defaults', () {
+      const config = AppConfig();
+      expect(config.backgroundListeningEnabled, isFalse);
+      expect(config.wakeWordEnabled, isFalse);
+      expect(config.picovoiceAccessKey, isNull);
+      expect(config.wakeWordKeyword, 'jarvis');
+      expect(config.wakeWordSensitivity, 0.5);
+    });
+
+    test('copyWith updates new fields', () {
+      const config = AppConfig();
+      final updated = config.copyWith(
+        backgroundListeningEnabled: true,
+        wakeWordEnabled: true,
+        picovoiceAccessKey: 'pv_key',
+        wakeWordKeyword: 'computer',
+        wakeWordSensitivity: 0.8,
+      );
+      expect(updated.backgroundListeningEnabled, isTrue);
+      expect(updated.wakeWordEnabled, isTrue);
+      expect(updated.picovoiceAccessKey, 'pv_key');
+      expect(updated.wakeWordKeyword, 'computer');
+      expect(updated.wakeWordSensitivity, 0.8);
+    });
+  });
+
   group('AppConfigService', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
@@ -120,6 +160,113 @@ void main() {
       final config = await service.load();
 
       expect(config.audioFeedbackEnabled, isFalse);
+    });
+
+    group('background activation config', () {
+      test('load returns defaults for new fields when storage is empty',
+          () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        final config = await service.load();
+
+        expect(config.backgroundListeningEnabled, isFalse);
+        expect(config.wakeWordEnabled, isFalse);
+        expect(config.picovoiceAccessKey, isNull);
+        expect(config.wakeWordKeyword, 'jarvis');
+        expect(config.wakeWordSensitivity, 0.5);
+      });
+
+      test('saveBackgroundListeningEnabled then load round-trips', () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        await service.saveBackgroundListeningEnabled(true);
+        final config = await service.load();
+
+        expect(config.backgroundListeningEnabled, isTrue);
+      });
+
+      test('saveWakeWordEnabled then load round-trips', () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        await service.saveWakeWordEnabled(true);
+        final config = await service.load();
+
+        expect(config.wakeWordEnabled, isTrue);
+      });
+
+      test('savePicovoiceAccessKey then load round-trips', () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        await service.savePicovoiceAccessKey('pv_test_key_12345');
+        final config = await service.load();
+
+        expect(config.picovoiceAccessKey, 'pv_test_key_12345');
+      });
+
+      test('saveWakeWordKeyword then load round-trips', () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        await service.saveWakeWordKeyword('computer');
+        final config = await service.load();
+
+        expect(config.wakeWordKeyword, 'computer');
+      });
+
+      test('saveWakeWordSensitivity then load round-trips', () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        await service.saveWakeWordSensitivity(0.8);
+        final config = await service.load();
+
+        expect(config.wakeWordSensitivity, 0.8);
+      });
+
+      test('picovoiceAccessKey survives SecureStorage failure gracefully',
+          () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        // Use a fresh service — FlutterSecureStorage mock has no key stored,
+        // so read returns null (simulating empty/failed storage)
+        final service = AppConfigService(prefs: prefs);
+
+        final config = await service.load();
+
+        expect(config.picovoiceAccessKey, isNull);
+      });
+
+      test('all background activation fields preserved alongside other config',
+          () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        await service.saveApiUrl('https://test.com');
+        await service.saveBackgroundListeningEnabled(true);
+        await service.saveWakeWordEnabled(true);
+        await service.savePicovoiceAccessKey('pv_key');
+        await service.saveWakeWordKeyword('alexa');
+        await service.saveWakeWordSensitivity(0.7);
+        final config = await service.load();
+
+        expect(config.apiUrl, 'https://test.com');
+        expect(config.backgroundListeningEnabled, isTrue);
+        expect(config.wakeWordEnabled, isTrue);
+        expect(config.picovoiceAccessKey, 'pv_key');
+        expect(config.wakeWordKeyword, 'alexa');
+        expect(config.wakeWordSensitivity, 0.7);
+      });
     });
 
     group('VAD config', () {


### PR DESCRIPTION
## Summary

- Add 5 new fields to `AppConfig`: `backgroundListeningEnabled`, `wakeWordEnabled`, `picovoiceAccessKey`, `wakeWordKeyword`, `wakeWordSensitivity`
- Add persistence methods to `AppConfigService` (SharedPreferences for booleans/strings/doubles, SecureStorage for access key)
- Add update methods to `AppConfigNotifier`
- Add 12 new tests (4 copyWith + 8 service round-trip/integration)

All fields have defaults; existing 316 tests pass without modification.

Closes #147

## Test plan

- [x] `flutter analyze` passes (1 pre-existing info warning)
- [x] `flutter test` passes (328 tests, 0 failures)
- [x] New fields round-trip through SharedPreferences and SecureStorage
- [x] Sentinel pattern for `picovoiceAccessKey` allows explicit null
- [x] Existing tests unaffected (all fields have defaults)
