### PR TITLE
feat(core/network): add generic postJson method to ApiClient

### DIFF
--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -124,6 +124,13 @@ class ApiClient {
     return request('PATCH', path, data: data);
   }
 
+  Future<ApiResult> postJson(
+    String path, {
+    Map<String, dynamic>? data,
+  }) {
+    return request('POST', path, data: data);
+  }
+
   Future<ApiResult> delete(String path) {
     return request('DELETE', path);
   }

--- a/test/core/network/api_client_test.dart
+++ b/test/core/network/api_client_test.dart
@@ -270,6 +270,56 @@ void main() {
       expect(_MockAdapter.lastRequestMethod, 'PATCH');
     });
 
+    test('postJson sends POST with data', () async {
+      _MockAdapter.nextStatusCode = 200;
+
+      final result = await configuredClient.postJson(
+        '/records/abc/done',
+        data: {'note': 'completed'},
+      );
+
+      expect(result, isA<ApiSuccess>());
+      expect(_MockAdapter.lastRequestPath,
+          'https://agent.jarco.casa/api/v1/records/abc/done');
+      expect(_MockAdapter.lastRequestMethod, 'POST');
+      expect(
+        (_MockAdapter.lastRequestData as Map<String, dynamic>)['note'],
+        'completed',
+      );
+    });
+
+    test('postJson sends POST without data', () async {
+      _MockAdapter.nextStatusCode = 200;
+
+      final result = await configuredClient.postJson('/records/abc/done');
+
+      expect(result, isA<ApiSuccess>());
+      expect(_MockAdapter.lastRequestMethod, 'POST');
+    });
+
+    test('postJson returns ApiNotConfigured when baseUrl is null', () async {
+      final unconfigured = ApiClient(dio: dio);
+      final result = await unconfigured.postJson('/records/abc/done');
+
+      expect(result, isA<ApiNotConfigured>());
+    });
+
+    test('postJson classifies 500 as ApiTransientFailure', () async {
+      _MockAdapter.nextStatusCode = 500;
+
+      final result = await configuredClient.postJson('/records/abc/done');
+
+      expect(result, isA<ApiTransientFailure>());
+    });
+
+    test('postJson classifies 400 as ApiPermanentFailure', () async {
+      _MockAdapter.nextStatusCode = 400;
+
+      final result = await configuredClient.postJson('/records/abc/done');
+
+      expect(result, isA<ApiPermanentFailure>());
+    });
+
     test('delete sends DELETE', () async {
       _MockAdapter.nextStatusCode = 200;
 


### PR DESCRIPTION
## Summary
- Add `postJson(String path, {Map<String, dynamic>? data})` to ApiClient
- Mirrors existing `get`/`patch`/`delete` pattern, delegates to `request('POST', ...)`
- 5 new tests covering success, no-data, not-configured, transient, and permanent failure

## Test plan
- [x] `flutter test test/core/network/api_client_test.dart` — 31 tests pass
- [x] `flutter analyze` — no issues

Closes #186
