### PR TITLE
fix(activation): fix P0/P1 issues from P019 implementation review

### DIFF
--- a/lib/app/app_shell_scaffold.dart
+++ b/lib/app/app_shell_scaffold.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
 import 'package:voice_agent/core/providers/app_foreground_provider.dart';
+import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
 import 'package:voice_agent/features/api_sync/sync_provider.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 
@@ -42,6 +43,7 @@ class _AppShellScaffoldState extends ConsumerState<AppShellScaffold>
   Widget build(BuildContext context) {
     ref.watch(syncWorkerProvider);
     ref.watch(handsFreeControllerProvider);
+    ref.watch(activationControllerProvider);
 
     ref.listen<AsyncValue<ConnectivityStatus>>(
       connectivityStatusProvider,

--- a/lib/core/providers/hands_free_session_status.dart
+++ b/lib/core/providers/hands_free_session_status.dart
@@ -19,6 +19,10 @@ class HandsFreeSessionCompletedOk extends HandsFreeSessionStatus {
 }
 
 class HandsFreeSessionFailed extends HandsFreeSessionStatus {
-  const HandsFreeSessionFailed({required this.message});
+  const HandsFreeSessionFailed({
+    required this.message,
+    this.requiresSettings = false,
+  });
   final String message;
+  final bool requiresSettings;
 }

--- a/lib/features/activation/presentation/activation_controller.dart
+++ b/lib/features/activation/presentation/activation_controller.dart
@@ -97,11 +97,16 @@ class ActivationController extends StateNotifier<ActivationState> {
         _ref.read(handsFreeSessionStatusProvider.notifier).state =
             const HandsFreeSessionInactive();
         startListening();
-      case HandsFreeSessionFailed(message: final msg):
+      case HandsFreeSessionFailed(
+          message: final msg,
+          requiresSettings: final rs,
+        ):
         _ref.read(handsFreeSessionStatusProvider.notifier).state =
             const HandsFreeSessionInactive();
-        state = ActivationError(message: msg);
-        _scheduleRetry();
+        state = ActivationError(message: msg, requiresSettings: rs);
+        if (!rs) {
+          _scheduleRetry();
+        }
       case HandsFreeSessionRunning():
       case HandsFreeSessionInactive():
         break;
@@ -128,11 +133,11 @@ class ActivationController extends StateNotifier<ActivationState> {
     }
   }
 
-  void _onDetection(int keywordIndex) {
+  Future<void> _onDetection(int keywordIndex) async {
     if (state is! ActivationListening) return;
 
     // Stop Porcupine before handing off to hands-free recording.
-    wakeWordService.stop();
+    await wakeWordService.stop();
 
     final keyword = (state as ActivationListening).keyword;
     state = const ActivationHandsFreeActive(

--- a/lib/features/activation/presentation/activation_provider.dart
+++ b/lib/features/activation/presentation/activation_provider.dart
@@ -1,9 +1,17 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
 import 'package:voice_agent/core/providers/activation_providers.dart';
+import 'package:voice_agent/features/activation/data/platform_channel_bridge.dart';
 import 'package:voice_agent/features/activation/domain/activation_state.dart';
 import 'package:voice_agent/features/activation/presentation/activation_controller.dart';
 import 'package:voice_agent/features/activation/presentation/wake_word_provider.dart';
+
+/// Overridable store for [PlatformChannelBridge]. Tests override this with
+/// an in-memory implementation to avoid [SharedPreferencesAsync] platform
+/// dependency.
+final bridgeStoreProvider = Provider<BridgeStore>((ref) {
+  return SharedPreferencesBridgeStore();
+});
 
 final activationControllerProvider =
     StateNotifierProvider<ActivationController, ActivationState>((ref) {
@@ -22,6 +30,27 @@ final activationControllerProvider =
   ref.listen(wakeWordPauseRequestProvider, (_, next) {
     controller.onPauseRequest(next);
   });
+
+  // Wire PlatformChannelBridge for native tile/control communication.
+  final bridge = PlatformChannelBridge(
+    onToggleRequested: () => controller.toggle(),
+    onStopRequested: () => controller.stopListening(),
+    store: ref.watch(bridgeStoreProvider),
+  );
+  bridge.start();
+  ref.onDispose(bridge.stop);
+
+  // Write activation state to shared preferences for native tiles.
+  final removeListener = controller.addListener((state) {
+    final stateStr = switch (state) {
+      ActivationListening() => 'listening',
+      ActivationHandsFreeActive() => 'active',
+      ActivationIdle() => 'idle',
+      ActivationError() => 'error',
+    };
+    bridge.writeActivationState(stateStr);
+  });
+  ref.onDispose(removeListener);
 
   return controller;
 });

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -153,7 +153,10 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
         requiresSettings: true,
         jobs: [],
       );
-      _signalSessionFailed('Microphone permission denied.');
+      _signalSessionFailed(
+        'Microphone permission denied.',
+        requiresSettings: true,
+      );
       return;
     }
 
@@ -166,7 +169,10 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
         requiresAppSettings: true,
         jobs: [],
       );
-      _signalSessionFailed('Groq API key not set.');
+      _signalSessionFailed(
+        'Groq API key not set.',
+        requiresSettings: true,
+      );
       return;
     }
 
@@ -418,7 +424,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     _engine = null;
     _triggeredByActivation = false;
 
-    _signalSessionFailed(message);
+    _signalSessionFailed(message, requiresSettings: requiresSettings);
 
     state = HandsFreeSessionError(
       message: message,
@@ -427,9 +433,15 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     );
   }
 
