### PR TITLE
feat(recording): wire session lifecycle for activation bridge

### DIFF
--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -8,6 +8,8 @@ import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/config/vad_config.dart';
 import 'package:voice_agent/core/models/transcript.dart';
+import 'package:voice_agent/core/providers/activation_providers.dart';
+import 'package:voice_agent/core/providers/hands_free_session_status.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
@@ -38,6 +40,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
 
   HandsFreeEngine? _engine;
   StreamSubscription<HandsFreeEngineEvent>? _engineSub;
+  bool _triggeredByActivation = false;
 
   // ── Job list ─────────────────────────────────────────────────────────────
   // Mutable list kept in controller; copied into each emitted state.
@@ -124,7 +127,9 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.paused && this.state is! HandsFreeIdle) {
+    if (state == AppLifecycleState.paused &&
+        this.state is! HandsFreeIdle &&
+        !_triggeredByActivation) {
       _terminateWithError(
         'Interrupted: app backgrounded',
         requiresSettings: false,
@@ -134,9 +139,10 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
 
   // ── Public API ────────────────────────────────────────────────────────────
 
-  Future<void> startSession() async {
+  Future<void> startSession({bool triggeredByActivation = false}) async {
     if (state is! HandsFreeIdle && state is! HandsFreeSessionError) return;
 
+    _triggeredByActivation = triggeredByActivation;
     final engine = _ref.read(handsFreeEngineProvider);
 
     // Guard 1 — microphone permission.
@@ -147,6 +153,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
         requiresSettings: true,
         jobs: [],
       );
+      _signalSessionFailed('Microphone permission denied.');
       return;
     }
 
@@ -159,12 +166,15 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
         requiresAppSettings: true,
         jobs: [],
       );
+      _signalSessionFailed('Groq API key not set.');
       return;
     }
 
     // All guards passed — start engine.
     _jobs.clear();
     _jobCounter = 0;
+    _ref.read(handsFreeSessionStatusProvider.notifier).state =
+        const HandsFreeSessionRunning();
     _startEngine(_ref.read(appConfigProvider).vadConfig);
   }
 
@@ -202,6 +212,9 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     // Drain: wait until no job is in Transcribing or Persisting state.
     await _drainInFlightJobs();
 
+    _triggeredByActivation = false;
+    _ref.read(handsFreeSessionStatusProvider.notifier).state =
+        const HandsFreeSessionCompletedOk();
     state = const HandsFreeIdle();
     _jobs.clear();
     _jobCounter = 0;
@@ -403,12 +416,20 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     _engineSub = null;
     unawaited(_engine?.stop());
     _engine = null;
+    _triggeredByActivation = false;
+
+    _signalSessionFailed(message);
 
     state = HandsFreeSessionError(
       message: message,
       requiresSettings: requiresSettings,
       jobs: List<SegmentJob>.unmodifiable(_jobs),
     );
+  }
+
+  void _signalSessionFailed(String message) {
+    _ref.read(handsFreeSessionStatusProvider.notifier).state =
+        HandsFreeSessionFailed(message: message);
   }
 
   /// Polls until no job is in [Transcribing] or [Persisting] state, with a

--- a/lib/features/recording/presentation/recording_providers.dart
+++ b/lib/features/recording/presentation/recording_providers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:record/record.dart';
+import 'package:voice_agent/core/providers/activation_providers.dart';
 import 'package:voice_agent/features/recording/data/groq_stt_service.dart';
 import 'package:voice_agent/features/recording/data/hands_free_orchestrator.dart';
 import 'package:voice_agent/features/recording/data/recording_service_impl.dart';
@@ -34,7 +35,18 @@ final handsFreeEngineProvider = Provider<HandsFreeEngine>((ref) {
 
 final handsFreeControllerProvider =
     StateNotifierProvider<HandsFreeController, HandsFreeSessionState>((ref) {
-  return HandsFreeController(ref);
+  final controller = HandsFreeController(ref);
+
+  // Watch activation events from wake word / shortcut and trigger a session.
+  ref.listen(activationEventProvider, (_, event) {
+    if (event != null) {
+      controller.startSession(triggeredByActivation: true);
+      // Clear the event after consuming it.
+      ref.read(activationEventProvider.notifier).state = null;
+    }
+  });
+
+  return controller;
 });
 
 final recordingControllerProvider =


### PR DESCRIPTION
## Summary

- Wire `HandsFreeController` into the activation lifecycle by signaling `handsFreeSessionStatusProvider` on session start/stop/error
- Add `triggeredByActivation` flag to gate cancel-on-background behavior (activation-triggered sessions survive app backgrounding per ADR-PLATFORM-004)
- Watch `activationEventProvider` in `handsFreeControllerProvider` to auto-start hands-free sessions on wake word detection or shortcut activation
- Clear the activation event after consuming it to prevent re-triggers

Closes #151

## Test plan

- [x] All 382 existing tests pass (`flutter test`)
- [x] `flutter analyze` passes with zero issues
- [x] Architecture dependency rule verified (no cross-feature imports)
