### PR TITLE
feat(app): restructure navigation to 5 tabs (P020-T2+T3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,11 +367,15 @@ final recordingControllerProvider =
 All navigation uses GoRouter:
 
 - Routes are defined in `lib/app/router.dart`.
-- The shell uses `StatefulShellRoute.indexedStack` with 3 tabs.
-- Child routes (e.g., `/record/review`) stay within their branch.
+- The shell uses `StatefulShellRoute.indexedStack` with 5 tabs (Agenda, Plan, Record, Routines, Chat).
+- Child routes (e.g., `/record/history`) stay within their branch.
 - Navigation arguments pass via GoRouter `extra` parameter.
-- Feature proposals **replace placeholder screens** in existing routes — they
-  do not add new top-level routes.
+- P020 established the 5-branch route structure. Feature proposals (P021–P024)
+  **replace placeholder screens** in existing routes — they do not add new
+  top-level routes.
+- Infrequently accessed screens (e.g., Settings) are top-level GoRoutes outside
+  the shell. Navigate to them with `context.push()` (not `context.go()`) to
+  preserve shell state.
 
 ### Error Handling
 
@@ -479,17 +483,22 @@ StorageService {
 - `SyncStatus` enum: `{ pending, sending, failed }` (no `sent`).
 - `DisplaySyncStatus` enum (view-level, 007 only): `{ sent, pending, failed }`.
 
-### Route Ownership (008 → 001, 003, 006, 007)
+### Route Ownership (008, 020 → 001, 006, 007, 021–024)
 
-Proposal 008 owns the shell and all top-level routes. Feature proposals
-**replace placeholders**, they do not add routes.
+P020 restructured the shell to 5 branches. Feature proposals replace
+placeholder screens within this structure — they do not add routes.
 
-| Route | Shell owner | Content owner |
-|-------|-------------|---------------|
-| `/record` | 008 | 001 (RecordingScreen) |
-| `/record/review` | 008 | 003 (TranscriptReviewScreen) |
-| `/history` | 008 | 007 (HistoryScreen) |
-| `/settings` | 008 | 006 (SettingsScreen) |
+| Route | Owner | Content owner |
+|-------|-------|---------------|
+| `/agenda` | 020 (shell branch 0) | 021 (AgendaPlaceholderScreen → real screen) |
+| `/plan` | 020 (shell branch 1) | 023 (PlanPlaceholderScreen → real screen) |
+| `/record` | 020 (shell branch 2) | 001 (RecordingScreen) |
+| `/record/history` | 020 (child of /record) | 007 (HistoryScreen) |
+| `/record/history/:id` | 020 (child of /record/history) | 007 (TranscriptDetailScreen) |
+| `/routines` | 020 (shell branch 3) | 022 (RoutinesPlaceholderScreen → real screen) |
+| `/chat` | 020 (shell branch 4) | 024 (ChatPlaceholderScreen → real screen) |
+| `/settings` | 020 (outside shell) | 006 (SettingsScreen) |
+| `/settings/advanced` | 020 (child of /settings) | 013 (AdvancedSettingsScreen) |
 
 ### Stub Provider Pattern (005, 008 → 006)
 

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,8 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:voice_agent/app/router.dart';
 
-class App extends StatelessWidget {
+class App extends StatefulWidget {
   const App({super.key});
+
+  @override
+  State<App> createState() => _AppState();
+}
+
+class _AppState extends State<App> {
+  late final _router = createRouter();
 
   @override
   Widget build(BuildContext context) {
@@ -12,7 +19,7 @@ class App extends StatelessWidget {
         colorSchemeSeed: Colors.blue,
         useMaterial3: true,
       ),
-      routerConfig: router,
+      routerConfig: _router,
     );
   }
 }

--- a/lib/app/app_shell_scaffold.dart
+++ b/lib/app/app_shell_scaffold.dart
@@ -73,16 +73,24 @@ class _AppShellScaffoldState extends ConsumerState<AppShellScaffold>
         },
         destinations: const [
           NavigationDestination(
-            icon: Icon(Icons.history),
-            label: 'History',
+            icon: Icon(Icons.calendar_today),
+            label: 'Agenda',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.checklist),
+            label: 'Plan',
           ),
           NavigationDestination(
             icon: Icon(Icons.mic),
             label: 'Record',
           ),
           NavigationDestination(
-            icon: Icon(Icons.settings),
-            label: 'Settings',
+            icon: Icon(Icons.repeat),
+            label: 'Routines',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.chat_bubble_outline),
+            label: 'Chat',
           ),
         ],
       ),

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,12 +1,16 @@
 import 'package:go_router/go_router.dart';
 import 'package:voice_agent/app/app_shell_scaffold.dart';
