### PR TITLE
fix(activation): fix P2 issues from P019 implementation review

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -14,6 +14,7 @@ import UIKit
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     if let controller = window?.rootViewController as? FlutterViewController {
       ActivationBridge.shared.configure(with: controller.binaryMessenger)
+      AudioSessionBridge.shared.configure(with: controller.binaryMessenger)
     }
   }
 

--- a/ios/Runner/AudioSessionBridge.swift
+++ b/ios/Runner/AudioSessionBridge.swift
@@ -1,0 +1,68 @@
+import AVFoundation
+import Flutter
+
+/// Manages the app-level AVAudioSession category via a MethodChannel.
+///
+/// Methods:
+///   - `setPlayAndRecord`: switches to `.playAndRecord` with `.defaultToSpeaker`
+///     to keep the app alive in background and allow simultaneous input/output.
+///   - `setAmbient`: reverts to `.ambient` (respects silent switch, mixes with
+///     other audio, standard foreground-only behavior per ADR-AUDIO-007).
+class AudioSessionBridge {
+    static let shared = AudioSessionBridge()
+
+    private let channelName = "com.voiceagent/audio_session"
+    private var methodChannel: FlutterMethodChannel?
+
+    private init() {}
+
+    /// Call from AppDelegate after the Flutter engine is available.
+    func configure(with messenger: FlutterBinaryMessenger) {
+        methodChannel = FlutterMethodChannel(
+            name: channelName,
+            binaryMessenger: messenger
+        )
+        methodChannel?.setMethodCallHandler { [weak self] call, result in
+            self?.handle(call, result: result)
+        }
+    }
+
+    private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let session = AVAudioSession.sharedInstance()
+        switch call.method {
+        case "setPlayAndRecord":
+            do {
+                try session.setCategory(
+                    .playAndRecord,
+                    mode: .default,
+                    options: [.defaultToSpeaker, .allowBluetooth, .mixWithOthers]
+                )
+                try session.setActive(true)
+                result(nil)
+            } catch {
+                result(FlutterError(
+                    code: "AUDIO_SESSION_ERROR",
+                    message: "Failed to set playAndRecord: \(error.localizedDescription)",
+                    details: nil
+                ))
+            }
+        case "setAmbient":
+            do {
+                try session.setCategory(
+                    .ambient,
+                    mode: .default,
+                    options: [.mixWithOthers]
+                )
+                result(nil)
+            } catch {
+                result(FlutterError(
+                    code: "AUDIO_SESSION_ERROR",
+                    message: "Failed to set ambient: \(error.localizedDescription)",
+                    details: nil
+                ))
+            }
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+}

--- a/lib/features/activation/presentation/activation_provider.dart
+++ b/lib/features/activation/presentation/activation_provider.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
+import 'package:voice_agent/core/background/background_service.dart';
+import 'package:voice_agent/core/background/background_service_provider.dart';
 import 'package:voice_agent/core/providers/activation_providers.dart';
 import 'package:voice_agent/features/activation/data/platform_channel_bridge.dart';
 import 'package:voice_agent/features/activation/domain/activation_state.dart';
@@ -40,8 +42,10 @@ final activationControllerProvider =
   bridge.start();
   ref.onDispose(bridge.stop);
 
-  // Write activation state to shared preferences for native tiles.
+  // Manage background service lifecycle and write state to native tiles.
+  final bgService = ref.watch(backgroundServiceProvider);
   final removeListener = controller.addListener((state) {
+    // Sync state string to SharedPreferences for native tiles.
     final stateStr = switch (state) {
       ActivationListening() => 'listening',
       ActivationHandsFreeActive() => 'active',
@@ -49,8 +53,32 @@ final activationControllerProvider =
       ActivationError() => 'error',
     };
     bridge.writeActivationState(stateStr);
+
+    // Start/stop background service based on activation state.
+    _syncBackgroundService(bgService, state);
   });
   ref.onDispose(removeListener);
 
   return controller;
 });
