### PR TITLE
chore: update gitignore for local tools and unused files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,13 @@ assets/models/
 .claude/settings.local.json
 
 # Codex CLI session state (local only, not for sharing)
-.codex/review-session-id
+.codex/
+
+# Claude Code local skills
+.claude/skills/
+
+# Sound effect samples (not production assets)
+mixkit-*.wav
+
+# iOS extensions not yet integrated
+ios/VoiceAgentControl/


### PR DESCRIPTION
## Summary
- Update .gitignore: ignore .codex/, .claude/skills/, mixkit-*.wav, ios/VoiceAgentControl/
- Delete Xcode duplicate files ("... 2.swift")
- Widget extension parked as backlog (#194)

## Test plan
- [ ] No code changes
