### PR TITLE
Pause VAD during TTS playback and allow background sessions

### DIFF
--- a/lib/core/tts/flutter_tts_service.dart
+++ b/lib/core/tts/flutter_tts_service.dart
@@ -1,15 +1,25 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 
 class FlutterTtsService implements TtsService {
   FlutterTtsService({FlutterTts? tts, bool? isIOS})
       : _tts = tts ?? FlutterTts(),
-        _isIOS = isIOS ?? Platform.isIOS;
+        _isIOS = isIOS ?? Platform.isIOS {
+    _tts.setStartHandler(() => _speaking.value = true);
+    _tts.setCompletionHandler(() => _speaking.value = false);
+    _tts.setCancelHandler(() => _speaking.value = false);
+    _tts.setErrorHandler((_) => _speaking.value = false);
+  }
 
   final FlutterTts _tts;
   final bool _isIOS;
+  final ValueNotifier<bool> _speaking = ValueNotifier(false);
+
+  @override
+  ValueListenable<bool> get isSpeaking => _speaking;
 
   // Cache best voice per resolved language string to avoid repeated getVoices()
   // calls. null value means "looked up, nothing better than system default".
@@ -34,6 +44,7 @@ class FlutterTtsService implements TtsService {
   @override
   void dispose() {
     _tts.stop();
+    _speaking.dispose();
   }
 
   String _resolveLanguage(String? code) {

--- a/lib/core/tts/tts_provider.dart
+++ b/lib/core/tts/tts_provider.dart
@@ -7,3 +7,15 @@ final ttsServiceProvider = Provider<TtsService>((ref) {
   ref.onDispose(tts.dispose);
   return tts;
 });
+
+/// Whether TTS is currently playing audio. Used by hands-free controller
+/// to pause VAD during playback (avoids mic picking up speaker output).
+final ttsPlayingProvider = Provider<bool>((ref) {
+  final tts = ref.watch(ttsServiceProvider);
+  final notifier = tts.isSpeaking;
+  // Bridge ValueListenable → Riverpod: invalidate self on each change.
+  void listener() => ref.invalidateSelf();
+  notifier.addListener(listener);
+  ref.onDispose(() => notifier.removeListener(listener));
+  return notifier.value;
+});

--- a/lib/core/tts/tts_service.dart
+++ b/lib/core/tts/tts_service.dart
@@ -1,5 +1,10 @@
+import 'package:flutter/foundation.dart';
+
 abstract class TtsService {
   Future<void> speak(String text, {String? languageCode});
   Future<void> stop();
   void dispose();
+
+  /// Whether TTS is currently playing audio.
+  ValueListenable<bool> get isSpeaking;
 }

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -61,6 +61,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
 
   // ignore: prefer_final_fields — T3 mutates this field
   bool _suspendedForManualRecording = false;
+  bool _suspendedForTts = false;
 
   bool get isSuspendedForManualRecording => _suspendedForManualRecording;
 
@@ -123,13 +124,44 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     state = _listeningOrBacklog();
   }
 
+
+  // ── TTS suspension ──────────────────────────────────────────────────────
+
+  /// Pauses the VAD engine while TTS is playing to prevent the mic from
+  /// picking up speaker output.
+  Future<void> suspendForTts() async {
+    if (_suspendedForTts || _suspendedForManualRecording) return;
+    if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
+
+    if (state is HandsFreeCapturing) {
+      await _engine?.interruptCapture();
+    } else {
+      await _engineSub?.cancel();
+      await _engine?.stop();
+    }
+    _engineSub = null;
+    _engine = null;
+    _suspendedForTts = true;
+    state = _listeningOrBacklog();
+  }
+
+  /// Restarts the VAD engine after TTS finishes playing.
+  Future<void> resumeAfterTts() async {
+    if (!_suspendedForTts) return;
+    _suspendedForTts = false;
+    if (_suspendedForManualRecording) return;
+    _startEngine(_ref.read(appConfigProvider).vadConfig);
+    state = _listeningOrBacklog();
+  }
+
   // ── Background lifecycle ─────────────────────────────────────────────────
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused &&
         this.state is! HandsFreeIdle &&
-        !_triggeredByActivation) {
+        !_triggeredByActivation &&
+        !_ref.read(appConfigProvider).backgroundListeningEnabled) {
       _terminateWithError(
         'Interrupted: app backgrounded',
         requiresSettings: false,

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -54,6 +54,16 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
       }
     });
 
+    // Pause VAD while TTS is playing to avoid mic picking up speaker output.
+    ref.listen<bool>(ttsPlayingProvider, (prev, next) {
+      final hfCtrl = ref.read(handsFreeControllerProvider.notifier);
+      if (next) {
+        unawaited(hfCtrl.suspendForTts());
+      } else {
+        unawaited(hfCtrl.resumeAfterTts());
+      }
+    });
+
     final recState = ref.watch(recordingControllerProvider);
     final hfState = ref.watch(handsFreeControllerProvider);
     final recCtrl = ref.read(recordingControllerProvider.notifier);
@@ -82,9 +92,15 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
               child: _buildRecordingArea(context, recState, recCtrl),
             ),
           ),
