### PR TITLE
feat(activation): Android Quick Settings tile + platform channel bridge

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,16 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <service
+            android:name=".VoiceAgentTileService"
+            android:exported="true"
+            android:label="Voice Agent"
+            android:icon="@android:drawable/ic_btn_speak_now"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE"/>
+            </intent-filter>
+        </service>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/kotlin/com/voiceagent/voice_agent/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/voiceagent/voice_agent/MainActivity.kt
@@ -1,5 +1,38 @@
 package com.voiceagent.voice_agent
 
+import android.content.Intent
+import android.os.Bundle
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+
+    companion object {
+        const val ACTION_TOGGLE_ACTIVATION = "com.voiceagent.ACTION_TOGGLE_ACTIVATION"
+        private const val CHANNEL = "com.voiceagent/activation"
+    }
+
+    private var methodChannel: MethodChannel? = null
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        methodChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        handleActivationIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleActivationIntent(intent)
+    }
+
+    private fun handleActivationIntent(intent: Intent?) {
+        if (intent?.action == ACTION_TOGGLE_ACTIVATION) {
+            methodChannel?.invokeMethod("toggleFromIntent", null)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/voiceagent/voice_agent/VoiceAgentTileService.kt
+++ b/android/app/src/main/kotlin/com/voiceagent/voice_agent/VoiceAgentTileService.kt
@@ -1,0 +1,72 @@
+package com.voiceagent.voice_agent
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+
+class VoiceAgentTileService : TileService() {
+
+    companion object {
+        private const val PREFS_NAME = "FlutterSharedPreferences"
+        private const val KEY_ACTIVATION_STATE = "flutter.activation_state"
+        private const val KEY_TOGGLE_REQUESTED = "flutter.activation_toggle_requested"
+        private const val KEY_FOREGROUND_SERVICE_RUNNING = "flutter.foreground_service_running"
+    }
+
+    private fun getPrefs(): SharedPreferences {
+        return applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    override fun onStartListening() {
+        super.onStartListening()
+        updateTile()
+    }
+
+    override fun onClick() {
+        super.onClick()
+        val prefs = getPrefs()
+        val isRunning = prefs.getBoolean(KEY_FOREGROUND_SERVICE_RUNNING, false)
+
+        if (isRunning) {
+            // App is alive — signal via SharedPreferences flag
+            prefs.edit().putBoolean(KEY_TOGGLE_REQUESTED, true).apply()
+        } else {
+            // App not alive — launch MainActivity with toggle intent
+            val intent = Intent(this, MainActivity::class.java).apply {
+                action = MainActivity.ACTION_TOGGLE_ACTIVATION
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startActivityAndCollapse(
+                    PendingIntent.getActivity(
+                        this, 0, intent,
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                    )
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                startActivityAndCollapse(intent)
+            }
+        }
+    }
+
+    private fun updateTile() {
+        val tile = qsTile ?: return
+        val prefs = getPrefs()
+        val isActive = prefs.getString(KEY_ACTIVATION_STATE, "idle") == "listening"
+
+        tile.state = if (isActive) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+        tile.label = if (isActive) "Listening" else "Voice Agent"
+        tile.icon = Icon.createWithResource(
+            this,
+            if (isActive) android.R.drawable.ic_btn_speak_now
+            else android.R.drawable.ic_lock_silent_mode_off
+        )
+        tile.updateTile()
+    }
+}

--- a/lib/features/activation/data/platform_channel_bridge.dart
+++ b/lib/features/activation/data/platform_channel_bridge.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Abstraction over SharedPreferences for platform bridge key-value access.
+/// Production uses [SharedPreferencesBridgeStore]; tests can substitute a
+/// synchronous in-memory implementation.
+abstract class BridgeStore {
+  Future<bool?> getBool(String key);
+  Future<void> setBool(String key, bool value);
+  Future<String?> getString(String key);
+  Future<void> setString(String key, String value);
+}
+
+/// Production [BridgeStore] backed by [SharedPreferencesAsync].
+class SharedPreferencesBridgeStore implements BridgeStore {
+  SharedPreferencesBridgeStore([SharedPreferencesAsync? prefs])
+      : _prefs = prefs ?? SharedPreferencesAsync();
+
+  final SharedPreferencesAsync _prefs;
+
+  @override
+  Future<bool?> getBool(String key) => _prefs.getBool(key);
+
+  @override
+  Future<void> setBool(String key, bool value) => _prefs.setBool(key, value);
+
+  @override
+  Future<String?> getString(String key) => _prefs.getString(key);
+
+  @override
+  Future<void> setString(String key, String value) =>
+      _prefs.setString(key, value);
+}
+
+/// Bridges native platform controls (Android Quick Settings tile, iOS Control
+/// Center) with the Flutter-side activation controller.
+///
+/// Communication paths:
+/// 1. MethodChannel: `toggleFromIntent` -- tile tap when app was not alive
+/// 2. SharedPreferences polling: `activation_toggle_requested` /
+///    `activation_stop_requested` flags -- tile tap when app is alive
+///
+/// State is written to SharedPreferences so the native tile can read it.
+class PlatformChannelBridge {
+  PlatformChannelBridge({
+    required this.onToggleRequested,
+    required this.onStopRequested,
+    MethodChannel? channel,
+    BridgeStore? store,
+  })  : _channel = channel ?? const MethodChannel('com.voiceagent/activation'),
+        _store = store ?? SharedPreferencesBridgeStore();
+
+  final void Function() onToggleRequested;
+  final void Function() onStopRequested;
+  final MethodChannel _channel;
+  final BridgeStore _store;
+
+  Timer? _pollTimer;
+
+  static const _pollInterval = Duration(seconds: 10);
+
+  static const _keyToggleRequested = 'activation_toggle_requested';
+  static const _keyStopRequested = 'activation_stop_requested';
+  static const _keyActivationState = 'activation_state';
+
+  /// Start listening for platform activation requests.
+  void start() {
+    _channel.setMethodCallHandler(_handleMethodCall);
+    _pollTimer?.cancel();
+    _pollTimer = Timer.periodic(_pollInterval, (_) => checkFlags());
+    // Also check immediately on start (e.g. after lifecycle resume).
+    unawaited(checkFlags());
+  }
+
+  /// Stop listening and cancel the poll timer.
+  void stop() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+    _channel.setMethodCallHandler(null);
+  }
+
+  /// Check SharedPreferences flags for pending activation requests.
+  /// Exposed for testing and for lifecycle resume checks.
+  Future<void> checkFlags() async {
+    final toggleRequested =
+        await _store.getBool(_keyToggleRequested) ?? false;
+    if (toggleRequested) {
+      await _store.setBool(_keyToggleRequested, false);
+      onToggleRequested();
+    }
+
+    final stopRequested =
+        await _store.getBool(_keyStopRequested) ?? false;
+    if (stopRequested) {
+      await _store.setBool(_keyStopRequested, false);
+      onStopRequested();
+    }
+  }
+
+  /// Write the current activation state so native tiles can read it.
+  Future<void> writeActivationState(String state) async {
+    await _store.setString(_keyActivationState, state);
+  }
+
+  Future<dynamic> _handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'toggleFromIntent':
+        onToggleRequested();
+      default:
+        throw PlatformException(
+          code: 'UNIMPLEMENTED',
+          message: 'Method ${call.method} not implemented',
+        );
+    }
+  }
+}

--- a/test/features/activation/data/platform_channel_bridge_test.dart
+++ b/test/features/activation/data/platform_channel_bridge_test.dart
@@ -1,0 +1,168 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/features/activation/data/platform_channel_bridge.dart';
+
+// ---------------------------------------------------------------------------
+// In-memory BridgeStore for tests
+// ---------------------------------------------------------------------------
+
+class InMemoryBridgeStore implements BridgeStore {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  Future<bool?> getBool(String key) async => _data[key] as bool?;
+
+  @override
+  Future<void> setBool(String key, bool value) async => _data[key] = value;
+
+  @override
+  Future<String?> getString(String key) async => _data[key] as String?;
+
+  @override
+  Future<void> setString(String key, String value) async => _data[key] = value;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MethodChannel channel;
+  late InMemoryBridgeStore store;
+  late int toggleCount;
+  late int stopCount;
+  late PlatformChannelBridge bridge;
+
+  setUp(() {
+    channel = const MethodChannel('com.voiceagent/activation.test');
+    store = InMemoryBridgeStore();
+    toggleCount = 0;
+    stopCount = 0;
+    bridge = PlatformChannelBridge(
+      onToggleRequested: () => toggleCount++,
+      onStopRequested: () => stopCount++,
+      channel: channel,
+      store: store,
+    );
+  });
+
+  tearDown(() {
+    bridge.stop();
+  });
+
+  group('PlatformChannelBridge', () {
+    group('MethodChannel', () {
+      test('toggleFromIntent calls onToggleRequested', () async {
+        bridge.start();
+
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+          'com.voiceagent/activation.test',
+          const StandardMethodCodec().encodeMethodCall(
+            const MethodCall('toggleFromIntent'),
+          ),
+          (ByteData? reply) {},
+        );
+
+        expect(toggleCount, 1);
+        expect(stopCount, 0);
+      });
+
+      test('unknown method throws PlatformException', () async {
+        bridge.start();
+
+        final completer = Completer<ByteData?>();
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+          'com.voiceagent/activation.test',
+          const StandardMethodCodec().encodeMethodCall(
+            const MethodCall('unknownMethod'),
+          ),
+          (ByteData? reply) {
+            completer.complete(reply);
+          },
+        );
+
+        final response = await completer.future;
+        expect(response, isNotNull);
+        expect(
+          () => const StandardMethodCodec().decodeEnvelope(response!),
+          throwsA(isA<PlatformException>()),
+        );
+      });
+    });
+
+    group('SharedPreferences polling', () {
+      test('checkFlags detects toggle request and clears flag', () async {
+        await store.setBool('activation_toggle_requested', true);
+
+        await bridge.checkFlags();
+
+        expect(toggleCount, 1);
+        expect(stopCount, 0);
+        expect(await store.getBool('activation_toggle_requested'), false);
+      });
+
+      test('checkFlags detects stop request and clears flag', () async {
+        await store.setBool('activation_stop_requested', true);
+
+        await bridge.checkFlags();
+
+        expect(toggleCount, 0);
+        expect(stopCount, 1);
+        expect(await store.getBool('activation_stop_requested'), false);
+      });
+
+      test('checkFlags handles both flags simultaneously', () async {
+        await store.setBool('activation_toggle_requested', true);
+        await store.setBool('activation_stop_requested', true);
+
+        await bridge.checkFlags();
+
+        expect(toggleCount, 1);
+        expect(stopCount, 1);
+      });
+
+      test('checkFlags is no-op when no flags set', () async {
+        await bridge.checkFlags();
+
+        expect(toggleCount, 0);
+        expect(stopCount, 0);
+      });
+    });
+
+    group('state writing', () {
+      test('writeActivationState persists to store', () async {
+        await bridge.writeActivationState('listening');
+
+        expect(await store.getString('activation_state'), 'listening');
+      });
+
+      test('writeActivationState overwrites previous value', () async {
+        await bridge.writeActivationState('listening');
+        await bridge.writeActivationState('idle');
+
+        expect(await store.getString('activation_state'), 'idle');
+      });
+    });
+
+    group('lifecycle', () {
+      test('stop cancels poll timer', () async {
+        bridge.start();
+        bridge.stop();
+
+        // Set a flag after stop — should not be detected
+        await store.setBool('activation_toggle_requested', true);
+
+        // Wait a tick
+        await Future.delayed(Duration.zero);
+
+        expect(toggleCount, 0);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `VoiceAgentTileService.kt`: Android Quick Settings tile that toggles voice agent activation. Uses SharedPreferences flag when app is alive, launches MainActivity with intent when app is dead.
- Update `MainActivity.kt`: handle `ACTION_TOGGLE_ACTIVATION` intent and forward to Flutter via `MethodChannel('com.voiceagent/activation')`
- Register TileService in `AndroidManifest.xml` with `QS_TILE` intent filter
- Add `PlatformChannelBridge` (Dart): polls SharedPreferences for `activation_toggle_requested`/`activation_stop_requested` flags, listens on MethodChannel for `toggleFromIntent`, writes `activation_state` for native tile to read
- Add `BridgeStore` abstraction for testable SharedPreferences access
- 9 tests for platform channel bridge: MethodChannel handling, flag polling, state writing, lifecycle

Closes #154

## Test plan

- [x] All 396 tests pass (`flutter test`)
- [x] `flutter analyze` passes with zero issues
- [x] Architecture dependency rule verified (no cross-feature imports)
- [ ] Manual: add tile from Quick Settings on Android device, verify toggle behavior
