### PR TITLE
feat(agenda): add domain and data layers with cache support

### DIFF
--- a/lib/features/agenda/data/api_agenda_repository.dart
+++ b/lib/features/agenda/data/api_agenda_repository.dart
@@ -1,0 +1,145 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+import 'package:voice_agent/core/models/agenda.dart';
+import 'package:voice_agent/core/models/routine.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/features/agenda/domain/agenda_repository.dart';
+
+class AgendaException implements Exception {
+  AgendaException(this.message);
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class ApiAgendaRepository implements AgendaRepository {
+  ApiAgendaRepository(this._apiClient);
+
+  final ApiClient _apiClient;
+  bool _cleanupDone = false;
+
+  @override
+  Future<AgendaResponse> fetchAgenda(String date) async {
+    final result = await _apiClient.get(
+      '/agenda',
+      queryParameters: {'date': date, 'granularity': 'day'},
+    );
+
+    final response = switch (result) {
+      ApiSuccess(body: final body) => _parseResponse(body),
+      ApiPermanentFailure(message: final msg, statusCode: final code) =>
+        throw AgendaException('Server error $code: $msg'),
+      ApiTransientFailure(reason: final reason) =>
+        throw AgendaException(reason),
+      ApiNotConfigured() => throw AgendaException('API not configured'),
+    };
+
+    if (!_cleanupDone) {
+      _cleanupDone = true;
+      _cleanupOldCache();
+    }
+
+    return response;
+  }
+
+  AgendaResponse _parseResponse(String? body) {
+    if (body == null) throw AgendaException('Empty response');
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final data = json['data'] as Map<String, dynamic>?;
+    if (data == null) throw AgendaException('Missing data envelope');
+    return AgendaResponse.fromMap(data);
+  }
+
+  @override
+  Future<CachedAgenda?> getCachedAgenda(String date) async {
+    try {
+      final file = await _cacheFile(date);
+      if (!file.existsSync()) return null;
+      final content = await file.readAsString();
+      final json = jsonDecode(content) as Map<String, dynamic>;
+      return CachedAgenda(
+        response:
+            AgendaResponse.fromMap(json['response'] as Map<String, dynamic>),
+        fetchedAt: DateTime.parse(json['fetched_at'] as String),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> cacheAgenda(String date, AgendaResponse response) async {
+    try {
+      final file = await _cacheFile(date);
+      final json = jsonEncode({
+        'fetched_at': DateTime.now().toIso8601String(),
+        'response': response.toMap(),
+      });
+      await file.writeAsString(json);
+    } catch (_) {
+      // Cache write is best-effort
+    }
+  }
+
+  @override
+  Future<void> markActionItemDone(String recordId) async {
+    final result = await _apiClient.postJson('/records/$recordId/done');
+    _throwOnFailure(result);
+  }
+
+  @override
+  Future<void> updateOccurrenceStatus(
+    String routineId,
+    String occurrenceId,
+    OccurrenceStatus status,
+  ) async {
+    final result = await _apiClient.patch(
+      '/routines/$routineId/occurrences/$occurrenceId',
+      data: {'status': status.toJson()},
+    );
+    _throwOnFailure(result);
+  }
+
+  void _throwOnFailure(ApiResult result) {
+    switch (result) {
+      case ApiSuccess():
+        return;
+      case ApiPermanentFailure(message: final msg, statusCode: final code):
+        throw AgendaException('Server error $code: $msg');
+      case ApiTransientFailure(reason: final reason):
+        throw AgendaException(reason);
+      case ApiNotConfigured():
+        throw AgendaException('API not configured');
+    }
+  }
+
+  Future<File> _cacheFile(String date) async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File('${dir.path}/agenda_cache_$date.json');
+  }
+
+  Future<void> _cleanupOldCache() async {
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      final cutoff = DateTime.now().subtract(const Duration(days: 7));
+      final files = dir.listSync().whereType<File>().where(
+            (f) => f.path.contains('agenda_cache_') && f.path.endsWith('.json'),
+          );
+      for (final file in files) {
+        final dateStr = file.path
+            .split('agenda_cache_')
+            .last
+            .replaceAll('.json', '');
+        final date = DateTime.tryParse(dateStr);
+        if (date != null && date.isBefore(cutoff)) {
+          await file.delete();
+        }
+      }
+    } catch (_) {
+      // Cleanup is best-effort
+    }
+  }
+}

--- a/lib/features/agenda/domain/agenda_repository.dart
+++ b/lib/features/agenda/domain/agenda_repository.dart
@@ -1,0 +1,20 @@
+import 'package:voice_agent/core/models/agenda.dart';
+import 'package:voice_agent/core/models/routine.dart';
+
+class CachedAgenda {
+  const CachedAgenda({required this.response, required this.fetchedAt});
+  final AgendaResponse response;
+  final DateTime fetchedAt;
+}
+
+abstract class AgendaRepository {
+  Future<AgendaResponse> fetchAgenda(String date);
+  Future<CachedAgenda?> getCachedAgenda(String date);
+  Future<void> cacheAgenda(String date, AgendaResponse response);
+  Future<void> markActionItemDone(String recordId);
+  Future<void> updateOccurrenceStatus(
+    String routineId,
+    String occurrenceId,
+    OccurrenceStatus status,
+  );
+}

--- a/lib/features/agenda/domain/agenda_state.dart
+++ b/lib/features/agenda/domain/agenda_state.dart
@@ -1,0 +1,27 @@
+import 'package:voice_agent/core/models/agenda.dart';
+import 'package:voice_agent/features/agenda/domain/agenda_repository.dart';
+
+sealed class AgendaState {
+  const AgendaState();
+}
+
+class AgendaInitial extends AgendaState {
+  const AgendaInitial();
+}
+
+class AgendaLoading extends AgendaState {
+  const AgendaLoading({this.cached});
+  final CachedAgenda? cached;
+}
+
+class AgendaLoaded extends AgendaState {
+  const AgendaLoaded({required this.response, required this.fetchedAt});
+  final AgendaResponse response;
+  final DateTime fetchedAt;
+}
+
+class AgendaError extends AgendaState {
+  const AgendaError({required this.message, this.cached});
+  final String message;
+  final CachedAgenda? cached;
+}

--- a/test/features/agenda/data/api_agenda_repository_test.dart
+++ b/test/features/agenda/data/api_agenda_repository_test.dart
@@ -1,0 +1,261 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/agenda.dart';
+import 'package:voice_agent/core/models/routine.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/features/agenda/data/api_agenda_repository.dart';
+
+class _StubApiClient extends ApiClient {
+  _StubApiClient() : super(baseUrl: 'https://test.com/api/v1');
+
+  ApiResult nextGetResult = const ApiSuccess(body: '{"data":{}}');
+  ApiResult nextPostResult = const ApiSuccess();
+  ApiResult nextPatchResult = const ApiSuccess();
+
+  String? lastGetPath;
+  Map<String, dynamic>? lastGetParams;
+  String? lastPostPath;
+  String? lastPatchPath;
+  Map<String, dynamic>? lastPatchData;
+
+  @override
+  Future<ApiResult> get(String path,
+      {Map<String, dynamic>? queryParameters}) async {
+    lastGetPath = path;
+    lastGetParams = queryParameters;
+    return nextGetResult;
+  }
+
+  @override
+  Future<ApiResult> postJson(String path,
+      {Map<String, dynamic>? data}) async {
+    lastPostPath = path;
+    return nextPostResult;
+  }
+
+  @override
+  Future<ApiResult> patch(String path,
+      {Map<String, dynamic>? data}) async {
+    lastPatchPath = path;
+    lastPatchData = data;
+    return nextPatchResult;
+  }
+}
+
+Map<String, dynamic> _buildAgendaJson({
+  List<Map<String, dynamic>>? items,
+  List<Map<String, dynamic>>? routineItems,
+}) {
+  return {
+    'data': {
+      'date': '2026-04-19',
+      'granularity': 'day',
+      'from': '2026-04-19',
+      'to': '2026-04-19',
+      'items': items ?? [],
+      'routine_items': routineItems ?? [],
+    },
+  };
+}
+
+Map<String, dynamic> _sampleActionItem() => {
+      'record_id': 'rec-1',
+      'text': 'Buy groceries',
+      'topic_ref': null,
+      'scheduled_for': '2026-04-19',
+      'time_window': 'day',
+      'origin_role': 'agent',
+      'status': 'active',
+      'linked_conversation_count': 1,
+    };
+
+Map<String, dynamic> _sampleRoutineItem() => {
+      'routine_id': 'rtn-1',
+      'routine_name': 'Morning routine',
+      'scheduled_for': '2026-04-19',
+      'start_time': '08:00',
+      'overdue': false,
+      'status': 'pending',
+      'occurrence_id': 'occ-1',
+      'templates': [
+        {'text': 'Meditate', 'sort_order': 0},
+      ],
+    };
+
+void main() {
+  late _StubApiClient apiClient;
+  late ApiAgendaRepository repo;
+
+  setUp(() {
+    apiClient = _StubApiClient();
+    repo = ApiAgendaRepository(apiClient);
+  });
+
+  group('fetchAgenda', () {
+    test('parses successful response with data envelope', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode(_buildAgendaJson(
+          items: [_sampleActionItem()],
+          routineItems: [_sampleRoutineItem()],
+        )),
+      );
+
+      final response = await repo.fetchAgenda('2026-04-19');
+
+      expect(response.date, '2026-04-19');
+      expect(response.items, hasLength(1));
+      expect(response.items.first.text, 'Buy groceries');
+      expect(response.routineItems, hasLength(1));
+      expect(response.routineItems.first.routineName, 'Morning routine');
+    });
+
+    test('sends correct path and query parameters', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode(_buildAgendaJson()),
+      );
+
+      await repo.fetchAgenda('2026-04-20');
+
+      expect(apiClient.lastGetPath, '/agenda');
+      expect(apiClient.lastGetParams, {
+        'date': '2026-04-20',
+        'granularity': 'day',
+      });
+    });
+
+    test('throws on empty body', () async {
+      apiClient.nextGetResult = const ApiSuccess(body: null);
+
+      expect(
+        () => repo.fetchAgenda('2026-04-19'),
+        throwsA(isA<AgendaException>()),
+      );
+    });
+
+    test('throws on missing data envelope', () async {
+      apiClient.nextGetResult = const ApiSuccess(
+        body: '{"other": "value"}',
+      );
+
+      expect(
+        () => repo.fetchAgenda('2026-04-19'),
+        throwsA(isA<AgendaException>()),
+      );
+    });
+
+    test('throws on permanent failure', () async {
+      apiClient.nextGetResult = const ApiPermanentFailure(
+        statusCode: 404,
+        message: 'Not found',
+      );
+
+      expect(
+        () => repo.fetchAgenda('2026-04-19'),
+        throwsA(
+          isA<AgendaException>().having(
+            (e) => e.message,
+            'message',
+            contains('404'),
+          ),
+        ),
+      );
+    });
+
+    test('throws on transient failure', () async {
+      apiClient.nextGetResult = const ApiTransientFailure(
+        reason: 'Timeout: connectionTimeout',
+      );
+
+      expect(
+        () => repo.fetchAgenda('2026-04-19'),
+        throwsA(
+          isA<AgendaException>().having(
+            (e) => e.message,
+            'message',
+            contains('Timeout'),
+          ),
+        ),
+      );
+    });
+
+    test('throws on not configured', () async {
+      apiClient.nextGetResult = const ApiNotConfigured();
+
+      expect(
+        () => repo.fetchAgenda('2026-04-19'),
+        throwsA(
+          isA<AgendaException>().having(
+            (e) => e.message,
+            'message',
+            contains('not configured'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('markActionItemDone', () {
+    test('sends POST to correct path', () async {
+      apiClient.nextPostResult = const ApiSuccess();
+
+      await repo.markActionItemDone('rec-1');
+
+      expect(apiClient.lastPostPath, '/records/rec-1/done');
+    });
+
+    test('throws on failure', () async {
+      apiClient.nextPostResult = const ApiPermanentFailure(
+        statusCode: 404,
+        message: 'Not found',
+      );
+
+      expect(
+        () => repo.markActionItemDone('rec-1'),
+        throwsA(isA<AgendaException>()),
+      );
+    });
+  });
+
+  group('updateOccurrenceStatus', () {
+    test('sends PATCH with correct path and data', () async {
+      apiClient.nextPatchResult = const ApiSuccess();
+
+      await repo.updateOccurrenceStatus(
+        'rtn-1',
+        'occ-1',
+        OccurrenceStatus.skipped,
+      );
+
+      expect(apiClient.lastPatchPath, '/routines/rtn-1/occurrences/occ-1');
+      expect(apiClient.lastPatchData, {'status': 'skipped'});
+    });
+
+    test('sends done status', () async {
+      apiClient.nextPatchResult = const ApiSuccess();
+
+      await repo.updateOccurrenceStatus(
+        'rtn-1',
+        'occ-1',
+        OccurrenceStatus.done,
+      );
+
+      expect(apiClient.lastPatchData, {'status': 'done'});
+    });
+
+    test('throws on failure', () async {
+      apiClient.nextPatchResult = const ApiTransientFailure(
+        reason: 'Connection error',
+      );
+
+      expect(
+        () => repo.updateOccurrenceStatus(
+          'rtn-1',
+          'occ-1',
+          OccurrenceStatus.skipped,
+        ),
+        throwsA(isA<AgendaException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add agenda domain layer: `AgendaRepository` interface, `CachedAgenda` wrapper, sealed `AgendaState`
- Add agenda data layer: `ApiAgendaRepository` with API calls, response envelope unwrap, file-based JSON cache
- 12 tests covering fetch (envelope parsing, all error types), mark-done, occurrence status update

## Test plan
- [x] `flutter test test/features/agenda/` — 12 tests pass
- [x] `flutter analyze lib/features/agenda/` — no issues

Closes #187