-  void _signalSessionFailed(String message) {
+  void _signalSessionFailed(
+    String message, {
+    bool requiresSettings = false,
+  }) {
     _ref.read(handsFreeSessionStatusProvider.notifier).state =
-        HandsFreeSessionFailed(message: message);
+        HandsFreeSessionFailed(
+      message: message,
+      requiresSettings: requiresSettings,
+    );
   }
 
   /// Polls until no job is in [Transcribing] or [Persisting] state, with a

--- a/test/app/app_test.dart
+++ b/test/app/app_test.dart
@@ -9,6 +9,9 @@ import 'package:voice_agent/features/api_sync/sync_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/models/transcript_with_status.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
+import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+
+import '../helpers/in_memory_bridge_store.dart';
 
 class _StubStorageService implements StorageService {
   @override
@@ -54,6 +57,7 @@ class _NoOpConnectivity extends ConnectivityService {
 List<Override> get _testOverrides => [
       storageServiceProvider.overrideWithValue(_StubStorageService()),
       connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
+      bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
     ];
 
 void main() {

--- a/test/app/router_test.dart
+++ b/test/app/router_test.dart
@@ -7,6 +7,9 @@ import 'package:voice_agent/core/models/transcript.dart';
 import 'package:voice_agent/core/models/transcript_with_status.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
+import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+
+import '../helpers/in_memory_bridge_store.dart';
 
 class _StubStorageService implements StorageService {
   @override
@@ -47,6 +50,7 @@ class _StubStorageService implements StorageService {
 void main() {
   final overrides = [
     storageServiceProvider.overrideWithValue(_StubStorageService()),
+    bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
   ];
 
   group('Tab state preservation', () {

--- a/test/features/activation/data/platform_channel_bridge_test.dart
+++ b/test/features/activation/data/platform_channel_bridge_test.dart
@@ -4,25 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:voice_agent/features/activation/data/platform_channel_bridge.dart';
 
-// ---------------------------------------------------------------------------
-// In-memory BridgeStore for tests
-// ---------------------------------------------------------------------------
-
-class InMemoryBridgeStore implements BridgeStore {
-  final Map<String, dynamic> _data = {};
-
-  @override
-  Future<bool?> getBool(String key) async => _data[key] as bool?;
-
-  @override
-  Future<void> setBool(String key, bool value) async => _data[key] = value;
-
-  @override
-  Future<String?> getString(String key) async => _data[key] as String?;
-
-  @override
-  Future<void> setString(String key, String value) async => _data[key] = value;
-}
+import '../../../helpers/in_memory_bridge_store.dart';
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/test/features/activation/presentation/activation_controller_test.dart
+++ b/test/features/activation/presentation/activation_controller_test.dart
@@ -15,6 +15,8 @@ import 'package:voice_agent/features/activation/domain/wake_word_service.dart';
 import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
 import 'package:voice_agent/features/activation/presentation/wake_word_provider.dart';
 
+import '../../../helpers/in_memory_bridge_store.dart';
+
 // ---------------------------------------------------------------------------
 // Fakes
 // ---------------------------------------------------------------------------
@@ -133,6 +135,7 @@ Future<({ProviderContainer container, FakeWakeWordService wakeWord, FakeAudioFee
       ),
       wakeWordServiceProvider.overrideWithValue(wakeWord),
       audioFeedbackServiceProvider.overrideWithValue(audio),
+      bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
     ],
   );
   // Wait for async config to load before creating the controller.
@@ -147,6 +150,8 @@ Future<({ProviderContainer container, FakeWakeWordService wakeWord, FakeAudioFee
 // ---------------------------------------------------------------------------
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('ActivationController', () {
     test('initial state is idle', () async {
       final s = await _setup();

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -27,6 +27,8 @@ import 'package:voice_agent/features/recording/presentation/hands_free_controlle
 import 'package:voice_agent/features/recording/presentation/recording_controller.dart';
 import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
 import 'package:voice_agent/core/audio/audio_feedback_service.dart';
+import 'package:voice_agent/core/providers/activation_providers.dart';
+import 'package:voice_agent/core/providers/hands_free_session_status.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 
 // ── FakeHandsFreeEngine ──────────────────────────────────────────────────────
@@ -521,6 +523,125 @@ void main() {
       await Future.delayed(Duration.zero);
 
       expect(stateOf(c), isA<HandsFreeIdle>());
+    });
+  });
+
+  // ── Activation-triggered background immunity ───────────────────────────────
+
+  group('triggeredByActivation', () {
+    test('app paused with triggeredByActivation: true → session NOT cancelled',
+        () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine);
+      await ctrl(c).startSession(triggeredByActivation: true);
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      ctrl(c).didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future.delayed(Duration.zero);
+
+      // Session must still be alive — not in error or idle.
+      expect(stateOf(c), isA<HandsFreeListening>());
+    });
+
+    test(
+        'app paused with triggeredByActivation: false → session cancelled '
+        '(control test)', () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine);
+      await ctrl(c).startSession(triggeredByActivation: false);
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      ctrl(c).didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future.delayed(Duration.zero);
+
+      expect(stateOf(c), isA<HandsFreeSessionError>());
+    });
+
+    test('stopSession clears triggeredByActivation', () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine);
+      await ctrl(c).startSession(triggeredByActivation: true);
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      await ctrl(c).stopSession();
+
+      // Start a new session WITHOUT activation trigger.
+      await ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      // App paused should now cancel (flag was cleared by previous stopSession).
+      ctrl(c).didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future.delayed(Duration.zero);
+      expect(stateOf(c), isA<HandsFreeSessionError>());
+    });
+  });
+
+  // ── Session status provider signals ─────────────────────────────────────────
+
+  group('session status signals', () {
+    test('successful start → HandsFreeSessionRunning', () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine);
+
+      await ctrl(c).startSession();
+
+      final status = c.read(handsFreeSessionStatusProvider);
+      expect(status, isA<HandsFreeSessionRunning>());
+    });
+
+    test('stopSession → HandsFreeSessionCompletedOk', () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine);
+      await ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      await ctrl(c).stopSession();
+
+      final status = c.read(handsFreeSessionStatusProvider);
+      expect(status, isA<HandsFreeSessionCompletedOk>());
+    });
+
+    test('permission denied → HandsFreeSessionFailed(requiresSettings: true)',
+        () async {
+      final engine = FakeHandsFreeEngine()..permissionGranted = false;
+      final c = makeContainer(engine: engine);
+
+      await ctrl(c).startSession();
+
+      final status =
+          c.read(handsFreeSessionStatusProvider) as HandsFreeSessionFailed;
+      expect(status.requiresSettings, isTrue);
+      expect(status.message, contains('permission'));
+    });
+
+    test('missing Groq key → HandsFreeSessionFailed(requiresSettings: true)',
+        () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine, groqApiKey: null);
+
+      await ctrl(c).startSession();
+
+      final status =
+          c.read(handsFreeSessionStatusProvider) as HandsFreeSessionFailed;
+      expect(status.requiresSettings, isTrue);
+    });
+
+    test('engine error → HandsFreeSessionFailed', () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine);
+      await ctrl(c).startSession();
+
+      engine.emit(const EngineError('VAD crashed'));
+      await Future.delayed(Duration.zero);
+
+      final status =
+          c.read(handsFreeSessionStatusProvider) as HandsFreeSessionFailed;
+      expect(status.message, contains('VAD crashed'));
     });
   });
 