-          _AgentReplyCard(reply: agentReply, onDismiss: () {
-            ref.read(latestAgentReplyProvider.notifier).state = null;
-          }),
+          _AgentReplyCard(
+            reply: agentReply,
+            isSpeaking: ref.watch(ttsPlayingProvider),
+            onStop: () => ref.read(ttsServiceProvider).stop(),
+            onDismiss: () {
+              unawaited(ref.read(ttsServiceProvider).stop());
+              ref.read(latestAgentReplyProvider.notifier).state = null;
+            },
+          ),
           _HandsFreeSection(
             hfState: hfState,
             onRetry: () => hfCtrl.startSession(),
@@ -147,9 +163,16 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
 // ── Agent reply card ─────────────────────────────────────────────────────────
 
 class _AgentReplyCard extends StatelessWidget {
-  const _AgentReplyCard({required this.reply, required this.onDismiss});
+  const _AgentReplyCard({
+    required this.reply,
+    required this.isSpeaking,
+    required this.onStop,
+    required this.onDismiss,
+  });
 
   final String? reply;
+  final bool isSpeaking;
+  final VoidCallback onStop;
   final VoidCallback onDismiss;
 
   @override
@@ -168,6 +191,13 @@ class _AgentReplyCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Expanded(child: Text(reply!)),
+                      if (isSpeaking)
+                        IconButton(
+                          key: const Key('agent-reply-stop'),
+                          icon: const Icon(Icons.stop_circle),
+                          onPressed: onStop,
+                          tooltip: 'Stop speaking',
+                        ),
                       IconButton(
                         key: const Key('agent-reply-dismiss'),
                         icon: const Icon(Icons.close),

--- a/test/features/api_sync/sync_worker_test.dart
+++ b/test/features/api_sync/sync_worker_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -156,6 +157,7 @@ class FakeApiClient extends ApiClient {
 }
 
 class _SpyTtsService implements TtsService {
+  @override ValueListenable<bool> get isSpeaking => ValueNotifier(false);
   final List<String> log = [];
 
   @override

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';
@@ -272,12 +273,14 @@ class _TrackingHfEngine implements HandsFreeEngine {
 // ── Stubs ────────────────────────────────────────────────────────────────────
 
 class _StubTtsService implements TtsService {
+  @override ValueListenable<bool> get isSpeaking => ValueNotifier(false);
   @override Future<void> speak(String text, {String? languageCode}) async {}
   @override Future<void> stop() async {}
   @override void dispose() {}
 }
 
 class _SpyTtsService implements TtsService {
+  @override ValueListenable<bool> get isSpeaking => ValueNotifier(false);
   int stopCount = 0;
   @override Future<void> speak(String text, {String? languageCode}) async {}
   @override Future<void> stop() async { stopCount++; }

--- a/test/features/recording/presentation/recording_screen_hands_free_test.dart
+++ b/test/features/recording/presentation/recording_screen_hands_free_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'dart:async';
 
 import 'package:flutter/material.dart';
@@ -36,6 +37,7 @@ import '../../../helpers/stub_background_service.dart';
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
 class _StubTtsService implements TtsService {
+  @override ValueListenable<bool> get isSpeaking => ValueNotifier(false);
   @override Future<void> speak(String text, {String? languageCode}) async {}
   @override Future<void> stop() async {}
   @override void dispose() {}

--- a/test/features/recording/presentation/recording_screen_mic_button_test.dart
+++ b/test/features/recording/presentation/recording_screen_mic_button_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'dart:async';
 
 import 'package:flutter/material.dart';
@@ -115,12 +116,14 @@ class _FakeRecordingController extends RecordingController {
 // ── Stubs ────────────────────────────────────────────────────────────────────
 
 class _StubTtsService implements TtsService {
+  @override ValueListenable<bool> get isSpeaking => ValueNotifier(false);
   @override Future<void> speak(String text, {String? languageCode}) async {}
   @override Future<void> stop() async {}
   @override void dispose() {}
 }
 
 class _SpyTtsService implements TtsService {
+  @override ValueListenable<bool> get isSpeaking => ValueNotifier(false);
   int stopCount = 0;
   @override Future<void> speak(String text, {String? languageCode}) async {}
   @override Future<void> stop() async { stopCount++; }

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'dart:async';
 
 import 'package:flutter/material.dart';
@@ -75,6 +76,7 @@ class _FixedConfigService extends AppConfigService {
 }
 
 class _StubTtsService implements TtsService {
+  @override ValueListenable<bool> get isSpeaking => ValueNotifier(false);
   @override Future<void> speak(String text, {String? languageCode}) async {}
   @override Future<void> stop() async {}
   @override void dispose() {}

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -66,6 +67,7 @@ class _SeededConfigService extends AppConfigService {
 }
 
 class _StubTtsService implements TtsService {
+  @override ValueListenable<bool> get isSpeaking => ValueNotifier(false);
   @override Future<void> speak(String text, {String? languageCode}) async {}
   @override Future<void> stop() async {}
   @override void dispose() {}


### PR DESCRIPTION
## Summary
- Pause VAD engine during TTS playback to prevent mic from picking up speaker output
- Resume VAD automatically when TTS finishes
- Add stop button on agent reply card to manually interrupt TTS
- Allow hands-free sessions to survive backgrounding when background listening is enabled in settings

## Changes
- `TtsService`: added `isSpeaking` ValueListenable to track playback state
- `FlutterTtsService`: wired flutter_tts start/completion/cancel/error handlers
- `ttsPlayingProvider`: bridges TtsService.isSpeaking into Riverpod
- `HandsFreeController`: added `suspendForTts()`/`resumeAfterTts()` + background listening config check
- `RecordingScreen`: wires ttsPlayingProvider to pause/resume VAD, adds stop button to agent reply card
- All TtsService test stubs updated with `isSpeaking` override

## Test plan
- [x] `flutter analyze` passes
- [x] `flutter test` passes (407 tests)
