### PR TITLE
feat(core/network): add SseClient for SSE streaming

### DIFF
--- a/lib/core/network/sse_client.dart
+++ b/lib/core/network/sse_client.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+
+class SseEvent {
+  const SseEvent({this.event, required this.data, this.id});
+  final String? event;
+  final String data;
+  final String? id;
+}
+
+class SseClient {
+  SseClient({required this.apiClient, Dio? dio})
+      : _dio = dio ?? _createSseDio();
+
+  final ApiClient apiClient;
+  final Dio _dio;
+
+  static Dio _createSseDio() {
+    return Dio(BaseOptions(
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(minutes: 10),
+      followRedirects: false,
+      maxRedirects: 0,
+      responseType: ResponseType.stream,
+    ));
+  }
+
+  Stream<SseEvent> post(
+    String path, {
+    required Map<String, dynamic> data,
+  }) {
+    final controller = StreamController<SseEvent>();
+
+    if (apiClient.baseUrl == null) {
+      controller.addError(const ApiNotConfigured());
+      controller.close();
+      return controller.stream;
+    }
+
+    final url = '${apiClient.baseUrl}$path';
+    _startStream(controller, url, data);
+
+    return controller.stream;
+  }
+
+  Future<void> _startStream(
+    StreamController<SseEvent> controller,
+    String url,
+    Map<String, dynamic> data,
+  ) async {
+    try {
+      final response = await _dio.post<ResponseBody>(
+        url,
+        data: data,
+        options: Options(
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'text/event-stream',
+            if (apiClient.token != null && apiClient.token!.isNotEmpty)
+              'Authorization': 'Bearer ${apiClient.token}',
+          },
+          responseType: ResponseType.stream,
+        ),
+      );
+
+      final stream = response.data!.stream;
+      String buffer = '';
+      String? currentEvent;
+      String? currentId;
+      final dataLines = <String>[];
+
+      await for (final chunk in stream) {
+        buffer += utf8.decode(chunk);
+        while (buffer.contains('\n')) {
+          final newlineIndex = buffer.indexOf('\n');
+          var line = buffer.substring(0, newlineIndex);
+          buffer = buffer.substring(newlineIndex + 1);
+
+          if (line.endsWith('\r')) {
+            line = line.substring(0, line.length - 1);
+          }
+
+          if (line.isEmpty) {
+            if (dataLines.isNotEmpty) {
+              controller.add(SseEvent(
+                event: currentEvent,
+                data: dataLines.join('\n'),
+                id: currentId,
+              ));
+            }
+            currentEvent = null;
+            currentId = null;
+            dataLines.clear();
+          } else if (line.startsWith('data:')) {
+            dataLines.add(line.substring(5).trimLeft());
+          } else if (line.startsWith('event:')) {
+            currentEvent = line.substring(6).trimLeft();
+          } else if (line.startsWith('id:')) {
+            currentId = line.substring(3).trimLeft();
+          }
+          // Lines starting with ':' are comments — ignored
+        }
+      }
+
+      if (dataLines.isNotEmpty) {
+        controller.add(SseEvent(
+          event: currentEvent,
+          data: dataLines.join('\n'),
+          id: currentId,
+        ));
+      }
+
+      await controller.close();
+    } on DioException catch (e) {
+      controller.addError(apiClient.classifyDioException(e));
+      await controller.close();
+    }
+  }
+}

--- a/lib/core/network/sse_client.dart
+++ b/lib/core/network/sse_client.dart
@@ -117,6 +117,9 @@ class SseClient {
     } on DioException catch (e) {
       controller.addError(apiClient.classifyDioException(e));
       await controller.close();
+    } catch (e) {
+      controller.addError(e);
+      await controller.close();
     }
   }
 }