--- a/test/features/recording/presentation/recording_screen_hands_free_test.dart
+++ b/test/features/recording/presentation/recording_screen_hands_free_test.dart
@@ -27,6 +27,9 @@ import 'package:voice_agent/core/audio/audio_feedback_service.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+
+import '../../../helpers/in_memory_bridge_store.dart';
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
@@ -131,6 +134,7 @@ List<Override> baseOverrides(FakeHfEngine engine) => [
       recordingServiceProvider.overrideWithValue(_NoOpRecordingService()),
       ttsServiceProvider.overrideWithValue(_StubTtsService()),
       audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
+      bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
     ];
 
 Future<void> pumpRecordScreen(

--- a/test/features/recording/presentation/recording_screen_mic_button_test.dart
+++ b/test/features/recording/presentation/recording_screen_mic_button_test.dart
@@ -29,6 +29,9 @@ import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/recording/presentation/recording_controller.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+
+import '../../../helpers/in_memory_bridge_store.dart';
 
 // ── Stubs ────────────────────────────────────────────────────────────────────
 
@@ -150,6 +153,7 @@ List<Override> get _baseOverrides => [
   )),
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
+  bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
 ];
 
 Future<void> pumpApp(WidgetTester tester) async {
@@ -183,6 +187,7 @@ Future<_SpyTtsService> _pumpAppWithSpyTts(WidgetTester tester) async {
         )),
         ttsServiceProvider.overrideWithValue(spy),
         audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
