### PR TITLE
feat(activation): add ActivationController and core activation providers

### DIFF
--- a/lib/core/providers/activation_event.dart
+++ b/lib/core/providers/activation_event.dart
@@ -1,0 +1,8 @@
+/// What triggered a hands-free recording session.
+enum ActivationEvent {
+  /// A wake word was detected by Porcupine.
+  wakeWordDetected,
+
+  /// The user tapped the Quick Settings tile or Control Center control.
+  shortcutActivated,
+}

--- a/lib/core/providers/activation_providers.dart
+++ b/lib/core/providers/activation_providers.dart
@@ -1,0 +1,25 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/providers/activation_event.dart';
+import 'package:voice_agent/core/providers/hands_free_session_status.dart';
+
+/// Set by `ActivationController` when a wake word is detected or a shortcut
+/// is activated. Watched by `HandsFreeController` to trigger a session.
+/// Reset to `null` after the session starts.
+final activationEventProvider = StateProvider<ActivationEvent?>((ref) => null);
+
+/// Set by `HandsFreeController` to signal session lifecycle.
+/// Observed by `ActivationController` to restart wake word detection after
+/// a session completes or transition to error on failure.
+final handsFreeSessionStatusProvider =
+    StateProvider<HandsFreeSessionStatus>((ref) {
+  return const HandsFreeSessionInactive();
+});
+
+/// Set by `RecordingController` before manual recording with a fresh
+/// `Completer<void>`. `ActivationController` stops Porcupine then completes
+/// the completer, letting the recording controller proceed.
+/// Reset to `null` by `RecordingController` when recording ends.
+final wakeWordPauseRequestProvider =
+    StateProvider<Completer<void>?>((ref) => null);

--- a/lib/core/providers/hands_free_session_status.dart
+++ b/lib/core/providers/hands_free_session_status.dart
@@ -1,0 +1,24 @@
+/// Cross-feature signal for hands-free session lifecycle.
+///
+/// **Producer:** `HandsFreeController` in `features/recording/`.
+/// **Consumer:** `ActivationController` in `features/activation/`.
+sealed class HandsFreeSessionStatus {
+  const HandsFreeSessionStatus();
+}
+
+class HandsFreeSessionInactive extends HandsFreeSessionStatus {
+  const HandsFreeSessionInactive();
+}
+
+class HandsFreeSessionRunning extends HandsFreeSessionStatus {
+  const HandsFreeSessionRunning();
+}
+
+class HandsFreeSessionCompletedOk extends HandsFreeSessionStatus {
+  const HandsFreeSessionCompletedOk();
+}
+
+class HandsFreeSessionFailed extends HandsFreeSessionStatus {
+  const HandsFreeSessionFailed({required this.message});
+  final String message;
+}

--- a/lib/features/activation/domain/activation_state.dart
+++ b/lib/features/activation/domain/activation_state.dart
@@ -1,0 +1,33 @@
+import 'package:voice_agent/core/providers/activation_event.dart';
+
+/// State machine for background activation.
+sealed class ActivationState {
+  const ActivationState();
+}
+
+/// Background listening is not active.
+class ActivationIdle extends ActivationState {
+  const ActivationIdle();
+}
+
+/// Porcupine is listening for a wake word.
+class ActivationListening extends ActivationState {
+  const ActivationListening({required this.keyword});
+  final String keyword;
+}
+
+/// A hands-free session is in progress.
+class ActivationHandsFreeActive extends ActivationState {
+  const ActivationHandsFreeActive({required this.trigger});
+  final ActivationEvent trigger;
+}
+
+/// An error occurred (e.g. invalid access key, audio failure).
+class ActivationError extends ActivationState {
+  const ActivationError({
+    required this.message,
+    this.requiresSettings = false,
+  });
+  final String message;
+  final bool requiresSettings;
+}