+import 'package:voice_agent/app/placeholders/agenda_placeholder_screen.dart';
+import 'package:voice_agent/app/placeholders/chat_placeholder_screen.dart';
+import 'package:voice_agent/app/placeholders/plan_placeholder_screen.dart';
+import 'package:voice_agent/app/placeholders/routines_placeholder_screen.dart';
 import 'package:voice_agent/features/history/history_screen.dart';
 import 'package:voice_agent/features/history/transcript_detail_screen.dart';
 import 'package:voice_agent/features/recording/presentation/recording_screen.dart';
 import 'package:voice_agent/features/settings/advanced_settings_screen.dart';
 import 'package:voice_agent/features/settings/settings_screen.dart';
 
-final router = GoRouter(
+GoRouter createRouter() => GoRouter(
   initialLocation: '/record',
   routes: [
     StatefulShellRoute.indexedStack(
@@ -14,48 +18,76 @@ final router = GoRouter(
         return AppShellScaffold(navigationShell: navigationShell);
       },
       branches: [
-        // Branch 0: History
+        // Branch 0: Agenda
         StatefulShellBranch(
           routes: [
             GoRoute(
-              path: '/history',
-              builder: (context, state) => const HistoryScreen(),
-              routes: [
-                GoRoute(
-                  path: ':id',
-                  builder: (context, state) {
-                    final id = state.pathParameters['id']!;
-                    return TranscriptDetailScreen(transcriptId: id);
-                  },
-                ),
-              ],
+              path: '/agenda',
+              builder: (context, state) => const AgendaPlaceholderScreen(),
             ),
           ],
         ),
-        // Branch 1: Record (default)
+        // Branch 1: Plan
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/plan',
+              builder: (context, state) => const PlanPlaceholderScreen(),
+            ),
+          ],
+        ),
+        // Branch 2: Record (default)
         StatefulShellBranch(
           routes: [
             GoRoute(
               path: '/record',
               builder: (context, state) => const RecordingScreen(),
-            ),
-          ],
-        ),
-        // Branch 2: Settings
-        StatefulShellBranch(
-          routes: [
-            GoRoute(
-              path: '/settings',
-              builder: (context, state) => const SettingsScreen(),
               routes: [
                 GoRoute(
-                  path: 'advanced',
-                  builder: (context, state) =>
-                      const AdvancedSettingsScreen(),
+                  path: 'history',
+                  builder: (context, state) => const HistoryScreen(),
+                  routes: [
+                    GoRoute(
+                      path: ':id',
+                      builder: (context, state) {
+                        final id = state.pathParameters['id']!;
+                        return TranscriptDetailScreen(transcriptId: id);
+                      },
+                    ),
+                  ],
                 ),
               ],
             ),
           ],
+        ),
+        // Branch 3: Routines
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/routines',
+              builder: (context, state) => const RoutinesPlaceholderScreen(),
+            ),
+          ],
+        ),
+        // Branch 4: Chat
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/chat',
+              builder: (context, state) => const ChatPlaceholderScreen(),
+            ),
+          ],
+        ),
+      ],
+    ),
+    // Settings — outside shell (full-screen, no bottom nav)
+    GoRoute(
+      path: '/settings',
+      builder: (context, state) => const SettingsScreen(),
+      routes: [
+        GoRoute(
+          path: 'advanced',
+          builder: (context, state) => const AdvancedSettingsScreen(),
         ),
       ],
     ),