+        bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
       ],
       child: const App(),
     ),

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -29,6 +29,9 @@ import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/recording/presentation/recording_controller.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+
+import '../../../helpers/in_memory_bridge_store.dart';
 
 class _StubStorage implements StorageService {
   @override Future<String> getDeviceId() async => 'test';
@@ -93,6 +96,7 @@ List<Override> get _baseOverrides => [
   ),
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
+  bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
 ];
 
 void main() {

--- a/test/features/settings/advanced_settings_screen_test.dart
+++ b/test/features/settings/advanced_settings_screen_test.dart
@@ -23,6 +23,9 @@ import 'package:voice_agent/features/recording/domain/recording_result.dart';
 import 'package:voice_agent/features/recording/domain/recording_service.dart';
 import 'package:voice_agent/features/recording/domain/stt_service.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+
+import '../../helpers/in_memory_bridge_store.dart';
 import 'package:voice_agent/app/router.dart';
 import 'package:voice_agent/features/settings/advanced_settings_screen.dart';
 
@@ -103,6 +106,7 @@ List<Override> _baseOverrides({AppConfigService? configService}) => [
   sttServiceProvider.overrideWithValue(_NoOpSttService()),
   if (configService != null)
     appConfigServiceProvider.overrideWithValue(configService),
+  bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
 ];
 
 /// Pumps [AdvancedSettingsScreen] directly inside a minimal scaffold+router

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -16,6 +16,9 @@ import 'package:voice_agent/core/audio/audio_feedback_service.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/api_sync/sync_provider.dart';
+import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+
+import '../../helpers/in_memory_bridge_store.dart';
 
 class _StubStorage implements StorageService {
   @override Future<String> getDeviceId() async => 'test';
@@ -80,6 +83,7 @@ List<Override> _baseOverrides() => [
   connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
+  bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
 ];
 
 Future<void> _navigateToSettings(WidgetTester tester) async {

--- a/test/helpers/in_memory_bridge_store.dart
+++ b/test/helpers/in_memory_bridge_store.dart
@@ -1,0 +1,19 @@
+import 'package:voice_agent/features/activation/data/platform_channel_bridge.dart';
+
+/// In-memory [BridgeStore] for tests. Avoids the
+/// [SharedPreferencesAsync] platform dependency.
+class InMemoryBridgeStore implements BridgeStore {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  Future<bool?> getBool(String key) async => _data[key] as bool?;
+
+  @override
+  Future<void> setBool(String key, bool value) async => _data[key] = value;
+
+  @override
+  Future<String?> getString(String key) async => _data[key] as String?;
+
+  @override
+  Future<void> setString(String key, String value) async => _data[key] = value;
+}


### PR DESCRIPTION
## Summary

Fix P0 and P1 issues identified by the proposal implementation review of P019 (Background Activation & Wake Word Detection).

**P0 fixes (dead code / unwired components):**
- P0-1: ActivationController was never instantiated — added ref.watch(activationControllerProvider) to AppShellScaffold
- P0-2: PlatformChannelBridge was never connected — wired into activationControllerProvider with overridable bridgeStoreProvider and StateNotifier.addListener for state sync (avoids self-referential provider cycle)

**P1 fixes (broken contracts):**
- P1-1: HandsFreeSessionFailed now carries requiresSettings, propagated through _signalSessionFailed. ActivationController skips auto-retry for config errors
- P1-2: wakeWordService.stop() is now awaited in _onDetection to prevent mic conflict with HandsFreeEngine
- P1-3: Added tests for triggeredByActivation background immunity and session status provider signal transitions

**Test infrastructure:**
- Extracted InMemoryBridgeStore into shared test helper (test/helpers/)
- Added bridgeStoreProvider override to all widget tests that transitively trigger activationControllerProvider

## Test plan
- [x] flutter analyze passes (zero errors)
- [x] flutter test passes (404 tests, all green)
- [x] Architecture dependency rule verified (no cross-feature imports)
