### PR TITLE
feat(core/models): add shared domain models for backend API

### DIFF
--- a/lib/core/models/agenda.dart
+++ b/lib/core/models/agenda.dart
@@ -24,12 +24,15 @@ class AgendaResponse {
       granularity: map['granularity'] as String,
       from: map['from'] as String,
       to: map['to'] as String,
-      items: (map['items'] as List<dynamic>)
-          .map((e) => AgendaItem.fromMap(e as Map<String, dynamic>))
-          .toList(),
-      routineItems: (map['routine_items'] as List<dynamic>)
-          .map((e) => AgendaRoutineItem.fromMap(e as Map<String, dynamic>))
-          .toList(),
+      items: (map['items'] as List<dynamic>?)
+              ?.map((e) => AgendaItem.fromMap(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+      routineItems: (map['routine_items'] as List<dynamic>?)
+              ?.map(
+                  (e) => AgendaRoutineItem.fromMap(e as Map<String, dynamic>))
+              .toList() ??
+          [],
     );
   }
 
@@ -61,7 +64,7 @@ class AgendaItem {
   final String text;
   final String? topicRef;
   final String scheduledFor;
-  final String timeWindow;
+  final TimeWindow timeWindow;
   final OriginRole originRole;
   final RecordStatus status;
   final int linkedConversationCount;
@@ -72,7 +75,7 @@ class AgendaItem {
       text: map['text'] as String,
       topicRef: map['topic_ref'] as String?,
       scheduledFor: map['scheduled_for'] as String,
-      timeWindow: map['time_window'] as String,
+      timeWindow: TimeWindow.fromString(map['time_window'] as String),
       originRole: OriginRole.fromString(map['origin_role'] as String),
       status: RecordStatus.fromString(map['status'] as String),
       linkedConversationCount: map['linked_conversation_count'] as int,
@@ -85,7 +88,7 @@ class AgendaItem {
       'text': text,
       'topic_ref': topicRef,
       'scheduled_for': scheduledFor,
-      'time_window': timeWindow,
+      'time_window': timeWindow.toJson(),
       'origin_role': originRole.name,
       'status': status.name,
       'linked_conversation_count': linkedConversationCount,

--- a/lib/core/models/agenda.dart
+++ b/lib/core/models/agenda.dart
@@ -1,0 +1,144 @@
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/models/routine.dart';
+
+class AgendaResponse {
+  const AgendaResponse({
+    required this.date,
+    required this.granularity,
+    required this.from,
+    required this.to,
+    required this.items,
+    required this.routineItems,
+  });
+
+  final String date;
+  final String granularity;
+  final String from;
+  final String to;
+  final List<AgendaItem> items;
+  final List<AgendaRoutineItem> routineItems;
+
+  factory AgendaResponse.fromMap(Map<String, dynamic> map) {
+    return AgendaResponse(
+      date: map['date'] as String,
+      granularity: map['granularity'] as String,
+      from: map['from'] as String,
+      to: map['to'] as String,
+      items: (map['items'] as List<dynamic>)
+          .map((e) => AgendaItem.fromMap(e as Map<String, dynamic>))
+          .toList(),
+      routineItems: (map['routine_items'] as List<dynamic>)
+          .map((e) => AgendaRoutineItem.fromMap(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'date': date,
+      'granularity': granularity,
+      'from': from,
+      'to': to,
+      'items': items.map((i) => i.toMap()).toList(),
+      'routine_items': routineItems.map((i) => i.toMap()).toList(),
+    };
+  }
+}
+
+class AgendaItem {
+  const AgendaItem({
+    required this.recordId,
+    required this.text,
+    this.topicRef,
+    required this.scheduledFor,
+    required this.timeWindow,
+    required this.originRole,
+    required this.status,
+    required this.linkedConversationCount,
+  });
+
+  final String recordId;
+  final String text;
+  final String? topicRef;
+  final String scheduledFor;
+  final String timeWindow;
+  final OriginRole originRole;
+  final RecordStatus status;
+  final int linkedConversationCount;
+
+  factory AgendaItem.fromMap(Map<String, dynamic> map) {
+    return AgendaItem(
+      recordId: map['record_id'] as String,
+      text: map['text'] as String,
+      topicRef: map['topic_ref'] as String?,
+      scheduledFor: map['scheduled_for'] as String,
+      timeWindow: map['time_window'] as String,
+      originRole: OriginRole.fromString(map['origin_role'] as String),
+      status: RecordStatus.fromString(map['status'] as String),
+      linkedConversationCount: map['linked_conversation_count'] as int,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'record_id': recordId,
+      'text': text,
+      'topic_ref': topicRef,
+      'scheduled_for': scheduledFor,
+      'time_window': timeWindow,
+      'origin_role': originRole.name,
+      'status': status.name,
+      'linked_conversation_count': linkedConversationCount,
+    };
+  }
+}
+
+class AgendaRoutineItem {
+  const AgendaRoutineItem({
+    required this.routineId,
+    required this.routineName,
+    required this.scheduledFor,
+    this.startTime,
+    required this.overdue,
+    required this.status,
+    this.occurrenceId,
+    required this.templates,
+  });
+
+  final String routineId;
+  final String routineName;
+  final String scheduledFor;
+  final String? startTime;
+  final bool overdue;
+  final OccurrenceStatus status;
+  final String? occurrenceId;
+  final List<RoutineTemplate> templates;
+
+  factory AgendaRoutineItem.fromMap(Map<String, dynamic> map) {
+    return AgendaRoutineItem(
+      routineId: map['routine_id'] as String,
+      routineName: map['routine_name'] as String,
+      scheduledFor: map['scheduled_for'] as String,
+      startTime: map['start_time'] as String?,
+      overdue: map['overdue'] as bool,
+      status: OccurrenceStatus.fromString(map['status'] as String),
+      occurrenceId: map['occurrence_id'] as String?,
+      templates: (map['templates'] as List<dynamic>)
+          .map((e) => RoutineTemplate.fromMap(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'routine_id': routineId,
+      'routine_name': routineName,
+      'scheduled_for': scheduledFor,
+      'start_time': startTime,
+      'overdue': overdue,
+      'status': status.toJson(),
+      'occurrence_id': occurrenceId,
+      'templates': templates.map((t) => t.toMap()).toList(),
+    };
+  }
+}

--- a/lib/core/models/conversation.dart
+++ b/lib/core/models/conversation.dart
@@ -1,0 +1,121 @@
+enum ConversationStatus {
+  open,
+  closed;
+
+  static ConversationStatus fromString(String value) {
+    return ConversationStatus.values.firstWhere((e) => e.name == value);
+  }
+}
+
+enum EventRole {
+  user,
+  agent;
+
+  static EventRole fromString(String value) {
+    return EventRole.values.firstWhere((e) => e.name == value);
+  }
+}
+
+class Conversation {
+  const Conversation({
+    required this.conversationId,
+    required this.sessionId,
+    required this.status,
+    required this.createdAt,
+    required this.eventCount,
+    this.lastEventAt,
+    this.firstMessagePreview,
+    this.subjectRecordId,
+    this.subjectRecordText,
+    this.subjectRecordStatus,
+  });
+
+  final String conversationId;
+  final String sessionId;
+  final ConversationStatus status;
+  final DateTime createdAt;
+  final int eventCount;
+  final DateTime? lastEventAt;
+  final String? firstMessagePreview;
+  final String? subjectRecordId;
+  final String? subjectRecordText;
+  final String? subjectRecordStatus;
+
+  factory Conversation.fromMap(Map<String, dynamic> map) {
+    return Conversation(
+      conversationId: map['conversation_id'] as String,
+      sessionId: map['session_id'] as String,
+      status: ConversationStatus.fromString(map['status'] as String),
+      createdAt: DateTime.parse(map['created_at'] as String),
+      eventCount: map['event_count'] as int,
+      lastEventAt: map['last_event_at'] != null
+          ? DateTime.parse(map['last_event_at'] as String)
+          : null,
+      firstMessagePreview: map['first_message_preview'] as String?,
+      subjectRecordId: map['subject_record_id'] as String?,
+      subjectRecordText: map['subject_record_text'] as String?,
+      subjectRecordStatus: map['subject_record_status'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'conversation_id': conversationId,
+      'session_id': sessionId,
+      'status': status.name,
+      'created_at': createdAt.toIso8601String(),
+      'event_count': eventCount,
+      'last_event_at': lastEventAt?.toIso8601String(),
+      'first_message_preview': firstMessagePreview,
+      'subject_record_id': subjectRecordId,
+      'subject_record_text': subjectRecordText,
+      'subject_record_status': subjectRecordStatus,
+    };
+  }
+}
+
+class ConversationEvent {
+  const ConversationEvent({
+    required this.eventId,
+    required this.conversationId,
+    required this.sequence,
+    required this.role,
+    required this.content,
+    this.occurredAt,
+    required this.receivedAt,
+  });
+
+  final String eventId;
+  final String conversationId;
+  final int sequence;
+  final EventRole role;
+  final String content;
+  final DateTime? occurredAt;
+  final DateTime receivedAt;
+
+  factory ConversationEvent.fromMap(Map<String, dynamic> map) {
+    return ConversationEvent(
+      eventId: map['event_id'] as String,
+      conversationId: map['conversation_id'] as String,
+      sequence: map['sequence'] as int,
+      role: EventRole.fromString(map['role'] as String),
+      content: map['content'] as String,
+      occurredAt: map['occurred_at'] != null
+          ? DateTime.parse(map['occurred_at'] as String)
+          : null,
+      receivedAt: DateTime.parse(map['received_at'] as String),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'event_id': eventId,
+      'conversation_id': conversationId,
+      'sequence': sequence,
+      'role': role.name,
+      'content': content,
+      'occurred_at': occurredAt?.toIso8601String(),
+      'received_at': receivedAt.toIso8601String(),
+    };
+  }
+}

--- a/lib/core/models/conversation.dart
+++ b/lib/core/models/conversation.dart
@@ -3,7 +3,9 @@ enum ConversationStatus {
   closed;
 
   static ConversationStatus fromString(String value) {
-    return ConversationStatus.values.firstWhere((e) => e.name == value);
+    return ConversationStatus.values.firstWhere((e) => e.name == value,
+        orElse: () =>
+            throw ArgumentError('Unknown ConversationStatus: $value'));
   }
 }
 
@@ -12,7 +14,8 @@ enum EventRole {
   agent;
 
   static EventRole fromString(String value) {
-    return EventRole.values.firstWhere((e) => e.name == value);
+    return EventRole.values.firstWhere((e) => e.name == value,
+        orElse: () => throw ArgumentError('Unknown EventRole: $value'));
   }
 }
 

--- a/lib/core/models/conversation_record.dart
+++ b/lib/core/models/conversation_record.dart
@@ -49,7 +49,8 @@ enum RecordStatus {
   done;
 
   static RecordStatus fromString(String value) {
-    return RecordStatus.values.firstWhere((e) => e.name == value);
+    return RecordStatus.values.firstWhere((e) => e.name == value,
+        orElse: () => throw ArgumentError('Unknown RecordStatus: $value'));
   }
 }
 
@@ -59,7 +60,8 @@ enum OriginRole {
   system;
 
   static OriginRole fromString(String value) {
-    return OriginRole.values.firstWhere((e) => e.name == value);
+    return OriginRole.values.firstWhere((e) => e.name == value,
+        orElse: () => throw ArgumentError('Unknown OriginRole: $value'));
   }
 }
 

--- a/lib/core/models/conversation_record.dart
+++ b/lib/core/models/conversation_record.dart
@@ -1,0 +1,121 @@
+enum RecordType {
+  topic,
+  question,
+  decision,
+  actionItem,
+  constraint,
+  preference,
+  summaryNote,
+  suggestion,
+  journalNote,
+  routineProposal;
+
+  static RecordType fromString(String value) {
+    return switch (value) {
+      'topic' => RecordType.topic,
+      'question' => RecordType.question,
+      'decision' => RecordType.decision,
+      'action_item' => RecordType.actionItem,
+      'constraint' => RecordType.constraint,
+      'preference' => RecordType.preference,
+      'summary_note' => RecordType.summaryNote,
+      'suggestion' => RecordType.suggestion,
+      'journal_note' => RecordType.journalNote,
+      'routine_proposal' => RecordType.routineProposal,
+      _ => throw ArgumentError('Unknown RecordType: $value'),
+    };
+  }
+
+  String toJson() {
+    return switch (this) {
+      RecordType.topic => 'topic',
+      RecordType.question => 'question',
+      RecordType.decision => 'decision',
+      RecordType.actionItem => 'action_item',
+      RecordType.constraint => 'constraint',
+      RecordType.preference => 'preference',
+      RecordType.summaryNote => 'summary_note',
+      RecordType.suggestion => 'suggestion',
+      RecordType.journalNote => 'journal_note',
+      RecordType.routineProposal => 'routine_proposal',
+    };
+  }
+}
+
+enum RecordStatus {
+  active,
+  superseded,
+  promoted,
+  done;
+
+  static RecordStatus fromString(String value) {
+    return RecordStatus.values.firstWhere((e) => e.name == value);
+  }
+}
+
+enum OriginRole {
+  user,
+  agent,
+  system;
+
+  static OriginRole fromString(String value) {
+    return OriginRole.values.firstWhere((e) => e.name == value);
+  }
+}
+
+class ConversationRecord {
+  const ConversationRecord({
+    required this.recordId,
+    required this.conversationId,
+    required this.recordType,
+    required this.subjectRef,
+    required this.payload,
+    required this.confidence,
+    required this.originRole,
+    required this.assertionMode,
+    required this.userEndorsed,
+    required this.sourceEventRefs,
+  });
+
+  final String recordId;
+  final String conversationId;
+  final RecordType recordType;
+  final String subjectRef;
+  final Map<String, dynamic> payload;
+  final double confidence;
+  final OriginRole originRole;
+  final String assertionMode;
+  final bool userEndorsed;
+  final List<String> sourceEventRefs;
+
+  factory ConversationRecord.fromMap(Map<String, dynamic> map) {
+    return ConversationRecord(
+      recordId: map['record_id'] as String,
+      conversationId: map['conversation_id'] as String,
+      recordType: RecordType.fromString(map['record_type'] as String),
+      subjectRef: map['subject_ref'] as String,
+      payload: Map<String, dynamic>.from(map['payload'] as Map),
+      confidence: (map['confidence'] as num).toDouble(),
+      originRole: OriginRole.fromString(map['origin_role'] as String),
+      assertionMode: map['assertion_mode'] as String,
+      userEndorsed: map['user_endorsed'] as bool,
+      sourceEventRefs: (map['source_event_refs'] as List<dynamic>)
+          .cast<String>(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'record_id': recordId,
+      'conversation_id': conversationId,
+      'record_type': recordType.toJson(),
+      'subject_ref': subjectRef,
+      'payload': payload,
+      'confidence': confidence,
+      'origin_role': originRole.name,
+      'assertion_mode': assertionMode,
+      'user_endorsed': userEndorsed,
+      'source_event_refs': sourceEventRefs,
+    };
+  }
+}

--- a/lib/core/models/plan.dart
+++ b/lib/core/models/plan.dart
@@ -1,0 +1,144 @@
+class PlanResponse {
+  const PlanResponse({
+    required this.topics,
+    required this.uncategorized,
+    required this.rules,
+    required this.rulesUncategorized,
+    required this.completed,
+    required this.completedUncategorized,
+    required this.totalCount,
+    required this.observedAt,
+  });
+
+  final List<PlanTopicGroup> topics;
+  final List<PlanEntry> uncategorized;
+  final List<PlanTopicGroup> rules;
+  final List<PlanEntry> rulesUncategorized;
+  final List<PlanTopicGroup> completed;
+  final List<PlanEntry> completedUncategorized;
+  final int totalCount;
+  final DateTime observedAt;
+
+  factory PlanResponse.fromMap(Map<String, dynamic> map) {
+    return PlanResponse(
+      topics: _parseTopicGroups(map['topics']),
+      uncategorized: _parsePlanEntries(map['uncategorized']),
+      rules: _parseTopicGroups(map['rules']),
+      rulesUncategorized: _parsePlanEntries(map['rules_uncategorized']),
+      completed: _parseTopicGroups(map['completed']),
+      completedUncategorized:
+          _parsePlanEntries(map['completed_uncategorized']),
+      totalCount: map['total_count'] as int,
+      observedAt: DateTime.parse(map['observed_at'] as String),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'topics': topics.map((t) => t.toMap()).toList(),
+      'uncategorized': uncategorized.map((e) => e.toMap()).toList(),
+      'rules': rules.map((t) => t.toMap()).toList(),
+      'rules_uncategorized':
+          rulesUncategorized.map((e) => e.toMap()).toList(),
+      'completed': completed.map((t) => t.toMap()).toList(),
+      'completed_uncategorized':
+          completedUncategorized.map((e) => e.toMap()).toList(),
+      'total_count': totalCount,
+      'observed_at': observedAt.toIso8601String(),
+    };
+  }
+
+  static List<PlanTopicGroup> _parseTopicGroups(dynamic value) {
+    if (value == null) return [];
+    return (value as List<dynamic>)
+        .map((e) => PlanTopicGroup.fromMap(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  static List<PlanEntry> _parsePlanEntries(dynamic value) {
+    if (value == null) return [];
+    return (value as List<dynamic>)
+        .map((e) => PlanEntry.fromMap(e as Map<String, dynamic>))
+        .toList();
+  }
+}
+
+class PlanTopicGroup {
+  const PlanTopicGroup({
+    required this.topicRef,
+    required this.canonicalName,
+    required this.items,
+  });
+
+  final String topicRef;
+  final String canonicalName;
+  final List<PlanEntry> items;
+
+  factory PlanTopicGroup.fromMap(Map<String, dynamic> map) {
+    return PlanTopicGroup(
+      topicRef: map['topic_ref'] as String,
+      canonicalName: map['canonical_name'] as String,
+      items: (map['items'] as List<dynamic>)
+          .map((e) => PlanEntry.fromMap(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'topic_ref': topicRef,
+      'canonical_name': canonicalName,
+      'items': items.map((i) => i.toMap()).toList(),
+    };
+  }
+}
+
+class PlanEntry {
+  const PlanEntry({
+    required this.entryId,
+    required this.displayText,
+    this.planBucket,
+    required this.confidence,
+    required this.conversationId,
+    required this.createdAt,
+    this.closedAt,
+    this.recordType,
+  });
+
+  final String entryId;
+  final String displayText;
+  final String? planBucket;
+  final double confidence;
+  final String conversationId;
+  final DateTime createdAt;
+  final DateTime? closedAt;
+  final String? recordType;
+
+  factory PlanEntry.fromMap(Map<String, dynamic> map) {
+    return PlanEntry(
+      entryId: map['entry_id'] as String,
+      displayText: map['display_text'] as String,
+      planBucket: map['plan_bucket'] as String?,
+      confidence: (map['confidence'] as num).toDouble(),
+      conversationId: map['conversation_id'] as String,
+      createdAt: DateTime.parse(map['created_at'] as String),
+      closedAt: map['closed_at'] != null
+          ? DateTime.parse(map['closed_at'] as String)
+          : null,
+      recordType: map['record_type'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'entry_id': entryId,
+      'display_text': displayText,
+      'plan_bucket': planBucket,
+      'confidence': confidence,
+      'conversation_id': conversationId,
+      'created_at': createdAt.toIso8601String(),
+      'closed_at': closedAt?.toIso8601String(),
+      'record_type': recordType,
+    };
+  }
+}

--- a/lib/core/models/routine.dart
+++ b/lib/core/models/routine.dart
@@ -5,7 +5,8 @@ enum RoutineStatus {
   archived;
 
   static RoutineStatus fromString(String value) {
-    return RoutineStatus.values.firstWhere((e) => e.name == value);
+    return RoutineStatus.values.firstWhere((e) => e.name == value,
+        orElse: () => throw ArgumentError('Unknown RoutineStatus: $value'));
   }
 }
 

--- a/lib/core/models/routine.dart
+++ b/lib/core/models/routine.dart
@@ -1,0 +1,307 @@
+enum RoutineStatus {
+  draft,
+  active,
+  paused,
+  archived;
+
+  static RoutineStatus fromString(String value) {
+    return RoutineStatus.values.firstWhere((e) => e.name == value);
+  }
+}
+
+enum OccurrenceStatus {
+  pending,
+  inProgress,
+  done,
+  skipped;
+
+  static OccurrenceStatus fromString(String value) {
+    return switch (value) {
+      'pending' => OccurrenceStatus.pending,
+      'in_progress' => OccurrenceStatus.inProgress,
+      'done' => OccurrenceStatus.done,
+      'skipped' => OccurrenceStatus.skipped,
+      _ => throw ArgumentError('Unknown OccurrenceStatus: $value'),
+    };
+  }
+
+  String toJson() {
+    return switch (this) {
+      OccurrenceStatus.pending => 'pending',
+      OccurrenceStatus.inProgress => 'in_progress',
+      OccurrenceStatus.done => 'done',
+      OccurrenceStatus.skipped => 'skipped',
+    };
+  }
+}
+
+enum TimeWindow {
+  day,
+  week,
+  month,
+  adHoc;
+
+  static TimeWindow fromString(String value) {
+    return switch (value) {
+      'day' => TimeWindow.day,
+      'week' => TimeWindow.week,
+      'month' => TimeWindow.month,
+      'ad_hoc' => TimeWindow.adHoc,
+      _ => throw ArgumentError('Unknown TimeWindow: $value'),
+    };
+  }
+
+  String toJson() {
+    return switch (this) {
+      TimeWindow.day => 'day',
+      TimeWindow.week => 'week',
+      TimeWindow.month => 'month',
+      TimeWindow.adHoc => 'ad_hoc',
+    };
+  }
+}
+
+class Routine {
+  const Routine({
+    required this.id,
+    required this.sourceRecordId,
+    required this.name,
+    required this.rrule,
+    this.cadence,
+    this.startTime,
+    required this.status,
+    this.templates = const [],
+    this.nextOccurrence,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String sourceRecordId;
+  final String name;
+  final String rrule;
+  final String? cadence;
+  final String? startTime;
+  final RoutineStatus status;
+  final List<RoutineTemplate> templates;
+  final RoutineNextOccurrence? nextOccurrence;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory Routine.fromMap(Map<String, dynamic> map) {
+    return Routine(
+      id: map['id'] as String,
+      sourceRecordId: map['source_record_id'] as String,
+      name: map['name'] as String,
+      rrule: map['rrule'] as String,
+      cadence: map['cadence'] as String?,
+      startTime: map['start_time'] as String?,
+      status: RoutineStatus.fromString(map['status'] as String),
+      templates: (map['templates'] as List<dynamic>?)
+              ?.map((e) =>
+                  RoutineTemplate.fromMap(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+      nextOccurrence: map['next_occurrence'] != null
+          ? RoutineNextOccurrence.fromMap(
+              map['next_occurrence'] as Map<String, dynamic>)
+          : null,
+      createdAt: DateTime.parse(map['created_at'] as String),
+      updatedAt: DateTime.parse(map['updated_at'] as String),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'source_record_id': sourceRecordId,
+      'name': name,
+      'rrule': rrule,
+      'cadence': cadence,
+      'start_time': startTime,
+      'status': status.name,
+      'templates': templates.map((t) => t.toMap()).toList(),
+      'next_occurrence': nextOccurrence?.toMap(),
+      'created_at': createdAt.toIso8601String(),
+      'updated_at': updatedAt.toIso8601String(),
+    };
+  }
+}
+
+class RoutineTemplate {
+  const RoutineTemplate({
+    this.id,
+    required this.text,
+    required this.sortOrder,
+  });
+
+  final String? id;
+  final String text;
+  final int sortOrder;
+
+  factory RoutineTemplate.fromMap(Map<String, dynamic> map) {
+    return RoutineTemplate(
+      id: map['id'] as String?,
+      text: map['text'] as String,
+      sortOrder: map['sort_order'] as int,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      if (id != null) 'id': id,
+      'text': text,
+      'sort_order': sortOrder,
+    };
+  }
+}
+
+class RoutineOccurrence {
+  const RoutineOccurrence({
+    required this.id,
+    required this.routineId,
+    required this.scheduledFor,
+    required this.timeWindow,
+    required this.status,
+    this.conversationId,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String routineId;
+  final String scheduledFor;
+  final TimeWindow timeWindow;
+  final OccurrenceStatus status;
+  final String? conversationId;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory RoutineOccurrence.fromMap(Map<String, dynamic> map) {
+    return RoutineOccurrence(
+      id: map['id'] as String,
+      routineId: map['routine_id'] as String,
+      scheduledFor: map['scheduled_for'] as String,
+      timeWindow: TimeWindow.fromString(map['time_window'] as String),
+      status: OccurrenceStatus.fromString(map['status'] as String),
+      conversationId: map['conversation_id'] as String?,
+      createdAt: DateTime.parse(map['created_at'] as String),
+      updatedAt: DateTime.parse(map['updated_at'] as String),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'routine_id': routineId,
+      'scheduled_for': scheduledFor,
+      'time_window': timeWindow.toJson(),
+      'status': status.toJson(),
+      'conversation_id': conversationId,
+      'created_at': createdAt.toIso8601String(),
+      'updated_at': updatedAt.toIso8601String(),
+    };
+  }
+}
+
+class RoutineNextOccurrence {
+  const RoutineNextOccurrence({
+    required this.date,
+    required this.timeWindow,
+  });
+
+  final String date;
+  final TimeWindow timeWindow;
+
+  factory RoutineNextOccurrence.fromMap(Map<String, dynamic> map) {
+    return RoutineNextOccurrence(
+      date: map['date'] as String,
+      timeWindow: TimeWindow.fromString(map['time_window'] as String),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'date': date,
+      'time_window': timeWindow.toJson(),
+    };
+  }
+}
+
+class RoutineProposal {
+  const RoutineProposal({
+    required this.id,
+    this.topicRef,
+    required this.name,
+    this.cadence,
+    this.startTime,
+    required this.items,
+    required this.confidence,
+    required this.conversationId,
+    required this.createdAt,
+  });
+
+  final String id;
+  final String? topicRef;
+  final String name;
+  final String? cadence;
+  final String? startTime;
+  final List<RoutineProposalItem> items;
+  final double confidence;
+  final String conversationId;
+  final DateTime createdAt;
+
+  factory RoutineProposal.fromMap(Map<String, dynamic> map) {
+    return RoutineProposal(
+      id: map['id'] as String,
+      topicRef: map['topic_ref'] as String?,
+      name: map['name'] as String,
+      cadence: map['cadence'] as String?,
+      startTime: map['start_time'] as String?,
+      items: (map['items'] as List<dynamic>)
+          .map((e) => RoutineProposalItem.fromMap(e as Map<String, dynamic>))
+          .toList(),
+      confidence: (map['confidence'] as num).toDouble(),
+      conversationId: map['conversation_id'] as String,
+      createdAt: DateTime.parse(map['created_at'] as String),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'topic_ref': topicRef,
+      'name': name,
+      'cadence': cadence,
+      'start_time': startTime,
+      'items': items.map((i) => i.toMap()).toList(),
+      'confidence': confidence,
+      'conversation_id': conversationId,
+      'created_at': createdAt.toIso8601String(),
+    };
+  }
+}
+
+class RoutineProposalItem {
+  const RoutineProposalItem({
+    required this.text,
+    required this.sortOrder,
+  });
+
+  final String text;
+  final int sortOrder;
+
+  factory RoutineProposalItem.fromMap(Map<String, dynamic> map) {
+    return RoutineProposalItem(
+      text: map['text'] as String,
+      sortOrder: map['sort_order'] as int,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'text': text,
+      'sort_order': sortOrder,
+    };
+  }
+}

--- a/test/core/models/agenda_test.dart
+++ b/test/core/models/agenda_test.dart
@@ -86,6 +86,7 @@ void main() {
       expect(item.recordId, 'rec-1');
       expect(item.text, 'Task text');
       expect(item.topicRef, 'topic:work');
+      expect(item.timeWindow, TimeWindow.day);
       expect(item.originRole, OriginRole.user);
       expect(item.status, RecordStatus.active);
       expect(item.linkedConversationCount, 3);

--- a/test/core/models/agenda_test.dart
+++ b/test/core/models/agenda_test.dart
@@ -1,0 +1,148 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/agenda.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/models/routine.dart';
+
+void main() {
+  group('AgendaResponse', () {
+    final sampleMap = {
+      'date': '2026-04-18',
+      'granularity': 'day',
+      'from': '2026-04-18',
+      'to': '2026-04-18',
+      'items': [
+        {
+          'record_id': 'rec-1',
+          'text': 'Buy groceries',
+          'topic_ref': 'topic:health',
+          'scheduled_for': '2026-04-18',
+          'time_window': 'day',
+          'origin_role': 'agent',
+          'status': 'active',
+          'linked_conversation_count': 2,
+        },
+      ],
+      'routine_items': [
+        {
+          'routine_id': 'rt-1',
+          'routine_name': 'Morning exercise',
+          'scheduled_for': '2026-04-18',
+          'start_time': '07:00',
+          'overdue': false,
+          'status': 'pending',
+          'occurrence_id': 'occ-1',
+          'templates': [
+            {'text': 'Stretch', 'sort_order': 0},
+          ],
+        },
+      ],
+    };
+
+    test('fromMap creates correct instance', () {
+      final agenda = AgendaResponse.fromMap(sampleMap);
+
+      expect(agenda.date, '2026-04-18');
+      expect(agenda.granularity, 'day');
+      expect(agenda.from, '2026-04-18');
+      expect(agenda.to, '2026-04-18');
+      expect(agenda.items, hasLength(1));
+      expect(agenda.routineItems, hasLength(1));
+    });
+
+    test('round-trip preserves all fields', () {
+      final agenda = AgendaResponse.fromMap(sampleMap);
+      final roundTripped = AgendaResponse.fromMap(agenda.toMap());
+
+      expect(roundTripped.date, agenda.date);
+      expect(roundTripped.items.length, agenda.items.length);
+      expect(roundTripped.routineItems.length, agenda.routineItems.length);
+    });
+
+    test('toMap produces valid JSON', () {
+      final agenda = AgendaResponse.fromMap(sampleMap);
+      final json = jsonEncode(agenda.toMap());
+      final decoded = jsonDecode(json) as Map<String, dynamic>;
+
+      expect(decoded['date'], '2026-04-18');
+      expect(decoded['items'], hasLength(1));
+    });
+  });
+
+  group('AgendaItem', () {
+    test('fromMap parses all fields', () {
+      final item = AgendaItem.fromMap({
+        'record_id': 'rec-1',
+        'text': 'Task text',
+        'topic_ref': 'topic:work',
+        'scheduled_for': '2026-04-18',
+        'time_window': 'day',
+        'origin_role': 'user',
+        'status': 'active',
+        'linked_conversation_count': 3,
+      });
+
+      expect(item.recordId, 'rec-1');
+      expect(item.text, 'Task text');
+      expect(item.topicRef, 'topic:work');
+      expect(item.originRole, OriginRole.user);
+      expect(item.status, RecordStatus.active);
+      expect(item.linkedConversationCount, 3);
+    });
+
+    test('topicRef is nullable', () {
+      final item = AgendaItem.fromMap({
+        'record_id': 'rec-1',
+        'text': 'Task',
+        'scheduled_for': '2026-04-18',
+        'time_window': 'day',
+        'origin_role': 'agent',
+        'status': 'done',
+        'linked_conversation_count': 0,
+      });
+
+      expect(item.topicRef, isNull);
+    });
+  });
+
+  group('AgendaRoutineItem', () {
+    test('fromMap parses all fields', () {
+      final item = AgendaRoutineItem.fromMap({
+        'routine_id': 'rt-1',
+        'routine_name': 'Exercise',
+        'scheduled_for': '2026-04-18',
+        'start_time': '07:00',
+        'overdue': true,
+        'status': 'pending',
+        'occurrence_id': 'occ-1',
+        'templates': [
+          {'text': 'Step 1', 'sort_order': 0},
+        ],
+      });
+
+      expect(item.routineId, 'rt-1');
+      expect(item.routineName, 'Exercise');
+      expect(item.startTime, '07:00');
+      expect(item.overdue, true);
+      expect(item.status, OccurrenceStatus.pending);
+      expect(item.occurrenceId, 'occ-1');
+      expect(item.templates, hasLength(1));
+    });
+
+    test('nullable fields handle absence', () {
+      final item = AgendaRoutineItem.fromMap({
+        'routine_id': 'rt-1',
+        'routine_name': 'Walk',
+        'scheduled_for': '2026-04-18',
+        'overdue': false,
+        'status': 'done',
+        'templates': <dynamic>[],
+      });
+
+      expect(item.startTime, isNull);
+      expect(item.occurrenceId, isNull);
+      expect(item.templates, isEmpty);
+    });
+  });
+}

--- a/test/core/models/conversation_record_test.dart
+++ b/test/core/models/conversation_record_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+
+void main() {
+  group('RecordType', () {
+    test('fromString parses snake_case backend values', () {
+      expect(RecordType.fromString('action_item'), RecordType.actionItem);
+      expect(RecordType.fromString('summary_note'), RecordType.summaryNote);
+      expect(RecordType.fromString('journal_note'), RecordType.journalNote);
+      expect(
+          RecordType.fromString('routine_proposal'), RecordType.routineProposal);
+      expect(RecordType.fromString('topic'), RecordType.topic);
+    });
+
+    test('toJson returns snake_case', () {
+      expect(RecordType.actionItem.toJson(), 'action_item');
+      expect(RecordType.summaryNote.toJson(), 'summary_note');
+      expect(RecordType.routineProposal.toJson(), 'routine_proposal');
+    });
+
+    test('fromString throws on unknown value', () {
+      expect(() => RecordType.fromString('unknown'), throwsArgumentError);
+    });
+  });
+
+  group('ConversationRecord', () {
+    final sampleMap = {
+      'record_id': 'rec-1',
+      'conversation_id': 'conv-1',
+      'record_type': 'action_item',
+      'subject_ref': 'topic:health',
+      'payload': {'text': 'Buy groceries'},
+      'confidence': 0.95,
+      'origin_role': 'agent',
+      'assertion_mode': 'extracted',
+      'user_endorsed': true,
+      'source_event_refs': ['evt-1', 'evt-2'],
+    };
+
+    test('fromMap creates correct instance', () {
+      final record = ConversationRecord.fromMap(sampleMap);
+
+      expect(record.recordId, 'rec-1');
+      expect(record.conversationId, 'conv-1');
+      expect(record.recordType, RecordType.actionItem);
+      expect(record.subjectRef, 'topic:health');
+      expect(record.payload, {'text': 'Buy groceries'});
+      expect(record.confidence, 0.95);
+      expect(record.originRole, OriginRole.agent);
+      expect(record.assertionMode, 'extracted');
+      expect(record.userEndorsed, true);
+      expect(record.sourceEventRefs, ['evt-1', 'evt-2']);
+    });
+
+    test('round-trip fromMap/toMap preserves all fields', () {
+      final record = ConversationRecord.fromMap(sampleMap);
+      final roundTripped = ConversationRecord.fromMap(record.toMap());
+
+      expect(roundTripped.recordId, record.recordId);
+      expect(roundTripped.conversationId, record.conversationId);
+      expect(roundTripped.recordType, record.recordType);
+      expect(roundTripped.subjectRef, record.subjectRef);
+      expect(roundTripped.payload, record.payload);
+      expect(roundTripped.confidence, record.confidence);
+      expect(roundTripped.originRole, record.originRole);
+      expect(roundTripped.assertionMode, record.assertionMode);
+      expect(roundTripped.userEndorsed, record.userEndorsed);
+      expect(roundTripped.sourceEventRefs, record.sourceEventRefs);
+    });
+
+    test('toMap produces valid JSON', () {
+      final record = ConversationRecord.fromMap(sampleMap);
+      final json = jsonEncode(record.toMap());
+      final decoded = jsonDecode(json) as Map<String, dynamic>;
+
+      expect(decoded['record_id'], 'rec-1');
+      expect(decoded['record_type'], 'action_item');
+    });
+
+    test('fromMap handles all record types', () {
+      for (final type in RecordType.values) {
+        final map = Map<String, dynamic>.from(sampleMap);
+        map['record_type'] = type.toJson();
+        final record = ConversationRecord.fromMap(map);
+        expect(record.recordType, type);
+      }
+    });
+  });
+}

--- a/test/core/models/conversation_test.dart
+++ b/test/core/models/conversation_test.dart
@@ -1,0 +1,124 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/conversation.dart';
+
+void main() {
+  group('Conversation', () {
+    final sampleMap = {
+      'conversation_id': 'conv-1',
+      'session_id': 'sess-1',
+      'status': 'open',
+      'created_at': '2026-04-18T10:00:00.000Z',
+      'event_count': 5,
+      'last_event_at': '2026-04-18T10:30:00.000Z',
+      'first_message_preview': 'Hello agent',
+      'subject_record_id': 'rec-1',
+      'subject_record_text': 'Health topic',
+      'subject_record_status': 'active',
+    };
+
+    test('fromMap creates correct instance', () {
+      final conv = Conversation.fromMap(sampleMap);
+
+      expect(conv.conversationId, 'conv-1');
+      expect(conv.sessionId, 'sess-1');
+      expect(conv.status, ConversationStatus.open);
+      expect(conv.eventCount, 5);
+      expect(conv.lastEventAt, isNotNull);
+      expect(conv.firstMessagePreview, 'Hello agent');
+      expect(conv.subjectRecordId, 'rec-1');
+      expect(conv.subjectRecordText, 'Health topic');
+      expect(conv.subjectRecordStatus, 'active');
+    });
+
+    test('round-trip preserves all fields', () {
+      final conv = Conversation.fromMap(sampleMap);
+      final roundTripped = Conversation.fromMap(conv.toMap());
+
+      expect(roundTripped.conversationId, conv.conversationId);
+      expect(roundTripped.sessionId, conv.sessionId);
+      expect(roundTripped.status, conv.status);
+      expect(roundTripped.eventCount, conv.eventCount);
+      expect(roundTripped.firstMessagePreview, conv.firstMessagePreview);
+      expect(roundTripped.subjectRecordId, conv.subjectRecordId);
+    });
+
+    test('nullable fields handle absence', () {
+      final minimalMap = {
+        'conversation_id': 'conv-2',
+        'session_id': 'sess-2',
+        'status': 'closed',
+        'created_at': '2026-04-18T10:00:00.000Z',
+        'event_count': 0,
+      };
+
+      final conv = Conversation.fromMap(minimalMap);
+
+      expect(conv.lastEventAt, isNull);
+      expect(conv.firstMessagePreview, isNull);
+      expect(conv.subjectRecordId, isNull);
+      expect(conv.subjectRecordText, isNull);
+      expect(conv.subjectRecordStatus, isNull);
+    });
+
+    test('toMap produces valid JSON', () {
+      final conv = Conversation.fromMap(sampleMap);
+      final json = jsonEncode(conv.toMap());
+      final decoded = jsonDecode(json) as Map<String, dynamic>;
+
+      expect(decoded['conversation_id'], 'conv-1');
+      expect(decoded['status'], 'open');
+    });
+  });
+
+  group('ConversationEvent', () {
+    final sampleMap = {
+      'event_id': 'evt-1',
+      'conversation_id': 'conv-1',
+      'sequence': 3,
+      'role': 'user',
+      'content': 'Tell me about my agenda',
+      'occurred_at': '2026-04-18T10:00:00.000Z',
+      'received_at': '2026-04-18T10:00:01.000Z',
+    };
+
+    test('fromMap creates correct instance', () {
+      final event = ConversationEvent.fromMap(sampleMap);
+
+      expect(event.eventId, 'evt-1');
+      expect(event.conversationId, 'conv-1');
+      expect(event.sequence, 3);
+      expect(event.role, EventRole.user);
+      expect(event.content, 'Tell me about my agenda');
+      expect(event.occurredAt, isNotNull);
+      expect(event.receivedAt, isNotNull);
+    });
+
+    test('round-trip preserves all fields', () {
+      final event = ConversationEvent.fromMap(sampleMap);
+      final roundTripped = ConversationEvent.fromMap(event.toMap());
+
+      expect(roundTripped.eventId, event.eventId);
+      expect(roundTripped.sequence, event.sequence);
+      expect(roundTripped.role, event.role);
+      expect(roundTripped.content, event.content);
+    });
+
+    test('occurredAt is nullable', () {
+      final map = Map<String, dynamic>.from(sampleMap);
+      map.remove('occurred_at');
+
+      final event = ConversationEvent.fromMap(map);
+      expect(event.occurredAt, isNull);
+    });
+
+    test('agent role parses correctly', () {
+      final map = Map<String, dynamic>.from(sampleMap);
+      map['role'] = 'agent';
+
+      final event = ConversationEvent.fromMap(map);
+      expect(event.role, EventRole.agent);
+    });
+  });
+}

--- a/test/core/models/plan_test.dart
+++ b/test/core/models/plan_test.dart
@@ -1,0 +1,218 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/plan.dart';
+
+void main() {
+  group('PlanResponse', () {
+    final sampleMap = {
+      'topics': [
+        {
+          'topic_ref': 'topic:health',
+          'canonical_name': 'Health',
+          'items': [
+            {
+              'entry_id': 'e-1',
+              'display_text': 'Exercise daily',
+              'plan_bucket': 'committed',
+              'confidence': 0.9,
+              'conversation_id': 'conv-1',
+              'created_at': '2026-04-01T00:00:00.000Z',
+            },
+          ],
+        },
+      ],
+      'uncategorized': [
+        {
+          'entry_id': 'e-2',
+          'display_text': 'Read more books',
+          'plan_bucket': 'candidate',
+          'confidence': 0.7,
+          'conversation_id': 'conv-2',
+          'created_at': '2026-04-02T00:00:00.000Z',
+        },
+      ],
+      'rules': [
+        {
+          'topic_ref': 'topic:diet',
+          'canonical_name': 'Diet',
+          'items': [
+            {
+              'entry_id': 'e-3',
+              'display_text': 'No sugar after 8pm',
+              'confidence': 0.85,
+              'conversation_id': 'conv-3',
+              'created_at': '2026-04-03T00:00:00.000Z',
+              'record_type': 'constraint',
+            },
+          ],
+        },
+      ],
+      'rules_uncategorized': <dynamic>[],
+      'completed': [
+        {
+          'topic_ref': 'topic:work',
+          'canonical_name': 'Work',
+          'items': [
+            {
+              'entry_id': 'e-4',
+              'display_text': 'Ship feature X',
+              'plan_bucket': 'committed',
+              'confidence': 1.0,
+              'conversation_id': 'conv-4',
+              'created_at': '2026-03-01T00:00:00.000Z',
+              'closed_at': '2026-04-15T00:00:00.000Z',
+            },
+          ],
+        },
+      ],
+      'completed_uncategorized': <dynamic>[],
+      'total_count': 4,
+      'observed_at': '2026-04-18T12:00:00.000Z',
+    };
+
+    test('fromMap creates correct instance', () {
+      final plan = PlanResponse.fromMap(sampleMap);
+
+      expect(plan.topics, hasLength(1));
+      expect(plan.uncategorized, hasLength(1));
+      expect(plan.rules, hasLength(1));
+      expect(plan.rulesUncategorized, isEmpty);
+      expect(plan.completed, hasLength(1));
+      expect(plan.completedUncategorized, isEmpty);
+      expect(plan.totalCount, 4);
+      expect(plan.observedAt.year, 2026);
+    });
+
+    test('round-trip preserves all fields', () {
+      final plan = PlanResponse.fromMap(sampleMap);
+      final roundTripped = PlanResponse.fromMap(plan.toMap());
+
+      expect(roundTripped.topics.length, plan.topics.length);
+      expect(roundTripped.uncategorized.length, plan.uncategorized.length);
+      expect(roundTripped.rules.length, plan.rules.length);
+      expect(roundTripped.completed.length, plan.completed.length);
+      expect(roundTripped.totalCount, plan.totalCount);
+    });
+
+    test('handles null lists as empty', () {
+      final minimalMap = {
+        'total_count': 0,
+        'observed_at': '2026-04-18T12:00:00.000Z',
+      };
+
+      final plan = PlanResponse.fromMap(minimalMap);
+
+      expect(plan.topics, isEmpty);
+      expect(plan.uncategorized, isEmpty);
+      expect(plan.rules, isEmpty);
+      expect(plan.rulesUncategorized, isEmpty);
+      expect(plan.completed, isEmpty);
+      expect(plan.completedUncategorized, isEmpty);
+    });
+
+    test('toMap produces valid JSON', () {
+      final plan = PlanResponse.fromMap(sampleMap);
+      final json = jsonEncode(plan.toMap());
+      final decoded = jsonDecode(json) as Map<String, dynamic>;
+
+      expect(decoded['total_count'], 4);
+      expect(decoded['topics'], hasLength(1));
+    });
+  });
+
+  group('PlanTopicGroup', () {
+    test('fromMap parses nested items', () {
+      final group = PlanTopicGroup.fromMap({
+        'topic_ref': 'topic:finance',
+        'canonical_name': 'Finance',
+        'items': [
+          {
+            'entry_id': 'e-1',
+            'display_text': 'Save money',
+            'plan_bucket': 'proposed',
+            'confidence': 0.6,
+            'conversation_id': 'conv-1',
+            'created_at': '2026-04-18T00:00:00.000Z',
+          },
+        ],
+      });
+
+      expect(group.topicRef, 'topic:finance');
+      expect(group.canonicalName, 'Finance');
+      expect(group.items, hasLength(1));
+      expect(group.items[0].displayText, 'Save money');
+    });
+  });
+
+  group('PlanEntry', () {
+    test('fromMap with plan bucket (active entry)', () {
+      final entry = PlanEntry.fromMap({
+        'entry_id': 'e-1',
+        'display_text': 'Do thing',
+        'plan_bucket': 'committed',
+        'confidence': 0.9,
+        'conversation_id': 'conv-1',
+        'created_at': '2026-04-18T00:00:00.000Z',
+      });
+
+      expect(entry.entryId, 'e-1');
+      expect(entry.displayText, 'Do thing');
+      expect(entry.planBucket, 'committed');
+      expect(entry.confidence, 0.9);
+      expect(entry.closedAt, isNull);
+      expect(entry.recordType, isNull);
+    });
+
+    test('fromMap with record type (rule entry)', () {
+      final entry = PlanEntry.fromMap({
+        'entry_id': 'e-2',
+        'display_text': 'Always do X',
+        'confidence': 0.8,
+        'conversation_id': 'conv-2',
+        'created_at': '2026-04-18T00:00:00.000Z',
+        'record_type': 'constraint',
+      });
+
+      expect(entry.recordType, 'constraint');
+      expect(entry.planBucket, isNull);
+    });
+
+    test('fromMap with closed_at (completed entry)', () {
+      final entry = PlanEntry.fromMap({
+        'entry_id': 'e-3',
+        'display_text': 'Done thing',
+        'plan_bucket': 'committed',
+        'confidence': 1.0,
+        'conversation_id': 'conv-3',
+        'created_at': '2026-03-01T00:00:00.000Z',
+        'closed_at': '2026-04-15T00:00:00.000Z',
+      });
+
+      expect(entry.closedAt, isNotNull);
+      expect(entry.closedAt!.month, 4);
+    });
+
+    test('round-trip preserves all fields', () {
+      final entry = PlanEntry.fromMap({
+        'entry_id': 'e-1',
+        'display_text': 'Test entry',
+        'plan_bucket': 'candidate',
+        'confidence': 0.75,
+        'conversation_id': 'conv-1',
+        'created_at': '2026-04-18T00:00:00.000Z',
+        'closed_at': '2026-04-19T00:00:00.000Z',
+        'record_type': 'preference',
+      });
+
+      final roundTripped = PlanEntry.fromMap(entry.toMap());
+
+      expect(roundTripped.entryId, entry.entryId);
+      expect(roundTripped.displayText, entry.displayText);
+      expect(roundTripped.planBucket, entry.planBucket);
+      expect(roundTripped.confidence, entry.confidence);
+      expect(roundTripped.recordType, entry.recordType);
+      expect(roundTripped.closedAt, isNotNull);
+    });
+  });
+}

--- a/test/core/models/routine_test.dart
+++ b/test/core/models/routine_test.dart
@@ -1,0 +1,207 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/routine.dart';
+
+void main() {
+  group('OccurrenceStatus', () {
+    test('fromString parses snake_case', () {
+      expect(
+          OccurrenceStatus.fromString('in_progress'), OccurrenceStatus.inProgress);
+      expect(OccurrenceStatus.fromString('done'), OccurrenceStatus.done);
+    });
+
+    test('toJson returns snake_case', () {
+      expect(OccurrenceStatus.inProgress.toJson(), 'in_progress');
+    });
+  });
+
+  group('TimeWindow', () {
+    test('fromString parses ad_hoc', () {
+      expect(TimeWindow.fromString('ad_hoc'), TimeWindow.adHoc);
+      expect(TimeWindow.fromString('day'), TimeWindow.day);
+    });
+
+    test('toJson returns snake_case', () {
+      expect(TimeWindow.adHoc.toJson(), 'ad_hoc');
+    });
+  });
+
+  group('Routine', () {
+    final sampleMap = {
+      'id': 'rt-1',
+      'source_record_id': 'rec-1',
+      'name': 'Morning exercise',
+      'rrule': 'FREQ=DAILY',
+      'cadence': 'daily',
+      'start_time': '07:00',
+      'status': 'active',
+      'templates': [
+        {'id': 'tmpl-1', 'text': 'Stretch', 'sort_order': 0},
+        {'id': 'tmpl-2', 'text': 'Run', 'sort_order': 1},
+      ],
+      'next_occurrence': {
+        'date': '2026-04-19',
+        'time_window': 'day',
+      },
+      'created_at': '2026-01-01T00:00:00.000Z',
+      'updated_at': '2026-04-18T12:00:00.000Z',
+    };
+
+    test('fromMap creates correct instance', () {
+      final routine = Routine.fromMap(sampleMap);
+
+      expect(routine.id, 'rt-1');
+      expect(routine.sourceRecordId, 'rec-1');
+      expect(routine.name, 'Morning exercise');
+      expect(routine.rrule, 'FREQ=DAILY');
+      expect(routine.cadence, 'daily');
+      expect(routine.startTime, '07:00');
+      expect(routine.status, RoutineStatus.active);
+      expect(routine.templates, hasLength(2));
+      expect(routine.templates[0].text, 'Stretch');
+      expect(routine.templates[1].sortOrder, 1);
+      expect(routine.nextOccurrence, isNotNull);
+      expect(routine.nextOccurrence!.date, '2026-04-19');
+      expect(routine.nextOccurrence!.timeWindow, TimeWindow.day);
+    });
+
+    test('round-trip preserves all fields', () {
+      final routine = Routine.fromMap(sampleMap);
+      final roundTripped = Routine.fromMap(routine.toMap());
+
+      expect(roundTripped.id, routine.id);
+      expect(roundTripped.name, routine.name);
+      expect(roundTripped.status, routine.status);
+      expect(roundTripped.templates.length, routine.templates.length);
+      expect(roundTripped.nextOccurrence?.date, routine.nextOccurrence?.date);
+    });
+
+    test('templates default to empty list when absent', () {
+      final map = Map<String, dynamic>.from(sampleMap);
+      map.remove('templates');
+      final routine = Routine.fromMap(map);
+
+      expect(routine.templates, isEmpty);
+    });
+
+    test('nextOccurrence is null when absent', () {
+      final map = Map<String, dynamic>.from(sampleMap);
+      map.remove('next_occurrence');
+      final routine = Routine.fromMap(map);
+
+      expect(routine.nextOccurrence, isNull);
+    });
+
+    test('startTime is null when absent', () {
+      final map = Map<String, dynamic>.from(sampleMap);
+      map.remove('start_time');
+      final routine = Routine.fromMap(map);
+
+      expect(routine.startTime, isNull);
+    });
+
+    test('toMap produces valid JSON', () {
+      final routine = Routine.fromMap(sampleMap);
+      final json = jsonEncode(routine.toMap());
+      final decoded = jsonDecode(json) as Map<String, dynamic>;
+
+      expect(decoded['id'], 'rt-1');
+      expect(decoded['status'], 'active');
+    });
+  });
+
+  group('RoutineTemplate', () {
+    test('id is optional', () {
+      final template = RoutineTemplate.fromMap({
+        'text': 'Step one',
+        'sort_order': 0,
+      });
+
+      expect(template.id, isNull);
+      expect(template.text, 'Step one');
+
+      final map = template.toMap();
+      expect(map.containsKey('id'), isFalse);
+    });
+  });
+
+  group('RoutineOccurrence', () {
+    final sampleMap = {
+      'id': 'occ-1',
+      'routine_id': 'rt-1',
+      'scheduled_for': '2026-04-18',
+      'time_window': 'day',
+      'status': 'pending',
+      'created_at': '2026-04-18T00:00:00.000Z',
+      'updated_at': '2026-04-18T00:00:00.000Z',
+    };
+
+    test('fromMap creates correct instance', () {
+      final occ = RoutineOccurrence.fromMap(sampleMap);
+
+      expect(occ.id, 'occ-1');
+      expect(occ.routineId, 'rt-1');
+      expect(occ.scheduledFor, '2026-04-18');
+      expect(occ.timeWindow, TimeWindow.day);
+      expect(occ.status, OccurrenceStatus.pending);
+      expect(occ.conversationId, isNull);
+    });
+
+    test('round-trip preserves all fields', () {
+      final map = Map<String, dynamic>.from(sampleMap);
+      map['conversation_id'] = 'conv-1';
+      map['status'] = 'in_progress';
+
+      final occ = RoutineOccurrence.fromMap(map);
+      final roundTripped = RoutineOccurrence.fromMap(occ.toMap());
+
+      expect(roundTripped.conversationId, 'conv-1');
+      expect(roundTripped.status, OccurrenceStatus.inProgress);
+    });
+  });
+
+  group('RoutineProposal', () {
+    final sampleMap = {
+      'id': 'prop-1',
+      'topic_ref': 'topic:fitness',
+      'name': 'Evening walk',
+      'cadence': 'daily',
+      'start_time': '18:00',
+      'items': [
+        {'text': 'Walk 30 min', 'sort_order': 0},
+      ],
+      'confidence': 0.85,
+      'conversation_id': 'conv-1',
+      'created_at': '2026-04-18T00:00:00.000Z',
+    };
+
+    test('fromMap creates correct instance', () {
+      final proposal = RoutineProposal.fromMap(sampleMap);
+
+      expect(proposal.id, 'prop-1');
+      expect(proposal.topicRef, 'topic:fitness');
+      expect(proposal.name, 'Evening walk');
+      expect(proposal.items, hasLength(1));
+      expect(proposal.items[0].text, 'Walk 30 min');
+      expect(proposal.confidence, 0.85);
+    });
+
+    test('round-trip preserves all fields', () {
+      final proposal = RoutineProposal.fromMap(sampleMap);
+      final roundTripped = RoutineProposal.fromMap(proposal.toMap());
+
+      expect(roundTripped.id, proposal.id);
+      expect(roundTripped.name, proposal.name);
+      expect(roundTripped.items.length, proposal.items.length);
+    });
+
+    test('topicRef is nullable', () {
+      final map = Map<String, dynamic>.from(sampleMap);
+      map['topic_ref'] = null;
+
+      final proposal = RoutineProposal.fromMap(map);
+      expect(proposal.topicRef, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add shared domain models matching personal-agent backend API responses
- Models: `ConversationRecord`, `Routine` (+ Template, Occurrence, Proposal), `Conversation` (+ Event), `AgendaResponse` (+ items), `PlanResponse` (+ TopicGroup, Entry)
- All models use `fromMap()`/`toMap()` with snake_case JSON field names verified against backend Go struct tags
- Enum types handle snake_case conversion: `RecordType`, `OccurrenceStatus`, `TimeWindow`, etc.
- 47 round-trip serialization tests covering all models, nullable fields, and edge cases

## Test plan
- [x] `flutter analyze` passes with zero issues
- [x] 47/47 model tests pass

Closes #173