--- a/lib/features/history/history_screen.dart
+++ b/lib/features/history/history_screen.dart
@@ -64,7 +64,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
                 final item = state.items[index];
                 return _HistoryListTile(
                   item: item,
-                  onTap: () => context.push('/history/${item.id}'),
+                  onTap: () => context.push('/record/history/${item.id}'),
                 );
               },
             ),

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -72,7 +72,19 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
     final agentReply = ref.watch(latestAgentReplyProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Record')),
+      appBar: AppBar(
+        title: const Text('Record'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.history),
+            onPressed: () => context.push('/record/history'),
+          ),
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () => context.push('/settings'),
+          ),
+        ],
+      ),
       body: Column(
         children: [
           if (!isApiConfigured)
@@ -82,7 +94,7 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
               ),
               actions: [
                 TextButton(
-                  onPressed: () => context.go('/settings'),
+                  onPressed: () => context.push('/settings'),
                   child: const Text('Go to Settings'),
                 ),
               ],
@@ -139,7 +151,7 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
             const SizedBox(height: 24),
             if (requiresAppSettings)
               FilledButton.icon(
-                onPressed: () => context.go('/settings'),
+                onPressed: () => context.push('/settings'),
                 icon: const Icon(Icons.settings),
                 label: const Text('Go to Settings'),
               )
@@ -344,7 +356,7 @@ class _ErrorStrip extends StatelessWidget {
               ),
               if (requiresAppSettings)
                 TextButton(
-                  onPressed: () => context.go('/settings'),
+                  onPressed: () => context.push('/settings'),
                   child: const Text('Go to Settings'),
                 )
               else if (requiresSettings)

--- a/test/app/app_test.dart
+++ b/test/app/app_test.dart
@@ -64,19 +64,21 @@ List<Override> get _testOverrides => [
     ];
 
 void main() {
-  testWidgets('App renders with shell and 3 tabs', (tester) async {
+  testWidgets('App renders with shell and 5 tabs', (tester) async {
     await tester.pumpWidget(
       ProviderScope(overrides: _testOverrides, child: const App()),
     );
     await tester.pumpAndSettle();
 
     expect(find.byType(NavigationBar), findsOneWidget);
-    expect(find.text('History'), findsWidgets);
+    expect(find.text('Agenda'), findsWidgets);
+    expect(find.text('Plan'), findsWidgets);
     expect(find.text('Record'), findsWidgets);
-    expect(find.text('Settings'), findsWidgets);
+    expect(find.text('Routines'), findsWidgets);
+    expect(find.text('Chat'), findsWidgets);
   });
 
-  testWidgets('Default tab is Record', (tester) async {
+  testWidgets('Default tab is Record (index 2)', (tester) async {
     await tester.pumpWidget(
       ProviderScope(overrides: _testOverrides, child: const App()),
     );
@@ -85,16 +87,16 @@ void main() {
     final navBar = tester.widget<NavigationBar>(
       find.byType(NavigationBar),
     );
-    expect(navBar.selectedIndex, 1);
+    expect(navBar.selectedIndex, 2);
   });
 
-  testWidgets('Tapping History tab shows History screen', (tester) async {
+  testWidgets('Tapping Agenda tab switches to index 0', (tester) async {
     await tester.pumpWidget(
       ProviderScope(overrides: _testOverrides, child: const App()),
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byIcon(Icons.history));
+    await tester.tap(find.byIcon(Icons.calendar_today));
     await tester.pumpAndSettle();
 
     final navBar = tester.widget<NavigationBar>(
@@ -103,19 +105,19 @@ void main() {
     expect(navBar.selectedIndex, 0);
   });
 
-  testWidgets('Tapping Settings tab shows Settings screen', (tester) async {
+  testWidgets('Tapping Chat tab switches to index 4', (tester) async {
     await tester.pumpWidget(
       ProviderScope(overrides: _testOverrides, child: const App()),
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byIcon(Icons.settings));
+    await tester.tap(find.byIcon(Icons.chat_bubble_outline));
     await tester.pumpAndSettle();
 
     final navBar = tester.widget<NavigationBar>(
       find.byType(NavigationBar),
     );
-    expect(navBar.selectedIndex, 2);
+    expect(navBar.selectedIndex, 4);
   });
 
   testWidgets('App uses Material 3', (tester) async {

--- a/test/app/router_test.dart
+++ b/test/app/router_test.dart
@@ -56,8 +56,8 @@ void main() {
     backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
   ];
 
-  group('Tab state preservation', () {
-    testWidgets('Switching tabs preserves state (indexedStack)', (tester) async {
+  group('5-tab navigation', () {
+    testWidgets('initial location is /record (center tab)', (tester) async {
       await tester.pumpWidget(
         ProviderScope(overrides: overrides, child: const App()),
       );
@@ -65,7 +65,31 @@ void main() {
 
       expect(find.text('Record'), findsWidgets);
 
-      await tester.tap(find.byIcon(Icons.history));
+      final navBar = tester.widget<NavigationBar>(
+        find.byType(NavigationBar),
+      );
+      expect(navBar.selectedIndex, 2);
+    });
+
+    testWidgets('all 5 tab destinations render', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(overrides: overrides, child: const App()),
+      );
+      await tester.pumpAndSettle();
+
+      final navBar = tester.widget<NavigationBar>(find.byType(NavigationBar));
+      expect(navBar.destinations.length, 5);
+    });
+
+    testWidgets('switching tabs preserves state (indexedStack)', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(overrides: overrides, child: const App()),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Record'), findsWidgets);
+
+      await tester.tap(find.byIcon(Icons.calendar_today));
       await tester.pumpAndSettle();
 
       await tester.tap(find.byIcon(Icons.mic));
@@ -74,8 +98,7 @@ void main() {
       final navBar = tester.widget<NavigationBar>(
         find.byType(NavigationBar),
       );
-      expect(navBar.selectedIndex, 1);
+      expect(navBar.selectedIndex, 2);
     });
   });
-
 }

--- a/test/features/settings/advanced_settings_screen_test.dart
+++ b/test/features/settings/advanced_settings_screen_test.dart
@@ -28,7 +28,6 @@ import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../helpers/in_memory_bridge_store.dart';
 import '../../helpers/stub_background_service.dart';
-import 'package:voice_agent/app/router.dart';
 import 'package:voice_agent/features/settings/advanced_settings_screen.dart';
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────
@@ -273,8 +272,6 @@ void main() {
           child: const App(),
         ),
       );
-      // Ensure we're on the record screen regardless of prior router state.
-      router.go('/record');
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('vad-params-strip')), findsOneWidget);
@@ -296,7 +293,6 @@ void main() {
           child: const App(),
         ),
       );
-      router.go('/record');
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const Key('vad-params-strip')));


### PR DESCRIPTION
## Summary
- Restructure router from 3 to 5 branches (Agenda, Plan, Record, Routines, Chat)
- Move History to `/record/history` as child route of Record branch
- Move Settings outside shell as top-level GoRoute (full-screen, no bottom nav)
- Fix `context.go('/settings')` -> `context.push('/settings')` in RecordingScreen
- Fix `/history/:id` -> `/record/history/:id` in HistoryScreen
- Add history + gear icons to RecordingScreen AppBar
- Update AppShellScaffold to 5 NavigationBar destinations
- Convert global router singleton to factory function for test isolation
- Update CLAUDE.md Route Ownership table and Navigation section
- Update all affected tests

## Test plan
- [x] `flutter analyze` — zero new issues
- [x] `flutter test` — all 497 tests pass

Closes #180
