### PR TITLE
feat(core/network): extend ApiClient with generic HTTP methods

### DIFF
--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -23,10 +23,17 @@ class ApiTransientFailure extends ApiResult {
   final String reason;
 }
 
+class ApiNotConfigured extends ApiResult {
+  const ApiNotConfigured();
+}
+
 class ApiClient {
-  ApiClient({Dio? dio}) : _dio = dio ?? _createDefaultDio();
+  ApiClient({Dio? dio, this.baseUrl, this.token})
+      : _dio = dio ?? _createDefaultDio();
 
   final Dio _dio;
+  final String? baseUrl;
+  final String? token;
 
   static Dio _createDefaultDio() {
     return Dio(BaseOptions(
@@ -68,9 +75,9 @@ class ApiClient {
             data == null ? null : (data is String ? data : jsonEncode(data));
         return ApiSuccess(body: body);
       }
-      return _classifyStatusCode(statusCode, response.statusMessage);
+      return classifyStatusCode(statusCode, response.statusMessage);
     } on DioException catch (e) {
-      return _classifyDioException(e);
+      return classifyDioException(e);
     }
   }
 
@@ -97,13 +104,71 @@ class ApiClient {
       if (statusCode >= 200 && statusCode < 300) {
         return const ApiSuccess();
       }
-      return _classifyStatusCode(statusCode, response.statusMessage);
+      return classifyStatusCode(statusCode, response.statusMessage);
     } on DioException catch (e) {
-      return _classifyDioException(e);
+      return classifyDioException(e);
     }
   }
 
-  ApiResult _classifyStatusCode(int statusCode, String? message) {
+  Future<ApiResult> get(
+    String path, {
+    Map<String, dynamic>? queryParameters,
+  }) {
+    return request('GET', path, queryParameters: queryParameters);
+  }
+
+  Future<ApiResult> patch(
+    String path, {
+    Map<String, dynamic>? data,
+  }) {
+    return request('PATCH', path, data: data);
+  }
+
+  Future<ApiResult> delete(String path) {
+    return request('DELETE', path);
+  }
+
+  Future<ApiResult> request(
+    String method,
+    String path, {
+    Map<String, dynamic>? data,
+    Map<String, dynamic>? queryParameters,
+  }) async {
+    if (baseUrl == null) return const ApiNotConfigured();
+
+    final url = '$baseUrl$path';
+    try {
+      final response = await _dio.request<dynamic>(
+        url,
+        data: data,
+        queryParameters: queryParameters,
+        options: Options(
+          method: method,
+          headers: {
+            'Content-Type': 'application/json',
+            if (token != null && token!.isNotEmpty)
+              'Authorization': 'Bearer $token',
+          },
+        ),
+      );
+
+      final statusCode = response.statusCode ?? 0;
+      if (statusCode >= 200 && statusCode < 300) {
+        final dynamic responseData = response.data;
+        final String? body = responseData == null
+            ? null
+            : (responseData is String
+                ? responseData
+                : jsonEncode(responseData));
+        return ApiSuccess(body: body);
+      }
+      return classifyStatusCode(statusCode, response.statusMessage);
+    } on DioException catch (e) {
+      return classifyDioException(e);
+    }
+  }
+
+  ApiResult classifyStatusCode(int statusCode, String? message) {
     if (statusCode == 408 || statusCode == 429 || statusCode >= 500) {
       return ApiTransientFailure(
         reason: 'Server error: $statusCode ${message ?? ''}',
@@ -115,10 +180,10 @@ class ApiClient {
     );
   }
 
-  ApiResult _classifyDioException(DioException e) {
+  ApiResult classifyDioException(DioException e) {
     final statusCode = e.response?.statusCode;
     if (statusCode != null) {
-      return _classifyStatusCode(statusCode, e.response?.statusMessage);
+      return classifyStatusCode(statusCode, e.response?.statusMessage);
     }
 
     switch (e.type) {

--- a/lib/core/providers/api_client_provider.dart
+++ b/lib/core/providers/api_client_provider.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+
+final apiClientProvider = Provider<ApiClient>((ref) {
+  final config = ref.watch(appConfigProvider);
+  return ApiClient(
+    baseUrl: deriveBaseUrl(config.apiUrl),
+    token: config.apiToken,
+  );
+});
+
+String? deriveBaseUrl(String? apiUrl) {
+  if (apiUrl == null || apiUrl.isEmpty) return null;
+  final uri = Uri.tryParse(apiUrl);
+  if (uri == null) return null;
+  final segments = uri.pathSegments;
+  final apiIdx = segments.indexOf('api');
+  if (apiIdx == -1 || apiIdx + 1 >= segments.length) return null;
+  final baseSegments = segments.sublist(0, apiIdx + 2);
+  var result = uri.replace(pathSegments: baseSegments).toString();
+  if (result.endsWith('/')) {
+    result = result.substring(0, result.length - 1);
+  }
+  return result;
+}

--- a/lib/features/api_sync/sync_provider.dart
+++ b/lib/features/api_sync/sync_provider.dart
@@ -1,18 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
-import 'package:voice_agent/core/network/api_client.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
 import 'package:voice_agent/core/providers/agent_reply_provider.dart';
+import 'package:voice_agent/core/providers/api_client_provider.dart';
 import 'package:voice_agent/core/providers/app_foreground_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/features/api_sync/api_config.dart';
 import 'package:voice_agent/features/api_sync/sync_worker.dart';
-
-final apiClientProvider = Provider<ApiClient>((ref) {
-  return ApiClient();
-});
 
 final connectivityServiceProvider = Provider<ConnectivityService>((ref) {
   return ConnectivityService();

--- a/lib/features/api_sync/sync_worker.dart
+++ b/lib/features/api_sync/sync_worker.dart
@@ -151,6 +151,8 @@ class SyncWorker {
           await storageService.markFailed(item.id, reason);
         }
         unawaited(audioFeedbackService.playError());
+      case ApiNotConfigured():
+        break;
     }
   }
 

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -8,10 +8,8 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:voice_agent/core/config/app_config.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/core/providers/api_client_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
-
-/// Provider for ApiClient — lives here to avoid settings importing api_sync.
-final _apiClientProvider = Provider<ApiClient>((ref) => ApiClient());
 
 class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
@@ -145,7 +143,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
     setState(() => _testStatus = _TestStatus.testing);
 
-    final apiClient = ref.read(_apiClientProvider);
+    final apiClient = ref.read(apiClientProvider);
     final token = _tokenController.text;
 
     final result = await apiClient.testConnection(
@@ -160,6 +158,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         ApiSuccess() => _TestStatus.success,
         ApiPermanentFailure() => _TestStatus.error,
         ApiTransientFailure() => _TestStatus.error,
+        ApiNotConfigured() => _TestStatus.error,
       };
     });
   }

--- a/test/core/network/api_client_test.dart
+++ b/test/core/network/api_client_test.dart
@@ -212,6 +212,145 @@ void main() {
       expect(parsed['language'], 'pl');
     });
   });
+
+  group('Generic methods', () {
+    late ApiClient configuredClient;
+
+    setUp(() {
+      dio = Dio();
+      dio.httpClientAdapter = _MockAdapter();
+      configuredClient = ApiClient(
+        dio: dio,
+        baseUrl: 'https://agent.jarco.casa/api/v1',
+        token: 'test-token',
+      );
+    });
+
+    test('get sends GET with correct URL', () async {
+      _MockAdapter.nextStatusCode = 200;
+      _MockAdapter.lastRequestMethod = null;
+
+      final result = await configuredClient.get('/agenda',
+          queryParameters: {'date': '2026-04-18'});
+
+      expect(result, isA<ApiSuccess>());
+      expect(_MockAdapter.lastRequestPath,
+          'https://agent.jarco.casa/api/v1/agenda');
+      expect(_MockAdapter.lastRequestMethod, 'GET');
+    });
+
+    test('request sends POST with data', () async {
+      _MockAdapter.nextStatusCode = 200;
+
+      final result = await configuredClient.request(
+        'POST',
+        '/records/abc/done',
+        data: {'note': 'completed'},
+      );
+
+      expect(result, isA<ApiSuccess>());
+      expect(_MockAdapter.lastRequestPath,
+          'https://agent.jarco.casa/api/v1/records/abc/done');
+      expect(_MockAdapter.lastRequestMethod, 'POST');
+      expect(
+        (_MockAdapter.lastRequestData as Map<String, dynamic>)['note'],
+        'completed',
+      );
+    });
+
+    test('patch sends PATCH with data', () async {
+      _MockAdapter.nextStatusCode = 200;
+
+      final result = await configuredClient.patch(
+        '/routines/abc/occurrences/xyz',
+        data: {'status': 'done'},
+      );
+
+      expect(result, isA<ApiSuccess>());
+      expect(_MockAdapter.lastRequestMethod, 'PATCH');
+    });
+
+    test('delete sends DELETE', () async {
+      _MockAdapter.nextStatusCode = 200;
+
+      final result =
+          await configuredClient.delete('/conversations/abc/events/xyz');
+
+      expect(result, isA<ApiSuccess>());
+      expect(_MockAdapter.lastRequestMethod, 'DELETE');
+    });
+
+    test('injects Authorization header', () async {
+      _MockAdapter.nextStatusCode = 200;
+      _MockAdapter.lastHeaders = null;
+
+      await configuredClient.get('/plan');
+
+      expect(
+        _MockAdapter.lastHeaders?['Authorization'],
+        'Bearer test-token',
+      );
+    });
+
+    test('omits Authorization header when token is null', () async {
+      final noTokenClient = ApiClient(
+        dio: dio,
+        baseUrl: 'https://example.com/api/v1',
+      );
+      _MockAdapter.nextStatusCode = 200;
+      _MockAdapter.lastHeaders = null;
+
+      await noTokenClient.get('/plan');
+
+      expect(_MockAdapter.lastHeaders?['Authorization'], isNull);
+    });
+
+    test('returns ApiNotConfigured when baseUrl is null', () async {
+      final unconfigured = ApiClient(dio: dio);
+      final result = await unconfigured.get('/agenda');
+
+      expect(result, isA<ApiNotConfigured>());
+    });
+
+    test('classifies 500 as ApiTransientFailure', () async {
+      _MockAdapter.nextStatusCode = 500;
+
+      final result = await configuredClient.get('/plan');
+
+      expect(result, isA<ApiTransientFailure>());
+    });
+
+    test('classifies 400 as ApiPermanentFailure', () async {
+      _MockAdapter.nextStatusCode = 400;
+
+      final result = await configuredClient.get('/plan');
+
+      expect(result, isA<ApiPermanentFailure>());
+    });
+
+    test('no double slash in composed URL path', () async {
+      _MockAdapter.nextStatusCode = 200;
+
+      await configuredClient.get('/agenda');
+
+      final path = _MockAdapter.lastRequestPath!;
+      final afterScheme = path.replaceFirst(RegExp(r'https?://'), '');
+      expect(afterScheme, isNot(contains('//')));
+    });
+
+    test('200 response body is valid JSON', () async {
+      _MockAdapter.nextStatusCode = 200;
+      _MockAdapter.nextResponseBody = '{"data": {"items": []}}';
+
+      final result = await configuredClient.get('/agenda');
+
+      expect(result, isA<ApiSuccess>());
+      final body = (result as ApiSuccess).body;
+      expect(body, isNotNull);
+      final parsed = jsonDecode(body!) as Map<String, dynamic>;
+      expect(parsed['data'], isA<Map>());
+    });
+  });
 }
 
 class _MockAdapter implements HttpClientAdapter {
@@ -220,6 +359,8 @@ class _MockAdapter implements HttpClientAdapter {
   static DioException? shouldThrow;
   static dynamic lastRequestData;
   static Map<String, dynamic>? lastHeaders;
+  static String? lastRequestMethod;
+  static String? lastRequestPath;
 
   @override
   Future<ResponseBody> fetch(
@@ -229,6 +370,8 @@ class _MockAdapter implements HttpClientAdapter {
   ) async {
     lastRequestData = options.data;
     lastHeaders = options.headers;
+    lastRequestMethod = options.method;
+    lastRequestPath = options.path;
 
     if (shouldThrow != null) {
       final e = shouldThrow!;

--- a/test/core/providers/api_client_provider_test.dart
+++ b/test/core/providers/api_client_provider_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/providers/api_client_provider.dart';
+
+void main() {
+  group('deriveBaseUrl', () {
+    test('extracts base URL from voice transcript endpoint', () {
+      expect(
+        deriveBaseUrl('https://agent.jarco.casa/api/v1/voice/transcript'),
+        'https://agent.jarco.casa/api/v1',
+      );
+    });
+
+    test('extracts base URL with port', () {
+      expect(
+        deriveBaseUrl('http://localhost:8888/api/v1/voice/transcript'),
+        'http://localhost:8888/api/v1',
+      );
+    });
+
+    test('handles URL with only /api/v1', () {
+      expect(
+        deriveBaseUrl('https://example.com/api/v1'),
+        'https://example.com/api/v1',
+      );
+    });
+
+    test('handles URL with trailing slash after /api/v1/', () {
+      expect(
+        deriveBaseUrl('https://example.com/api/v1/'),
+        'https://example.com/api/v1',
+      );
+    });
+
+    test('returns null for null input', () {
+      expect(deriveBaseUrl(null), isNull);
+    });
+
+    test('returns null for empty input', () {
+      expect(deriveBaseUrl(''), isNull);
+    });
+
+    test('returns null for URL without /api segment', () {
+      expect(deriveBaseUrl('https://example.com/other/path'), isNull);
+    });
+
+    test('returns null for URL with /api but no version segment', () {
+      expect(deriveBaseUrl('https://example.com/api'), isNull);
+    });
+
+    test('returns null for invalid URL', () {
+      expect(deriveBaseUrl('not a url'), isNull);
+    });
+
+    test('handles different API versions', () {
+      expect(
+        deriveBaseUrl('https://example.com/api/v2/voice/transcript'),
+        'https://example.com/api/v2',
+      );
+    });
+
+    test('result never ends with slash', () {
+      final result =
+          deriveBaseUrl('https://example.com/api/v1/voice/transcript');
+      expect(result, isNotNull);
+      expect(result!.endsWith('/'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
P025-T1: Extend ApiClient with generic HTTP methods

## Summary
- Add generic get/request/patch/delete methods to ApiClient with base URL composition and auth injection
- Add ApiNotConfigured as fourth ApiResult subtype
- Promote classify methods to public for SseClient reuse
- Move apiClientProvider to core/providers
- Update exhaustive switches in SyncWorker and SettingsScreen

Closes #171