--- a/lib/features/activation/presentation/activation_controller.dart
+++ b/lib/features/activation/presentation/activation_controller.dart
@@ -1,0 +1,191 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/audio/audio_feedback_service.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/providers/activation_event.dart';
+import 'package:voice_agent/core/providers/activation_providers.dart';
+import 'package:voice_agent/core/providers/hands_free_session_status.dart';
+import 'package:voice_agent/features/activation/domain/activation_state.dart';
+import 'package:voice_agent/features/activation/domain/wake_word_service.dart';
+
+class ActivationController extends StateNotifier<ActivationState> {
+  ActivationController({
+    required this.wakeWordService,
+    required this.audioFeedback,
+    required Ref ref,
+  })  : _ref = ref,
+        super(const ActivationIdle()) {
+    _detectionSub = wakeWordService.detections.listen(_onDetection);
+    _errorSub = wakeWordService.errors.listen(_onWakeWordError);
+  }
+
+  final WakeWordService wakeWordService;
+  final AudioFeedbackService audioFeedback;
+  final Ref _ref;
+
+  StreamSubscription<int>? _detectionSub;
+  StreamSubscription<WakeWordError>? _errorSub;
+  Timer? _retryTimer;
+
+  /// Start or restart wake word listening based on current config.
+  Future<void> startListening() async {
+    final config = _ref.read(appConfigProvider);
+    if (!config.backgroundListeningEnabled) return;
+
+    final accessKey = config.picovoiceAccessKey;
+    if (accessKey == null || accessKey.isEmpty) {
+      state = const ActivationError(
+        message: 'Picovoice access key not configured',
+        requiresSettings: true,
+      );
+      return;
+    }
+
+    if (!config.wakeWordEnabled) {
+      // Background listening without wake word: just stay idle
+      // (foreground service may still be running for other purposes)
+      state = const ActivationIdle();
+      return;
+    }
+
+    final keyword = config.wakeWordKeyword;
+    final builtIn = BuiltInKeyword.values.where((k) => k.name == keyword);
+    if (builtIn.isEmpty) {
+      state = ActivationError(
+        message: 'Unknown keyword: $keyword',
+        requiresSettings: true,
+      );
+      return;
+    }
+
+    await wakeWordService.startBuiltIn(
+      accessKey: accessKey,
+      keywords: [builtIn.first],
+      sensitivities: [config.wakeWordSensitivity],
+    );
+
+    if (wakeWordService.isListening) {
+      state = ActivationListening(keyword: keyword);
+    }
+    // If not listening, an error was emitted via the errors stream
+    // and _onWakeWordError will handle the state transition.
+  }
+
+  /// Stop wake word listening and return to idle.
+  Future<void> stopListening() async {
+    _retryTimer?.cancel();
+    _retryTimer = null;
+    await wakeWordService.stop();
+    state = const ActivationIdle();
+  }
+
+  /// Toggle background activation on/off.
+  Future<void> toggle() async {
+    if (state is ActivationIdle || state is ActivationError) {
+      await startListening();
+    } else {
+      await stopListening();
+    }
+  }
+
+  /// Called when the hands-free session status changes.
+  void onSessionStatusChanged(HandsFreeSessionStatus status) {
+    switch (status) {
+      case HandsFreeSessionCompletedOk():
+        // Session completed — restart wake word detection.
+        _ref.read(handsFreeSessionStatusProvider.notifier).state =
+            const HandsFreeSessionInactive();
+        startListening();
+      case HandsFreeSessionFailed(message: final msg):
+        _ref.read(handsFreeSessionStatusProvider.notifier).state =
+            const HandsFreeSessionInactive();
+        state = ActivationError(message: msg);
+        _scheduleRetry();
+      case HandsFreeSessionRunning():
+      case HandsFreeSessionInactive():
+        break;
+    }
+  }
+
+  /// Called when a wake word pause is requested (manual recording).
+  Future<void> onPauseRequest(Completer<void>? completer) async {
+    if (completer == null) {
+      // Pause cleared — resume listening if we were active.
+      if (state is ActivationIdle) {
+        await startListening();
+      }
+      return;
+    }
+
+    // Pause requested — stop Porcupine and complete the completer.
+    if (state is ActivationListening) {
+      await wakeWordService.stop();
+      state = const ActivationIdle();
+    }
+    if (!completer.isCompleted) {
+      completer.complete();
+    }
+  }
+
+  void _onDetection(int keywordIndex) {
+    if (state is! ActivationListening) return;
+
+    // Stop Porcupine before handing off to hands-free recording.
+    wakeWordService.stop();
+
+    final keyword = (state as ActivationListening).keyword;
+    state = const ActivationHandsFreeActive(
+      trigger: ActivationEvent.wakeWordDetected,
+    );
+
+    // Signal to HandsFreeController via the activation event provider.
+    _ref.read(activationEventProvider.notifier).state =
+        ActivationEvent.wakeWordDetected;
+
+    audioFeedback.playWakeWordAcknowledgment();
+
+    // Log the detected keyword for debugging.
+    assert(() {
+      // ignore: avoid_print
+      print('Wake word detected: $keyword (index: $keywordIndex)');
+      return true;
+    }());
+  }
+
+  void _onWakeWordError(WakeWordError error) {
+    final (message, requiresSettings) = switch (error) {
+      InvalidAccessKey() => ('Invalid Picovoice access key', true),
+      CorruptModel(path: final p) => ('Corrupt keyword model: $p', true),
+      AudioCaptureFailed(reason: final r) => ('Audio capture failed: $r', false),
+      UnknownWakeWordError(message: final m) => ('Wake word error: $m', false),
+    };
+
+    state = ActivationError(
+      message: message,
+      requiresSettings: requiresSettings,
+    );
+
+    if (!requiresSettings) {
+      _scheduleRetry();
+    }
+  }
+
+  void _scheduleRetry() {
+    _retryTimer?.cancel();
+    _retryTimer = Timer(const Duration(seconds: 5), () {
+      if (state is ActivationError &&
+          !(state as ActivationError).requiresSettings) {
+        startListening();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _retryTimer?.cancel();
+    _detectionSub?.cancel();
+    _errorSub?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/features/activation/presentation/activation_provider.dart
+++ b/lib/features/activation/presentation/activation_provider.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
+import 'package:voice_agent/core/providers/activation_providers.dart';
+import 'package:voice_agent/features/activation/domain/activation_state.dart';
+import 'package:voice_agent/features/activation/presentation/activation_controller.dart';
+import 'package:voice_agent/features/activation/presentation/wake_word_provider.dart';
+
+final activationControllerProvider =
+    StateNotifierProvider<ActivationController, ActivationState>((ref) {
+  final controller = ActivationController(
+    wakeWordService: ref.watch(wakeWordServiceProvider),
+    audioFeedback: ref.watch(audioFeedbackServiceProvider),
+    ref: ref,
+  );
+
+  // Watch session status changes and forward to controller.
+  ref.listen(handsFreeSessionStatusProvider, (_, next) {
+    controller.onSessionStatusChanged(next);
+  });
+
+  // Watch pause requests from manual recording.
+  ref.listen(wakeWordPauseRequestProvider, (_, next) {
+    controller.onPauseRequest(next);
+  });
+
+  return controller;
+});

--- a/test/features/activation/presentation/activation_controller_test.dart
+++ b/test/features/activation/presentation/activation_controller_test.dart
@@ -1,0 +1,497 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
+import 'package:voice_agent/core/audio/audio_feedback_service.dart';
+import 'package:voice_agent/core/config/app_config.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/config/app_config_service.dart';
+import 'package:voice_agent/core/providers/activation_event.dart';
+import 'package:voice_agent/core/providers/activation_providers.dart';
+import 'package:voice_agent/core/providers/hands_free_session_status.dart';
+import 'package:voice_agent/features/activation/domain/activation_state.dart';
+import 'package:voice_agent/features/activation/domain/wake_word_service.dart';
+import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+import 'package:voice_agent/features/activation/presentation/wake_word_provider.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeWakeWordService implements WakeWordService {
+  bool _listening = false;
+  final _detectionsController = StreamController<int>.broadcast();
+  final _errorsController = StreamController<WakeWordError>.broadcast();
+
+  String? lastAccessKey;
+  List<BuiltInKeyword>? lastKeywords;
+  List<double>? lastSensitivities;
+  int startCallCount = 0;
+  int stopCallCount = 0;
+
+  @override
+  Stream<int> get detections => _detectionsController.stream;
+
+  @override
+  Stream<WakeWordError> get errors => _errorsController.stream;
+
+  @override
+  bool get isListening => _listening;
+
+  @override
+  Future<void> startBuiltIn({
+    required String accessKey,
+    required List<BuiltInKeyword> keywords,
+    required List<double> sensitivities,
+  }) async {
+    startCallCount++;
+    lastAccessKey = accessKey;
+    lastKeywords = keywords;
+    lastSensitivities = sensitivities;
+    _listening = true;
+  }
+
+  @override
+  Future<void> startCustom({
+    required String accessKey,
+    required List<String> keywordPaths,
+    required List<double> sensitivities,
+  }) async {
+    startCallCount++;
+    _listening = true;
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCallCount++;
+    _listening = false;
+  }
+
+  @override
+  void dispose() {
+    _detectionsController.close();
+    _errorsController.close();
+  }
+
+  void emitDetection(int index) => _detectionsController.add(index);
+  void emitError(WakeWordError error) => _errorsController.add(error);
+}
+
+class FakeAudioFeedbackService implements AudioFeedbackService {
+  int wakeWordAckCount = 0;
+
+  @override
+  Future<void> playWakeWordAcknowledgment() async => wakeWordAckCount++;
+  @override
+  Future<void> startProcessingFeedback() async {}
+  @override
+  Future<void> stopLoop() async {}
+  @override
+  Future<void> playSuccess() async {}
+  @override
+  Future<void> playError() async {}
+  @override
+  void dispose() {}
+}
+
+class FakeAppConfigService extends AppConfigService {
+  FakeAppConfigService(this._config);
+  final AppConfig _config;
+
+  @override
+  Future<AppConfig> load() async => _config;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+AppConfig _defaultConfig({
+  bool backgroundListeningEnabled = true,
+  bool wakeWordEnabled = true,
+  String? picovoiceAccessKey = 'test-key',
+  String wakeWordKeyword = 'jarvis',
+  double wakeWordSensitivity = 0.5,
+}) =>
+    AppConfig(
+      backgroundListeningEnabled: backgroundListeningEnabled,
+      wakeWordEnabled: wakeWordEnabled,
+      picovoiceAccessKey: picovoiceAccessKey,
+      wakeWordKeyword: wakeWordKeyword,
+      wakeWordSensitivity: wakeWordSensitivity,
+    );
+
+Future<({ProviderContainer container, FakeWakeWordService wakeWord, FakeAudioFeedbackService audio})>
+    _setup({AppConfig? config}) async {
+  final wakeWord = FakeWakeWordService();
+  final audio = FakeAudioFeedbackService();
+  final container = ProviderContainer(
+    overrides: [
+      appConfigServiceProvider.overrideWithValue(
+        FakeAppConfigService(config ?? _defaultConfig()),
+      ),
+      wakeWordServiceProvider.overrideWithValue(wakeWord),
+      audioFeedbackServiceProvider.overrideWithValue(audio),
+    ],
+  );
+  // Wait for async config to load before creating the controller.
+  await container.read(appConfigProvider.notifier).loadCompleted;
+  // Force creation of the controller so stream subscriptions are active.
+  container.read(activationControllerProvider);
+  return (container: container, wakeWord: wakeWord, audio: audio);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('ActivationController', () {
+    test('initial state is idle', () async {
+      final s = await _setup();
+      addTearDown(s.container.dispose);
+
+      final state = s.container.read(activationControllerProvider);
+      expect(state, isA<ActivationIdle>());
+    });
+
+    test('startListening transitions to Listening', () async {
+      final s = await _setup();
+      addTearDown(s.container.dispose);
+      final notifier =
+          s.container.read(activationControllerProvider.notifier);
+
+      await notifier.startListening();
+
+      expect(s.container.read(activationControllerProvider),
+          isA<ActivationListening>());
+      final listening = s.container.read(activationControllerProvider)
+          as ActivationListening;
+      expect(listening.keyword, 'jarvis');
+      expect(s.wakeWord.lastAccessKey, 'test-key');
+      expect(s.wakeWord.lastKeywords, [BuiltInKeyword.jarvis]);
+      expect(s.wakeWord.lastSensitivities, [0.5]);
+    });
+
+    test('startListening with missing access key transitions to Error',
+        () async {
+      final s =
+          await _setup(config: _defaultConfig(picovoiceAccessKey: null));
+      addTearDown(s.container.dispose);
+      final notifier =
+          s.container.read(activationControllerProvider.notifier);
+
+      await notifier.startListening();
+
+      final state = s.container.read(activationControllerProvider);
+      expect(state, isA<ActivationError>());
+      expect((state as ActivationError).requiresSettings, isTrue);
+    });
+
+    test('startListening with empty access key transitions to Error',
+        () async {
+      final s = await _setup(config: _defaultConfig(picovoiceAccessKey: ''));
+      addTearDown(s.container.dispose);
+      final notifier =
+          s.container.read(activationControllerProvider.notifier);
+
+      await notifier.startListening();
+
+      final state = s.container.read(activationControllerProvider);
+      expect(state, isA<ActivationError>());
+      expect((state as ActivationError).requiresSettings, isTrue);
+    });
+
+    test('startListening when background disabled stays idle', () async {
+      final s = await _setup(
+          config: _defaultConfig(backgroundListeningEnabled: false));
+      addTearDown(s.container.dispose);
+      final notifier =
+          s.container.read(activationControllerProvider.notifier);
+
+      await notifier.startListening();
+
+      expect(s.container.read(activationControllerProvider),
+          isA<ActivationIdle>());
+      expect(s.wakeWord.startCallCount, 0);
+    });
+
+    test('startListening when wake word disabled stays idle', () async {
+      final s =
+          await _setup(config: _defaultConfig(wakeWordEnabled: false));
+      addTearDown(s.container.dispose);
+      final notifier =
+          s.container.read(activationControllerProvider.notifier);
+
+      await notifier.startListening();
+
+      expect(s.container.read(activationControllerProvider),
+          isA<ActivationIdle>());
+    });
+
+    test('stopListening transitions to Idle', () async {
+      final s = await _setup();
+      addTearDown(s.container.dispose);
+      final notifier =
+          s.container.read(activationControllerProvider.notifier);
+
+      await notifier.startListening();
+      expect(s.container.read(activationControllerProvider),
+          isA<ActivationListening>());
+
+      await notifier.stopListening();
+
+      expect(s.container.read(activationControllerProvider),
+          isA<ActivationIdle>());
+      expect(s.wakeWord.stopCallCount, 1);
+    });
+
+    test('toggle starts when idle', () async {
+      final s = await _setup();
+      addTearDown(s.container.dispose);
+      final notifier =
+          s.container.read(activationControllerProvider.notifier);
+
+      await notifier.toggle();
+
+      expect(s.container.read(activationControllerProvider),
+          isA<ActivationListening>());
+    });
+
+    test('toggle stops when listening', () async {
+      final s = await _setup();
+      addTearDown(s.container.dispose);
+      final notifier =
+          s.container.read(activationControllerProvider.notifier);
+
+      await notifier.startListening();
+      await notifier.toggle();
+
+      expect(s.container.read(activationControllerProvider),
+          isA<ActivationIdle>());
+    });
+
+    test('wake word detection transitions to HandsFreeActive', () async {
+      final s = await _setup();
+      addTearDown(s.container.dispose);
+      final notifier =
+          s.container.read(activationControllerProvider.notifier);
+
+      await notifier.startListening();
+      s.wakeWord.emitDetection(0);
+      await Future.delayed(Duration.zero);
+
+      final state = s.container.read(activationControllerProvider);
+      expect(state, isA<ActivationHandsFreeActive>());
+      expect(
+        (state as ActivationHandsFreeActive).trigger,
+        ActivationEvent.wakeWordDetected,
+      );
+      expect(s.wakeWord.stopCallCount, 1);
+    });
+
+    test('detection sets activationEventProvider', () async {
+      final s = await _setup();
+      addTearDown(s.container.dispose);
+      final notifier =
+          s.container.read(activationControllerProvider.notifier);
+
+      await notifier.startListening();
+      s.wakeWord.emitDetection(0);
+      await Future.delayed(Duration.zero);
+
+      expect(s.container.read(activationEventProvider),
+          ActivationEvent.wakeWordDetected);
+    });
+
+    test('detection plays acknowledgment tone', () async {
+      final s = await _setup();
+      addTearDown(s.container.dispose);
+      final notifier =
+          s.container.read(activationControllerProvider.notifier);
+
+      await notifier.startListening();
+      s.wakeWord.emitDetection(0);
+      await Future.delayed(Duration.zero);
+
+      expect(s.audio.wakeWordAckCount, 1);
+    });
+
+    test('detection ignored when not listening', () async {
+      final s = await _setup();
+      addTearDown(s.container.dispose);
+
+      s.wakeWord.emitDetection(0);
+      await Future.delayed(Duration.zero);
+
+      expect(s.container.read(activationControllerProvider),
+          isA<ActivationIdle>());
+      expect(s.audio.wakeWordAckCount, 0);
+    });
+
+    group('session status', () {
+      test('CompletedOk restarts listening', () async {
+        final s = await _setup();
+        addTearDown(s.container.dispose);
+        final notifier =
+            s.container.read(activationControllerProvider.notifier);
+
+        await notifier.startListening();
+        s.wakeWord.emitDetection(0);
+        await Future.delayed(Duration.zero);
+        expect(s.container.read(activationControllerProvider),
+            isA<ActivationHandsFreeActive>());
+
+        notifier
+            .onSessionStatusChanged(const HandsFreeSessionCompletedOk());
+        await Future.delayed(Duration.zero);
+
+        expect(s.container.read(activationControllerProvider),
+            isA<ActivationListening>());
+      });
+
+      test('Failed transitions to error', () async {
+        final s = await _setup();
+        addTearDown(s.container.dispose);
+        final notifier =
+            s.container.read(activationControllerProvider.notifier);
+
+        await notifier.startListening();
+        s.wakeWord.emitDetection(0);
+        await Future.delayed(Duration.zero);
+
+        notifier.onSessionStatusChanged(
+          const HandsFreeSessionFailed(message: 'transcription error'),
+        );
+
+        final state = s.container.read(activationControllerProvider);
+        expect(state, isA<ActivationError>());
+        expect((state as ActivationError).message, 'transcription error');
+      });
+
+      test('Running and Inactive are ignored', () async {
+        final s = await _setup();
+        addTearDown(s.container.dispose);
+        final notifier =
+            s.container.read(activationControllerProvider.notifier);
+
+        await notifier.startListening();
+        final beforeState =
+            s.container.read(activationControllerProvider);
+
+        notifier
+            .onSessionStatusChanged(const HandsFreeSessionRunning());
+        expect(s.container.read(activationControllerProvider),
+            beforeState);
+
+        notifier
+            .onSessionStatusChanged(const HandsFreeSessionInactive());
+        expect(s.container.read(activationControllerProvider),
+            beforeState);
+      });
+    });
+
+    group('pause request', () {
+      test('non-null Completer stops wake word and completes', () async {
+        final s = await _setup();
+        addTearDown(s.container.dispose);
+        final notifier =
+            s.container.read(activationControllerProvider.notifier);
+
+        await notifier.startListening();
+        expect(s.container.read(activationControllerProvider),
+            isA<ActivationListening>());
+
+        final completer = Completer<void>();
+        await notifier.onPauseRequest(completer);
+
+        expect(s.container.read(activationControllerProvider),
+            isA<ActivationIdle>());
+        expect(completer.isCompleted, isTrue);
+        expect(s.wakeWord.stopCallCount, 1);
+      });
+
+      test('null Completer restarts listening', () async {
+        final s = await _setup();
+        addTearDown(s.container.dispose);
+        final notifier =
+            s.container.read(activationControllerProvider.notifier);
+
+        await notifier.startListening();
+        final completer = Completer<void>();
+        await notifier.onPauseRequest(completer);
+        expect(s.container.read(activationControllerProvider),
+            isA<ActivationIdle>());
+
+        await notifier.onPauseRequest(null);
+
+        expect(s.container.read(activationControllerProvider),
+            isA<ActivationListening>());
+      });
+
+      test('completer completes immediately when idle', () async {
+        final s = await _setup();
+        addTearDown(s.container.dispose);
+        final notifier =
+            s.container.read(activationControllerProvider.notifier);
+
+        final completer = Completer<void>();
+        await notifier.onPauseRequest(completer);
+
+        expect(completer.isCompleted, isTrue);
+        expect(s.wakeWord.stopCallCount, 0);
+      });
+    });
+
+    group('error handling', () {
+      test('InvalidAccessKey transitions to Error with requiresSettings',
+          () async {
+        final s = await _setup();
+        addTearDown(s.container.dispose);
+        final notifier =
+            s.container.read(activationControllerProvider.notifier);
+
+        await notifier.startListening();
+        s.wakeWord.emitError(const InvalidAccessKey());
+        await Future.delayed(Duration.zero);
+
+        final state = s.container.read(activationControllerProvider);
+        expect(state, isA<ActivationError>());
+        expect((state as ActivationError).requiresSettings, isTrue);
+      });
+
+      test('AudioCaptureFailed transitions to Error without requiresSettings',
+          () async {
+        final s = await _setup();
+        addTearDown(s.container.dispose);
+        final notifier =
+            s.container.read(activationControllerProvider.notifier);
+
+        await notifier.startListening();
+        s.wakeWord
+            .emitError(const AudioCaptureFailed(reason: 'mic unavailable'));
+        await Future.delayed(Duration.zero);
+
+        final state = s.container.read(activationControllerProvider);
+        expect(state, isA<ActivationError>());
+        expect((state as ActivationError).requiresSettings, isFalse);
+      });
+
+      test('unknown keyword transitions to Error with requiresSettings',
+          () async {
+        final s = await _setup(
+            config: _defaultConfig(wakeWordKeyword: 'nonexistent'));
+        addTearDown(s.container.dispose);
+        final notifier =
+            s.container.read(activationControllerProvider.notifier);
+
+        await notifier.startListening();
+
+        final state = s.container.read(activationControllerProvider);
+        expect(state, isA<ActivationError>());
+        expect((state as ActivationError).requiresSettings, isTrue);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Implements T4a from Proposal 019: Core activation bridge and ActivationController
- Adds ActivationEvent enum, HandsFreeSessionStatus sealed class, and 3 core providers for cross-feature signaling
- Adds ActivationState sealed class (Idle/Listening/HandsFreeActive/Error)
- Implements ActivationController state machine bridging wake word detection to hands-free recording
- Handles mic ownership (pause/resume for manual recording via Completer-based handoff)
- Error recovery: auto-retry (5s) for transient errors, requiresSettings flag for config issues
- 22 unit tests covering all state transitions, error paths, and provider interactions

## Test plan
- [x] All 382 tests pass (flutter test)
- [x] flutter analyze clean (0 new issues)
- [x] No cross-feature import violations
- [x] Architecture dependency rule respected

Closes #150