--- a/test/core/network/sse_client_test.dart
+++ b/test/core/network/sse_client_test.dart
@@ -1,0 +1,272 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/core/network/sse_client.dart';
+
+void main() {
+  late Dio mockDio;
+  late ApiClient apiClient;
+  late SseClient sseClient;
+
+  setUp(() {
+    mockDio = Dio();
+    mockDio.httpClientAdapter = _SseMockAdapter();
+    apiClient = ApiClient(
+      baseUrl: 'https://example.com/api/v1',
+      token: 'test-token',
+    );
+    sseClient = SseClient(apiClient: apiClient, dio: mockDio);
+  });
+
+  group('SseClient', () {
+    test('emits ApiNotConfigured when baseUrl is null', () async {
+      final unconfigured = ApiClient();
+      final client = SseClient(apiClient: unconfigured, dio: mockDio);
+
+      final errors = <Object>[];
+      final done = Completer<void>();
+
+      client.post('/chat', data: {'message': 'hi'}).listen(
+        (_) {},
+        onError: errors.add,
+        onDone: done.complete,
+      );
+
+      await done.future;
+
+      expect(errors, hasLength(1));
+      expect(errors.first, isA<ApiNotConfigured>());
+    });
+
+    test('parses single SSE event', () async {
+      _SseMockAdapter.nextChunks = [
+        'event: message\ndata: hello\nid: 1\n\n',
+      ];
+
+      final events =
+          await sseClient.post('/chat', data: {'q': 'hi'}).toList();
+
+      expect(events, hasLength(1));
+      expect(events[0].event, 'message');
+      expect(events[0].data, 'hello');
+      expect(events[0].id, '1');
+    });
+
+    test('parses multiple SSE events from single chunk', () async {
+      _SseMockAdapter.nextChunks = [
+        'data: first\n\ndata: second\n\n',
+      ];
+
+      final events =
+          await sseClient.post('/chat', data: {'q': 'hi'}).toList();
+
+      expect(events, hasLength(2));
+      expect(events[0].data, 'first');
+      expect(events[1].data, 'second');
+    });
+
+    test('joins multi-line data fields', () async {
+      _SseMockAdapter.nextChunks = [
+        'data: line one\ndata: line two\ndata: line three\n\n',
+      ];
+
+      final events =
+          await sseClient.post('/chat', data: {'q': 'hi'}).toList();
+
+      expect(events, hasLength(1));
+      expect(events[0].data, 'line one\nline two\nline three');
+    });
+
+    test('handles chunks split across boundaries', () async {
+      _SseMockAdapter.nextChunks = [
+        'data: hel',
+        'lo\n\n',
+      ];
+
+      final events =
+          await sseClient.post('/chat', data: {'q': 'hi'}).toList();
+
+      expect(events, hasLength(1));
+      expect(events[0].data, 'hello');
+    });
+
+    test('strips carriage returns', () async {
+      _SseMockAdapter.nextChunks = [
+        'data: hello\r\n\r\n',
+      ];
+
+      final events =
+          await sseClient.post('/chat', data: {'q': 'hi'}).toList();
+
+      expect(events, hasLength(1));
+      expect(events[0].data, 'hello');
+    });
+
+    test('ignores comment lines', () async {
+      _SseMockAdapter.nextChunks = [
+        ': this is a comment\ndata: real data\n\n',
+      ];
+
+      final events =
+          await sseClient.post('/chat', data: {'q': 'hi'}).toList();
+
+      expect(events, hasLength(1));
+      expect(events[0].data, 'real data');
+    });
+
+    test('emits trailing event without final blank line', () async {
+      _SseMockAdapter.nextChunks = [
+        'data: trailing\n',
+      ];
+
+      final events =
+          await sseClient.post('/chat', data: {'q': 'hi'}).toList();
+
+      expect(events, hasLength(1));
+      expect(events[0].data, 'trailing');
+    });
+
+    test('event field is null when not specified', () async {
+      _SseMockAdapter.nextChunks = [
+        'data: no event type\n\n',
+      ];
+
+      final events =
+          await sseClient.post('/chat', data: {'q': 'hi'}).toList();
+
+      expect(events, hasLength(1));
+      expect(events[0].event, isNull);
+      expect(events[0].id, isNull);
+    });
+
+    test('does not emit event for empty data', () async {
+      _SseMockAdapter.nextChunks = [
+        'event: ping\n\n',
+      ];
+
+      final events =
+          await sseClient.post('/chat', data: {'q': 'hi'}).toList();
+
+      expect(events, isEmpty);
+    });
+
+    test('propagates DioException as classified ApiResult error', () async {
+      _SseMockAdapter.shouldThrow = DioException(
+        requestOptions: RequestOptions(path: '/chat'),
+        type: DioExceptionType.connectionTimeout,
+      );
+
+      final errors = <Object>[];
+      final done = Completer<void>();
+
+      sseClient.post('/chat', data: {'q': 'hi'}).listen(
+        (_) {},
+        onError: errors.add,
+        onDone: done.complete,
+      );
+
+      await done.future;
+
+      expect(errors, hasLength(1));
+      expect(errors.first, isA<ApiTransientFailure>());
+    });
+
+    test('sends Authorization header', () async {
+      _SseMockAdapter.nextChunks = ['data: ok\n\n'];
+      _SseMockAdapter.lastHeaders = null;
+
+      await sseClient.post('/chat', data: {'q': 'hi'}).toList();
+
+      expect(
+        _SseMockAdapter.lastHeaders?['Authorization'],
+        'Bearer test-token',
+      );
+    });
+
+    test('omits Authorization when token is null', () async {
+      final noTokenClient = ApiClient(
+        baseUrl: 'https://example.com/api/v1',
+      );
+      final client = SseClient(apiClient: noTokenClient, dio: mockDio);
+
+      _SseMockAdapter.nextChunks = ['data: ok\n\n'];
+      _SseMockAdapter.lastHeaders = null;
+
+      await client.post('/chat', data: {'q': 'hi'}).toList();
+
+      expect(_SseMockAdapter.lastHeaders?['Authorization'], isNull);
+    });
+
+    test('sends Accept text/event-stream header', () async {
+      _SseMockAdapter.nextChunks = ['data: ok\n\n'];
+      _SseMockAdapter.lastHeaders = null;
+
+      await sseClient.post('/chat', data: {'q': 'hi'}).toList();
+
+      expect(
+        _SseMockAdapter.lastHeaders?['Accept'],
+        'text/event-stream',
+      );
+    });
+
+    test('composes correct URL from baseUrl and path', () async {
+      _SseMockAdapter.nextChunks = ['data: ok\n\n'];
+
+      await sseClient.post('/conversations/chat', data: {'q': 'hi'}).toList();
+
+      expect(
+        _SseMockAdapter.lastRequestPath,
+        'https://example.com/api/v1/conversations/chat',
+      );
+    });
+  });
+}
+
+class _SseMockAdapter implements HttpClientAdapter {
+  static List<String> nextChunks = [];
+  static DioException? shouldThrow;
+  static Map<String, dynamic>? lastHeaders;
+  static String? lastRequestPath;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    lastHeaders = options.headers;
+    lastRequestPath = options.path;
+
+    if (shouldThrow != null) {
+      final e = shouldThrow!;
+      shouldThrow = null;
+      throw e;
+    }
+
+    final chunks = nextChunks;
+    nextChunks = [];
+
+    final controller = StreamController<Uint8List>();
+    Future<void>.delayed(Duration.zero, () async {
+      for (final chunk in chunks) {
+        controller.add(Uint8List.fromList(utf8.encode(chunk)));
+      }
+      await controller.close();
+    });
+
+    return ResponseBody(
+      controller.stream,
+      200,
+      headers: {
+        'content-type': ['text/event-stream'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}


### PR DESCRIPTION
## Summary
- Add `SseClient` for streaming server-sent events over POST requests
- Dedicated Dio instance with 10-minute receive timeout for long-running chat streams
- Full SSE spec parsing: multi-line data, event types, IDs, comment ignoring, CR/LF handling
- Delegates URL composition and auth to `ApiClient`, emits `ApiNotConfigured` when not configured
- 15 unit tests covering parsing, chunked boundaries, error propagation, and auth headers

## Test plan
- [x] `flutter analyze` passes with zero issues
- [x] `flutter test test/core/network/sse_client_test.dart` — 15/15 pass

Closes #175