+
+/// Start or stop the background service to match the current activation state.
+void _syncBackgroundService(BackgroundService service, ActivationState state) {
+  switch (state) {
+    case ActivationListening():
+      if (!service.isRunning) service.startService();
+      service.updateNotification(
+        title: 'Voice Agent',
+        body: 'Listening for wake word...',
+      );
+    case ActivationHandsFreeActive():
+      if (!service.isRunning) service.startService();
+      service.updateNotification(
+        title: 'Voice Agent',
+        body: 'Recording session active',
+      );
+    case ActivationIdle():
+    case ActivationError():
+      if (service.isRunning) service.stopService();
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -100,6 +100,29 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     ref.read(appConfigProvider.notifier).updatePicovoiceAccessKey(key);
   }
 
+  Future<void> _onWakeWordChanged(bool value) async {
+    if (value) {
+      // Verify microphone permission before enabling wake word.
+      final status = await Permission.microphone.request();
+      if (status.isDenied || status.isPermanentlyDenied) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Microphone permission required for wake word'),
+            action: status.isPermanentlyDenied
+                ? SnackBarAction(
+                    label: 'Settings',
+                    onPressed: openAppSettings,
+                  )
+                : null,
+          ),
+        );
+        return;
+      }
+    }
+    ref.read(appConfigProvider.notifier).updateWakeWordEnabled(value);
+  }
+
   Future<void> _onBackgroundListeningChanged(bool value) async {
     if (value && Platform.isAndroid) {
       final status = await Permission.notification.request();
@@ -318,11 +341,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             subtitle: const Text('Activate recording with a spoken keyword'),
             value: config.wakeWordEnabled,
             onChanged: config.backgroundListeningEnabled
-                ? (v) {
-                    ref
-                        .read(appConfigProvider.notifier)
-                        .updateWakeWordEnabled(v);
-                  }
+                ? _onWakeWordChanged
                 : null,
           ),
           Padding(

--- a/test/app/app_test.dart
+++ b/test/app/app_test.dart
@@ -10,8 +10,10 @@ import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/models/transcript_with_status.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
 import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../helpers/in_memory_bridge_store.dart';
+import '../helpers/stub_background_service.dart';
 
 class _StubStorageService implements StorageService {
   @override
@@ -58,6 +60,7 @@ List<Override> get _testOverrides => [
       storageServiceProvider.overrideWithValue(_StubStorageService()),
       connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
       bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
+      backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
     ];
 
 void main() {

--- a/test/app/router_test.dart
+++ b/test/app/router_test.dart
@@ -8,8 +8,10 @@ import 'package:voice_agent/core/models/transcript_with_status.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
 import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../helpers/in_memory_bridge_store.dart';
+import '../helpers/stub_background_service.dart';
 
 class _StubStorageService implements StorageService {
   @override
@@ -51,6 +53,7 @@ void main() {
   final overrides = [
     storageServiceProvider.overrideWithValue(_StubStorageService()),
     bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
+    backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
   ];
 
   group('Tab state preservation', () {

--- a/test/features/activation/presentation/activation_controller_test.dart
+++ b/test/features/activation/presentation/activation_controller_test.dart
@@ -14,8 +14,10 @@ import 'package:voice_agent/features/activation/domain/activation_state.dart';
 import 'package:voice_agent/features/activation/domain/wake_word_service.dart';
 import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
 import 'package:voice_agent/features/activation/presentation/wake_word_provider.dart';
+import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../../helpers/in_memory_bridge_store.dart';
+import '../../../helpers/stub_background_service.dart';
 
 // ---------------------------------------------------------------------------
 // Fakes
@@ -136,6 +138,7 @@ Future<({ProviderContainer container, FakeWakeWordService wakeWord, FakeAudioFee
       wakeWordServiceProvider.overrideWithValue(wakeWord),
       audioFeedbackServiceProvider.overrideWithValue(audio),
       bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
+      backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
     ],
   );
   // Wait for async config to load before creating the controller.
@@ -496,6 +499,105 @@ void main() {
         final state = s.container.read(activationControllerProvider);
         expect(state, isA<ActivationError>());
         expect((state as ActivationError).requiresSettings, isTrue);
+      });
+    });
+
+    group('auto-retry', () {
+      test(
+          'transient error (requiresSettings: false) retries after 5 seconds',
+          () async {
+        final s = await _setup();
+        addTearDown(s.container.dispose);
+        final notifier =
+            s.container.read(activationControllerProvider.notifier);
+
+        await notifier.startListening();
+        expect(s.container.read(activationControllerProvider),
+            isA<ActivationListening>());
+
+        // Emit transient error — triggers _scheduleRetry.
+        s.wakeWord
+            .emitError(const AudioCaptureFailed(reason: 'mic unavailable'));
+        await Future.delayed(Duration.zero);
+        expect(s.container.read(activationControllerProvider),
+            isA<ActivationError>());
+        final startsBefore = s.wakeWord.startCallCount;
+
+        // Wait for the 5-second retry timer to fire.
+        await Future.delayed(const Duration(seconds: 6));
+        expect(s.wakeWord.startCallCount, startsBefore + 1,
+            reason: 'transient error should auto-retry after 5s');
+        expect(s.container.read(activationControllerProvider),
+            isA<ActivationListening>());
+      });
+
+      test('config error (requiresSettings: true) does NOT auto-retry',
+          () async {
+        final s = await _setup();
+        addTearDown(s.container.dispose);
+        final notifier =
+            s.container.read(activationControllerProvider.notifier);
+
+        await notifier.startListening();
+
+        // Emit config error.
+        s.wakeWord.emitError(const InvalidAccessKey());
+        await Future.delayed(Duration.zero);
+        expect(s.container.read(activationControllerProvider),
+            isA<ActivationError>());
+        final startsBefore = s.wakeWord.startCallCount;
+
+        // Wait past the retry window — should NOT retry.
+        await Future.delayed(const Duration(seconds: 6));
+        expect(s.wakeWord.startCallCount, startsBefore,
+            reason: 'config errors must not auto-retry');
+        expect(s.container.read(activationControllerProvider),
+            isA<ActivationError>());
+      });
+
+      test(
+          'session failure (requiresSettings: false) schedules retry; '
+          '(requiresSettings: true) does not', () async {
+        final s = await _setup();
+        addTearDown(s.container.dispose);
+        final notifier =
+            s.container.read(activationControllerProvider.notifier);
+
+        // Start listening → detect wake word → session active.
+        await notifier.startListening();
+        s.wakeWord.emitDetection(0);
+        await Future.delayed(Duration.zero);
+
+        // Transient session failure → should retry.
+        notifier.onSessionStatusChanged(
+          const HandsFreeSessionFailed(
+            message: 'engine error',
+            requiresSettings: false,
+          ),
+        );
+        expect(s.container.read(activationControllerProvider),
+            isA<ActivationError>());
+        final startsA = s.wakeWord.startCallCount;
+
+        await Future.delayed(const Duration(seconds: 6));
+        expect(s.wakeWord.startCallCount, startsA + 1,
+            reason: 'transient session failure should retry');
+
+        // Now trigger session active again → config failure.
+        s.wakeWord.emitDetection(0);
+        await Future.delayed(Duration.zero);
+
+        notifier.onSessionStatusChanged(
+          const HandsFreeSessionFailed(
+            message: 'permission denied',
+            requiresSettings: true,
+          ),
+        );
+        final startsB = s.wakeWord.startCallCount;
+
+        await Future.delayed(const Duration(seconds: 6));
+        expect(s.wakeWord.startCallCount, startsB,
+            reason: 'config session failure must not retry');
       });
     });
   });

--- a/test/features/recording/presentation/recording_screen_hands_free_test.dart
+++ b/test/features/recording/presentation/recording_screen_hands_free_test.dart
@@ -28,8 +28,10 @@ import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../../helpers/in_memory_bridge_store.dart';
+import '../../../helpers/stub_background_service.dart';
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
@@ -135,6 +137,7 @@ List<Override> baseOverrides(FakeHfEngine engine) => [
       ttsServiceProvider.overrideWithValue(_StubTtsService()),
       audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
       bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
+      backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
     ];
 
 Future<void> pumpRecordScreen(

--- a/test/features/recording/presentation/recording_screen_mic_button_test.dart
+++ b/test/features/recording/presentation/recording_screen_mic_button_test.dart
@@ -30,8 +30,10 @@ import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/recording/presentation/recording_controller.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../../helpers/in_memory_bridge_store.dart';
+import '../../../helpers/stub_background_service.dart';
 
 // ── Stubs ────────────────────────────────────────────────────────────────────
 
@@ -154,6 +156,7 @@ List<Override> get _baseOverrides => [
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
   bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
+  backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
 ];
 
 Future<void> pumpApp(WidgetTester tester) async {
@@ -188,6 +191,7 @@ Future<_SpyTtsService> _pumpAppWithSpyTts(WidgetTester tester) async {
         ttsServiceProvider.overrideWithValue(spy),
         audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
         bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
+        backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
       ],
       child: const App(),
     ),

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -30,8 +30,10 @@ import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/recording/presentation/recording_controller.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../../helpers/in_memory_bridge_store.dart';
+import '../../../helpers/stub_background_service.dart';
 
 class _StubStorage implements StorageService {
   @override Future<String> getDeviceId() async => 'test';
@@ -97,6 +99,7 @@ List<Override> get _baseOverrides => [
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
   bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
+  backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
 ];
 
 void main() {

--- a/test/features/settings/advanced_settings_screen_test.dart
+++ b/test/features/settings/advanced_settings_screen_test.dart
@@ -24,8 +24,10 @@ import 'package:voice_agent/features/recording/domain/recording_service.dart';
 import 'package:voice_agent/features/recording/domain/stt_service.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../helpers/in_memory_bridge_store.dart';
+import '../../helpers/stub_background_service.dart';
 import 'package:voice_agent/app/router.dart';
 import 'package:voice_agent/features/settings/advanced_settings_screen.dart';
 
@@ -107,6 +109,7 @@ List<Override> _baseOverrides({AppConfigService? configService}) => [
   if (configService != null)
     appConfigServiceProvider.overrideWithValue(configService),
   bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
+  backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
 ];
 
 /// Pumps [AdvancedSettingsScreen] directly inside a minimal scaffold+router

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -17,8 +17,10 @@ import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/api_sync/sync_provider.dart';
 import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../helpers/in_memory_bridge_store.dart';
+import '../../helpers/stub_background_service.dart';
 
 class _StubStorage implements StorageService {
   @override Future<String> getDeviceId() async => 'test';
@@ -84,6 +86,7 @@ List<Override> _baseOverrides() => [
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
   bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
+  backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
 ];
 
 Future<void> _navigateToSettings(WidgetTester tester) async {

--- a/test/helpers/stub_background_service.dart
+++ b/test/helpers/stub_background_service.dart
@@ -1,0 +1,22 @@
+import 'package:voice_agent/core/background/background_service.dart';
+
+/// No-op [BackgroundService] for tests. Avoids platform dependency on
+/// `flutter_foreground_task`.
+class StubBackgroundService implements BackgroundService {
+  bool _running = false;
+
+  @override
+  bool get isRunning => _running;
+
+  @override
+  Future<void> startService() async => _running = true;
+
+  @override
+  Future<void> stopService() async => _running = false;
+
+  @override
+  Future<void> updateNotification({
+    required String title,
+    required String body,
+  }) async {}
+}


### PR DESCRIPTION
## Summary

Fix P2 issues identified by the second proposal implementation review of P019 (Background Activation & Wake Word Detection).

**P2-1: BackgroundService wiring** - The foreground service / iOS audio session was never started. Wired `backgroundServiceProvider` into `activation_provider.dart` state listener to start/stop the background service and update notification text based on activation state.

**P2-2: iOS audio session native handler** - Created `AudioSessionBridge.swift` handling `setPlayAndRecord` (background keepalive) and `setAmbient` (revert to default) on the `com.voiceagent/audio_session` MethodChannel. Wired into `AppDelegate`.

**P2-3: Auto-retry tests** - Added 3 tests verifying the 5-second retry timer: transient errors retry, config errors don't, and session failure `requiresSettings` distinction works.

**P2-4: Mic permission in settings** - Wake word toggle now checks microphone permission before enabling. Shows snackbar on denial with Settings button for permanent denial.

## Test plan
- [x] `flutter analyze` passes (zero errors)
- [x] `flutter test` passes (407 tests, all green)
- [x] Architecture dependency rule verified
