### PR TITLE
feat(app): add placeholder screens for P020 navigation restructure

### DIFF
--- a/lib/app/placeholders/agenda_placeholder_screen.dart
+++ b/lib/app/placeholders/agenda_placeholder_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class AgendaPlaceholderScreen extends StatelessWidget {
+  const AgendaPlaceholderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Agenda'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () => context.push('/settings'),
+          ),
+        ],
+      ),
+      body: const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.calendar_today, size: 64, color: Colors.grey),
+            SizedBox(height: 16),
+            Text('Agenda', style: TextStyle(fontSize: 20)),
+            SizedBox(height: 8),
+            Text(
+              'Daily tasks and routine schedule',
+              style: TextStyle(color: Colors.grey),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/placeholders/chat_placeholder_screen.dart
+++ b/lib/app/placeholders/chat_placeholder_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class ChatPlaceholderScreen extends StatelessWidget {
+  const ChatPlaceholderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Chat'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () => context.push('/settings'),
+          ),
+        ],
+      ),
+      body: const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.chat_bubble_outline, size: 64, color: Colors.grey),
+            SizedBox(height: 16),
+            Text('Chat', style: TextStyle(fontSize: 20)),
+            SizedBox(height: 8),
+            Text(
+              'Conversations with your agent',
+              style: TextStyle(color: Colors.grey),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/placeholders/plan_placeholder_screen.dart
+++ b/lib/app/placeholders/plan_placeholder_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class PlanPlaceholderScreen extends StatelessWidget {
+  const PlanPlaceholderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Plan'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () => context.push('/settings'),
+          ),
+        ],
+      ),
+      body: const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.checklist, size: 64, color: Colors.grey),
+            SizedBox(height: 16),
+            Text('Plan', style: TextStyle(fontSize: 20)),
+            SizedBox(height: 8),
+            Text(
+              'Action items and goals',
+              style: TextStyle(color: Colors.grey),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/placeholders/routines_placeholder_screen.dart
+++ b/lib/app/placeholders/routines_placeholder_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class RoutinesPlaceholderScreen extends StatelessWidget {
+  const RoutinesPlaceholderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Routines'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () => context.push('/settings'),
+          ),
+        ],
+      ),
+      body: const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.repeat, size: 64, color: Colors.grey),
+            SizedBox(height: 16),
+            Text('Routines', style: TextStyle(fontSize: 20)),
+            SizedBox(height: 8),
+            Text(
+              'Recurring habits and schedules',
+              style: TextStyle(color: Colors.grey),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/app/placeholders/agenda_placeholder_screen_test.dart
+++ b/test/app/placeholders/agenda_placeholder_screen_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/app/placeholders/agenda_placeholder_screen.dart';
+
+void main() {
+  group('AgendaPlaceholderScreen', () {
+    testWidgets('renders title and gear icon', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: AgendaPlaceholderScreen()),
+      );
+
+      expect(find.text('Agenda'), findsWidgets);
+      expect(find.byIcon(Icons.settings), findsOneWidget);
+      expect(find.byIcon(Icons.calendar_today), findsOneWidget);
+      expect(
+        find.text('Daily tasks and routine schedule'),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/test/app/placeholders/chat_placeholder_screen_test.dart
+++ b/test/app/placeholders/chat_placeholder_screen_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/app/placeholders/chat_placeholder_screen.dart';
+
+void main() {
+  group('ChatPlaceholderScreen', () {
+    testWidgets('renders title and gear icon', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: ChatPlaceholderScreen()),
+      );
+
+      expect(find.text('Chat'), findsWidgets);
+      expect(find.byIcon(Icons.settings), findsOneWidget);
+      expect(find.byIcon(Icons.chat_bubble_outline), findsOneWidget);
+      expect(
+        find.text('Conversations with your agent'),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/test/app/placeholders/plan_placeholder_screen_test.dart
+++ b/test/app/placeholders/plan_placeholder_screen_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/app/placeholders/plan_placeholder_screen.dart';
+
+void main() {
+  group('PlanPlaceholderScreen', () {
+    testWidgets('renders title and gear icon', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: PlanPlaceholderScreen()),
+      );
+
+      expect(find.text('Plan'), findsWidgets);
+      expect(find.byIcon(Icons.settings), findsOneWidget);
+      expect(find.byIcon(Icons.checklist), findsOneWidget);
+      expect(find.text('Action items and goals'), findsOneWidget);
+    });
+  });
+}

--- a/test/app/placeholders/routines_placeholder_screen_test.dart
+++ b/test/app/placeholders/routines_placeholder_screen_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/app/placeholders/routines_placeholder_screen.dart';
+
+void main() {
+  group('RoutinesPlaceholderScreen', () {
+    testWidgets('renders title and gear icon', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: RoutinesPlaceholderScreen()),
+      );
+
+      expect(find.text('Routines'), findsWidgets);
+      expect(find.byIcon(Icons.settings), findsOneWidget);
+      expect(find.byIcon(Icons.repeat), findsOneWidget);
+      expect(
+        find.text('Recurring habits and schedules'),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Create 4 placeholder screens in `lib/app/placeholders/` for the 5-tab navigation layout
- Each screen has its own Scaffold + AppBar with gear icon for Settings access
- Widget tests for all 4 placeholders

Closes #179
