### PR TITLE
feat(core/background): add background service infrastructure

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application
         android:label="voice_agent"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -66,7 +66,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Voice Agent needs microphone access to record audio for transcription.</string>
+	<string>Voice Agent needs microphone access to record audio for transcription and to listen for your wake word in the background.</string>
 </dict>
 </plist>

--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -1,0 +1,12 @@
+/// Abstract interface for background service management.
+///
+/// Manages the platform-specific keepalive mechanism that prevents the OS from
+/// killing the app process when backgrounded. On Android this is a foreground
+/// service; on iOS it is the audio background mode entitlement combined with
+/// an active audio session.
+abstract class BackgroundService {
+  Future<void> startService();
+  Future<void> stopService();
+  Future<void> updateNotification({required String title, required String body});
+  bool get isRunning;
+}

--- a/lib/core/background/background_service_provider.dart
+++ b/lib/core/background/background_service_provider.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/background/background_service.dart';
+import 'package:voice_agent/core/background/flutter_foreground_task_service.dart';
+
+final backgroundServiceProvider = Provider<BackgroundService>((ref) {
+  final service = FlutterForegroundTaskService();
+  ref.onDispose(() async {
+    if (service.isRunning) {
+      await service.stopService();
+    }
+  });
+  return service;
+});

--- a/lib/core/background/flutter_foreground_task_service.dart
+++ b/lib/core/background/flutter_foreground_task_service.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:voice_agent/core/background/background_service.dart';
+
+/// [BackgroundService] implementation using `flutter_foreground_task` (Android)
+/// and AVAudioSession category switching (iOS) via platform channel.
+///
+/// The foreground service is purely a keepalive — no [TaskHandler] or send-port
+/// communication is used (see ADR-PLATFORM-005).
+class FlutterForegroundTaskService implements BackgroundService {
+  FlutterForegroundTaskService({MethodChannel? audioSessionChannel})
+      : _audioSessionChannel = audioSessionChannel ??
+            const MethodChannel('com.voiceagent/audio_session');
+
+  final MethodChannel _audioSessionChannel;
+  bool _running = false;
+
+  @override
+  bool get isRunning => _running;
+
+  /// Call once before [startService], typically in `main()` before `runApp()`.
+  static void initForegroundTask() {
+    FlutterForegroundTask.init(
+      androidNotificationOptions: AndroidNotificationOptions(
+        channelId: 'voice_agent_background',
+        channelName: 'Voice Agent Background',
+        channelDescription: 'Background listening for wake word detection',
+        channelImportance: NotificationChannelImportance.LOW,
+        priority: NotificationPriority.LOW,
+      ),
+      iosNotificationOptions: const IOSNotificationOptions(),
+      foregroundTaskOptions: ForegroundTaskOptions(
+        eventAction: ForegroundTaskEventAction.nothing(),
+        autoRunOnBoot: false,
+        autoRunOnMyPackageReplaced: false,
+        allowWakeLock: true,
+        allowWifiLock: false,
+      ),
+    );
+  }
+
+  @override
+  Future<void> startService() async {
+    if (_running) return;
+
+    if (Platform.isAndroid) {
+      await FlutterForegroundTask.startService(
+        serviceId: 1,
+        notificationTitle: 'Voice Agent',
+        notificationText: 'Listening for wake word...',
+        serviceTypes: [ForegroundServiceTypes.microphone],
+      );
+    }
+
+    if (Platform.isIOS) {
+      try {
+        await _audioSessionChannel.invokeMethod('setPlayAndRecord');
+      } on PlatformException {
+        // Audio session switch failed — continue anyway, background may
+        // not persist but foreground still works
+      }
+    }
+
+    _running = true;
+  }
+
+  @override
+  Future<void> stopService() async {
+    if (!_running) return;
+
+    if (Platform.isAndroid) {
+      await FlutterForegroundTask.stopService();
+    }
+
+    if (Platform.isIOS) {
+      try {
+        await _audioSessionChannel.invokeMethod('setAmbient');
+      } on PlatformException {
+        // Audio session revert failed — non-critical
+      }
+    }
+
+    _running = false;
+  }
+
+  @override
+  Future<void> updateNotification({
+    required String title,
+    required String body,
+  }) async {
+    if (!_running) return;
+    if (Platform.isAndroid) {
+      await FlutterForegroundTask.updateService(
+        notificationTitle: title,
+        notificationText: body,
+      );
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,11 +2,14 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/app/app.dart';
+import 'package:voice_agent/core/background/flutter_foreground_task_service.dart';
 import 'package:voice_agent/core/storage/sqlite_storage_service.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  FlutterForegroundTaskService.initForegroundTask();
 
   final storage = await SqliteStorageService.initialize();
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -198,6 +198,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_foreground_task:
+    dependency: "direct main"
+    description:
+      name: flutter_foreground_task
+      sha256: fc5c01a5e1b8f7bb51d0c737714f0c50440dbdf1aeddc5f8cbba313aa6fd4856
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.2"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   vad: ^0.0.7
   flutter_tts: ^4.2.5
   audioplayers: ^6.0.0
+  flutter_foreground_task: ^9.2.2
 
 dev_dependencies:
   flutter_test:

--- a/test/core/background/flutter_foreground_task_service_test.dart
+++ b/test/core/background/flutter_foreground_task_service_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/background/flutter_foreground_task_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FlutterForegroundTaskService', () {
+    late FlutterForegroundTaskService service;
+    late MethodChannel audioSessionChannel;
+    final List<MethodCall> audioSessionCalls = [];
+
+    setUp(() {
+      audioSessionCalls.clear();
+      audioSessionChannel = const MethodChannel('com.voiceagent/audio_session');
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(audioSessionChannel, (call) async {
+        audioSessionCalls.add(call);
+        return null;
+      });
+
+      service = FlutterForegroundTaskService(
+        audioSessionChannel: audioSessionChannel,
+      );
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(audioSessionChannel, null);
+    });
+
+    test('isRunning is false initially', () {
+      expect(service.isRunning, isFalse);
+    });
+
+    test('startService sets isRunning to true', () async {
+      await service.startService();
+      expect(service.isRunning, isTrue);
+    });
+
+    test('stopService sets isRunning to false', () async {
+      await service.startService();
+      await service.stopService();
+      expect(service.isRunning, isFalse);
+    });
+
+    test('startService is idempotent when already running', () async {
+      await service.startService();
+      await service.startService();
+      expect(service.isRunning, isTrue);
+      // Only one set of platform calls should have been made
+    });
+
+    test('stopService is idempotent when not running', () async {
+      await service.stopService();
+      expect(service.isRunning, isFalse);
+      expect(audioSessionCalls, isEmpty);
+    });
+
+    test('updateNotification is no-op when not running', () async {
+      // Should not throw
+      await service.updateNotification(
+        title: 'Test',
+        body: 'Test body',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `BackgroundService` abstract interface in `core/background/`
- Add `FlutterForegroundTaskService` implementation (Android foreground service + iOS audio session switching)
- Add `backgroundServiceProvider` with dispose cleanup
- Add `flutter_foreground_task: ^9.2.2` dependency
- Add Android permissions (FOREGROUND_SERVICE, FOREGROUND_SERVICE_MICROPHONE, POST_NOTIFICATIONS, INTERNET)
- Add iOS `UIBackgroundModes: audio` entitlement
- Initialize foreground task config in `main.dart` before `runApp()`

Closes #148

## Test plan

- [x] `flutter analyze` passes (1 pre-existing info warning)
- [x] `flutter test` passes (334 tests, 0 failures)
- [x] Service lifecycle: start/stop/idempotent guards
- [x] Notification update no-op when not running
