### PR TITLE
feat(routines): add routines list screen with notifier and providers

### DIFF
--- a/lib/features/routines/presentation/routines_notifier.dart
+++ b/lib/features/routines/presentation/routines_notifier.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/models/routine.dart';
+import 'package:voice_agent/features/routines/domain/routines_repository.dart';
+import 'package:voice_agent/features/routines/domain/routines_state.dart';
+
+class RoutinesNotifier extends StateNotifier<RoutinesState> {
+  RoutinesNotifier(this._repository) : super(const RoutinesInitial()) {
+    _selectedStatus = RoutineStatus.active;
+    loadRoutines();
+  }
+
+  final RoutinesRepository _repository;
+  late RoutineStatus _selectedStatus;
+  List<RoutineProposal> _cachedProposals = [];
+  String? lastActionError;
+
+  RoutineStatus get selectedStatus => _selectedStatus;
+
+  Future<void> loadRoutines() async {
+    state = const RoutinesLoading();
+    lastActionError = null;
+
+    try {
+      final proposalsFuture = _repository
+          .fetchProposals()
+          .then((v) => v)
+          .catchError((_) => <RoutineProposal>[]);
+      final routinesFuture = _repository.fetchRoutines(_selectedStatus);
+
+      final results = await Future.wait([routinesFuture, proposalsFuture]);
+      final routines = results[0] as List<Routine>;
+      final proposals = results[1] as List<RoutineProposal>;
+      _cachedProposals = proposals;
+
+      state = RoutinesLoaded(routines: routines, proposals: proposals);
+    } catch (e) {
+      state = RoutinesError(message: e.toString());
+    }
+  }
+
+  Future<void> selectStatus(RoutineStatus status) async {
+    _selectedStatus = status;
+    state = const RoutinesLoading();
+
+    try {
+      final routines = await _repository.fetchRoutines(status);
+      state = RoutinesLoaded(routines: routines, proposals: _cachedProposals);
+    } catch (e) {
+      state = RoutinesError(message: e.toString());
+    }
+  }
+
+  Future<void> refresh() => loadRoutines();
+
+  Future<bool> triggerRoutine(String id, String scheduledFor) async {
+    lastActionError = null;
+    try {
+      await _repository.triggerRoutine(id, scheduledFor);
+      await _reloadCurrentTab();
+      return true;
+    } on RoutineAlreadyTriggedException catch (e) {
+      lastActionError = e.message;
+      return false;
+    } on RoutinesException catch (e) {
+      lastActionError = e.message;
+      return false;
+    }
+  }
+
+  Future<bool> pauseRoutine(String id) async {
+    lastActionError = null;
+    try {
+      await _repository.pauseRoutine(id);
+      await _reloadCurrentTab();
+      return true;
+    } on RoutinesException catch (e) {
+      lastActionError = e.message;
+      return false;
+    }
+  }
+
+  Future<bool> approveProposal(String proposalId) async {
+    lastActionError = null;
+    try {
+      await _repository.approveProposal(proposalId);
+      await loadRoutines();
+      return true;
+    } on RoutinesException catch (e) {
+      lastActionError = e.message;
+      return false;
+    }
+  }
+
+  Future<bool> rejectProposal(String proposalId) async {
+    lastActionError = null;
+    try {
+      await _repository.rejectProposal(proposalId);
+      await loadRoutines();
+      return true;
+    } on RoutinesException catch (e) {
+      lastActionError = e.message;
+      return false;
+    }
+  }
+
+  Future<void> _reloadCurrentTab() async {
+    try {
+      final routines = await _repository.fetchRoutines(_selectedStatus);
+      state = RoutinesLoaded(routines: routines, proposals: _cachedProposals);
+    } catch (e) {
+      state = RoutinesError(message: e.toString());
+    }
+  }
+}

--- a/lib/features/routines/presentation/routines_providers.dart
+++ b/lib/features/routines/presentation/routines_providers.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/providers/api_client_provider.dart';
+import 'package:voice_agent/features/routines/data/api_routines_repository.dart';
+import 'package:voice_agent/features/routines/domain/routines_repository.dart';
+import 'package:voice_agent/features/routines/domain/routines_state.dart';
+import 'package:voice_agent/features/routines/presentation/routines_notifier.dart';
+
+final routinesRepositoryProvider = Provider<RoutinesRepository>((ref) {
+  final apiClient = ref.watch(apiClientProvider);
+  return ApiRoutinesRepository(apiClient);
+});
+
+final routinesNotifierProvider =
+    StateNotifierProvider<RoutinesNotifier, RoutinesState>((ref) {
+  final repository = ref.watch(routinesRepositoryProvider);
+  return RoutinesNotifier(repository);
+});

--- a/lib/features/routines/presentation/routines_screen.dart
+++ b/lib/features/routines/presentation/routines_screen.dart
@@ -1,0 +1,403 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:voice_agent/core/models/routine.dart';
+import 'package:voice_agent/features/routines/domain/routines_state.dart';
+import 'package:voice_agent/features/routines/presentation/routines_notifier.dart';
+import 'package:voice_agent/features/routines/presentation/routines_providers.dart';
+
+class RoutinesScreen extends ConsumerStatefulWidget {
+  const RoutinesScreen({super.key});
+
+  @override
+  ConsumerState<RoutinesScreen> createState() => _RoutinesScreenState();
+}
+
+class _RoutinesScreenState extends ConsumerState<RoutinesScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  static const _tabs = [
+    RoutineStatus.active,
+    RoutineStatus.draft,
+    RoutineStatus.paused,
+    RoutineStatus.archived,
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: _tabs.length, vsync: this);
+    _tabController.addListener(_onTabChanged);
+  }
+
+  @override
+  void dispose() {
+    _tabController.removeListener(_onTabChanged);
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  void _onTabChanged() {
+    if (_tabController.indexIsChanging) return;
+    ref
+        .read(routinesNotifierProvider.notifier)
+        .selectStatus(_tabs[_tabController.index]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(routinesNotifierProvider);
+    final notifier = ref.read(routinesNotifierProvider.notifier);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Routines'),
+        actions: [
+          IconButton(
+            key: const Key('routines-settings-icon'),
+            icon: const Icon(Icons.settings),
+            onPressed: () => context.push('/settings'),
+          ),
+        ],
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Active'),
+            Tab(text: 'Draft'),
+            Tab(text: 'Paused'),
+            Tab(text: 'Archived'),
+          ],
+        ),
+      ),
+      body: _buildBody(state, notifier),
+    );
+  }
+
+  Widget _buildBody(RoutinesState state, RoutinesNotifier notifier) {
+    return switch (state) {
+      RoutinesInitial() => const Center(child: CircularProgressIndicator()),
+      RoutinesLoading() => const Center(child: CircularProgressIndicator()),
+      RoutinesLoaded(routines: final routines, proposals: final proposals) =>
+        _buildContent(routines, proposals, notifier),
+      RoutinesError(message: final message) =>
+        _buildError(message, notifier),
+    };
+  }
+
+  Widget _buildContent(
+    List<Routine> routines,
+    List<RoutineProposal> proposals,
+    RoutinesNotifier notifier,
+  ) {
+    final showProposals =
+        proposals.isNotEmpty && _tabController.index == 0;
+
+    return RefreshIndicator(
+      onRefresh: notifier.refresh,
+      child: routines.isEmpty && !showProposals
+          ? ListView(
+              children: [
+                const SizedBox(height: 120),
+                Center(
+                  child: Column(
+                    children: [
+                      const Icon(Icons.event_repeat,
+                          size: 64, color: Colors.grey),
+                      const SizedBox(height: 16),
+                      Text(
+                        'No ${_tabs[_tabController.index].name} routines',
+                        key: const Key('routines-empty-state'),
+                        style: const TextStyle(
+                            fontSize: 16, color: Colors.grey),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            )
+          : ListView(
+              children: [
+                if (showProposals) ...[
+                  _SectionHeader(
+                    title: 'Proposals',
+                    count: proposals.length,
+                  ),
+                  ...proposals.map((p) => _ProposalCard(
+                        proposal: p,
+                        onApprove: () => _handleApprove(p.id),
+                        onReject: () => _handleReject(p.id),
+                      )),
+                  const Divider(),
+                ],
+                ...routines.map((r) => _RoutineCard(
+                      routine: r,
+                      onTap: () => _navigateToDetail(r.id),
+                      onTrigger:
+                          r.status == RoutineStatus.active
+                              ? () => _handleTrigger(r.id)
+                              : null,
+                      onPause:
+                          r.status == RoutineStatus.active
+                              ? () => _handlePause(r.id)
+                              : null,
+                    )),
+              ],
+            ),
+    );
+  }
+
+  Widget _buildError(String message, RoutinesNotifier notifier) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.error_outline, size: 64, color: Colors.red),
+          const SizedBox(height: 16),
+          Text(message, textAlign: TextAlign.center),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            key: const Key('routines-retry-button'),
+            onPressed: notifier.refresh,
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _navigateToDetail(String routineId) async {
+    await context.push('/routines/$routineId');
+    if (mounted) {
+      ref.read(routinesNotifierProvider.notifier).refresh();
+    }
+  }
+
+  Future<void> _handleTrigger(String id) async {
+    final now = DateTime.now();
+    final date =
+        '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+    final notifier = ref.read(routinesNotifierProvider.notifier);
+    final success = await notifier.triggerRoutine(id, date);
+    if (!success && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content:
+                Text(notifier.lastActionError ?? 'Failed to trigger')),
+      );
+    }
+  }
+
+  Future<void> _handlePause(String id) async {
+    final notifier = ref.read(routinesNotifierProvider.notifier);
+    final success = await notifier.pauseRoutine(id);
+    if (!success && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content:
+                Text(notifier.lastActionError ?? 'Failed to pause')),
+      );
+    }
+  }
+
+  Future<void> _handleApprove(String proposalId) async {
+    final notifier = ref.read(routinesNotifierProvider.notifier);
+    final success = await notifier.approveProposal(proposalId);
+    if (!success && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content:
+                Text(notifier.lastActionError ?? 'Failed to approve')),
+      );
+    }
+  }
+
+  Future<void> _handleReject(String proposalId) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Reject proposal?'),
+        content:
+            const Text('This proposal will be permanently dismissed.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            key: const Key('reject-confirm-button'),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Reject'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    final notifier = ref.read(routinesNotifierProvider.notifier);
+    final success = await notifier.rejectProposal(proposalId);
+    if (!success && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content:
+                Text(notifier.lastActionError ?? 'Failed to reject')),
+      );
+    }
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title, required this.count});
+  final String title;
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      child: Row(
+        children: [
+          Text(
+            title,
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+          ),
+          const SizedBox(width: 8),
+          Text('($count)', style: Theme.of(context).textTheme.bodySmall),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProposalCard extends StatelessWidget {
+  const _ProposalCard({
+    required this.proposal,
+    required this.onApprove,
+    required this.onReject,
+  });
+  final RoutineProposal proposal;
+  final VoidCallback onApprove;
+  final VoidCallback onReject;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: Key('proposal-card-${proposal.id}'),
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(proposal.name,
+                      style: Theme.of(context).textTheme.titleMedium),
+                ),
+                if (proposal.cadence != null)
+                  Chip(label: Text(proposal.cadence!)),
+              ],
+            ),
+            const SizedBox(height: 8),
+            ...proposal.items.take(3).map(
+                  (item) => Padding(
+                    padding: const EdgeInsets.only(left: 8, bottom: 2),
+                    child: Text('- ${item.text}',
+                        style: Theme.of(context).textTheme.bodyMedium),
+                  ),
+                ),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  key: Key('proposal-reject-${proposal.id}'),
+                  onPressed: onReject,
+                  child: const Text('Reject'),
+                ),
+                const SizedBox(width: 8),
+                FilledButton(
+                  key: Key('proposal-approve-${proposal.id}'),
+                  onPressed: onApprove,
+                  child: const Text('Approve'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RoutineCard extends StatelessWidget {
+  const _RoutineCard({
+    required this.routine,
+    required this.onTap,
+    this.onTrigger,
+    this.onPause,
+  });
+  final Routine routine;
+  final VoidCallback onTap;
+  final VoidCallback? onTrigger;
+  final VoidCallback? onPause;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: Key('routine-card-${routine.id}'),
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(routine.name,
+                        style: Theme.of(context).textTheme.titleMedium),
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        if (routine.cadence != null) ...[
+                          Text(routine.cadence!,
+                              style: Theme.of(context).textTheme.bodySmall),
+                          const SizedBox(width: 12),
+                        ],
+                        if (routine.nextOccurrence != null)
+                          Text(
+                            'Next: ${routine.nextOccurrence!.date}',
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              if (onTrigger != null)
+                IconButton(
+                  key: Key('routine-trigger-${routine.id}'),
+                  icon: const Icon(Icons.play_arrow),
+                  tooltip: 'Trigger now',
+                  onPressed: onTrigger,
+                ),
+              if (onPause != null)
+                IconButton(
+                  key: Key('routine-pause-${routine.id}'),
+                  icon: const Icon(Icons.pause),
+                  tooltip: 'Pause',
+                  onPressed: onPause,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/routines/presentation/routines_notifier_test.dart
+++ b/test/features/routines/presentation/routines_notifier_test.dart
@@ -1,0 +1,328 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/routine.dart';
+import 'package:voice_agent/features/routines/domain/routines_repository.dart';
+import 'package:voice_agent/features/routines/domain/routines_state.dart';
+import 'package:voice_agent/features/routines/presentation/routines_notifier.dart';
+
+class _MockRepository implements RoutinesRepository {
+  List<Routine> nextRoutines = [];
+  List<RoutineProposal> nextProposals = [];
+  Exception? fetchRoutinesError;
+  Exception? fetchProposalsError;
+  Exception? actionError;
+
+  int fetchRoutinesCount = 0;
+  int fetchProposalsCount = 0;
+  RoutineStatus? lastFetchStatus;
+  String? lastTriggerId;
+  String? lastTriggerDate;
+  String? lastPauseId;
+  String? lastApproveId;
+  String? lastRejectId;
+
+  @override
+  Future<List<Routine>> fetchRoutines(RoutineStatus status) async {
+    fetchRoutinesCount++;
+    lastFetchStatus = status;
+    if (fetchRoutinesError != null) throw fetchRoutinesError!;
+    return nextRoutines;
+  }
+
+  @override
+  Future<List<RoutineProposal>> fetchProposals() async {
+    fetchProposalsCount++;
+    if (fetchProposalsError != null) throw fetchProposalsError!;
+    return nextProposals;
+  }
+
+  @override
+  Future<Routine> fetchRoutineDetail(String id) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<List<RoutineOccurrence>> fetchOccurrences(String id) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> activateRoutine(String id) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> pauseRoutine(String id) async {
+    lastPauseId = id;
+    if (actionError != null) throw actionError!;
+  }
+
+  @override
+  Future<void> archiveRoutine(String id) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> triggerRoutine(String id, String scheduledFor) async {
+    lastTriggerId = id;
+    lastTriggerDate = scheduledFor;
+    if (actionError != null) throw actionError!;
+  }
+
+  @override
+  Future<void> updateOccurrenceStatus(
+    String routineId,
+    String occurrenceId,
+    OccurrenceStatus status,
+  ) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> approveProposal(String proposalId) async {
+    lastApproveId = proposalId;
+    if (actionError != null) throw actionError!;
+  }
+
+  @override
+  Future<void> rejectProposal(String proposalId) async {
+    lastRejectId = proposalId;
+    if (actionError != null) throw actionError!;
+  }
+}
+
+Routine _sampleRoutine({String id = 'rtn-1', String name = 'Morning routine'}) =>
+    Routine(
+      id: id,
+      sourceRecordId: 'src-1',
+      name: name,
+      rrule: 'FREQ=DAILY',
+      cadence: 'daily',
+      status: RoutineStatus.active,
+      createdAt: DateTime(2026, 4, 1),
+      updatedAt: DateTime(2026, 4, 18),
+    );
+
+RoutineProposal _sampleProposal({String id = 'prop-1'}) => RoutineProposal(
+      id: id,
+      name: 'Weekly review',
+      cadence: 'weekly',
+      items: const [RoutineProposalItem(text: 'Review items', sortOrder: 1)],
+      confidence: 0.85,
+      conversationId: 'conv-1',
+      createdAt: DateTime(2026, 4, 18),
+    );
+
+void main() {
+  late _MockRepository repo;
+
+  setUp(() {
+    repo = _MockRepository();
+  });
+
+  group('RoutinesNotifier', () {
+    test('constructor triggers loadRoutines and transitions to loaded',
+        () async {
+      repo.nextRoutines = [_sampleRoutine()];
+      repo.nextProposals = [_sampleProposal()];
+      final notifier = RoutinesNotifier(repo);
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(notifier.state, isA<RoutinesLoaded>());
+      final loaded = notifier.state as RoutinesLoaded;
+      expect(loaded.routines, hasLength(1));
+      expect(loaded.proposals, hasLength(1));
+    });
+
+    test('defaults to active status', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(notifier.selectedStatus, RoutineStatus.active);
+      expect(repo.lastFetchStatus, RoutineStatus.active);
+    });
+
+    test('transitions to error on fetch failure', () async {
+      repo.fetchRoutinesError = Exception('Network error');
+      final notifier = RoutinesNotifier(repo);
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(notifier.state, isA<RoutinesError>());
+      expect(
+        (notifier.state as RoutinesError).message,
+        contains('Network error'),
+      );
+    });
+
+    test('proposals failure does not block routines loading', () async {
+      repo.nextRoutines = [_sampleRoutine()];
+      repo.fetchProposalsError = Exception('Proposals failed');
+      final notifier = RoutinesNotifier(repo);
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(notifier.state, isA<RoutinesLoaded>());
+      final loaded = notifier.state as RoutinesLoaded;
+      expect(loaded.routines, hasLength(1));
+      expect(loaded.proposals, isEmpty);
+    });
+
+    test('selectStatus changes tab and reloads routines', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.fetchRoutinesCount = 0;
+      await notifier.selectStatus(RoutineStatus.draft);
+
+      expect(notifier.selectedStatus, RoutineStatus.draft);
+      expect(repo.lastFetchStatus, RoutineStatus.draft);
+      expect(repo.fetchRoutinesCount, 1);
+    });
+
+    test('selectStatus retains cached proposals', () async {
+      repo.nextProposals = [_sampleProposal()];
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      await notifier.selectStatus(RoutineStatus.paused);
+
+      final loaded = notifier.state as RoutinesLoaded;
+      expect(loaded.proposals, hasLength(1));
+    });
+
+    test('selectStatus transitions to error on failure', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.fetchRoutinesError = Exception('Offline');
+      await notifier.selectStatus(RoutineStatus.archived);
+
+      expect(notifier.state, isA<RoutinesError>());
+    });
+
+    test('refresh reloads data', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.fetchRoutinesCount = 0;
+      repo.fetchProposalsCount = 0;
+      await notifier.refresh();
+
+      expect(repo.fetchRoutinesCount, 1);
+      expect(repo.fetchProposalsCount, 1);
+      expect(notifier.state, isA<RoutinesLoaded>());
+    });
+
+    test('triggerRoutine returns true on success', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await notifier.triggerRoutine('rtn-1', '2026-04-19');
+
+      expect(result, isTrue);
+      expect(repo.lastTriggerId, 'rtn-1');
+      expect(repo.lastTriggerDate, '2026-04-19');
+      expect(notifier.lastActionError, isNull);
+    });
+
+    test('triggerRoutine returns false on RoutineAlreadyTriggered', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.actionError = RoutineAlreadyTriggedException();
+      final result = await notifier.triggerRoutine('rtn-1', '2026-04-19');
+
+      expect(result, isFalse);
+      expect(notifier.lastActionError, 'Already triggered for this date');
+    });
+
+    test('triggerRoutine returns false on general exception', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.actionError = RoutinesGeneralException('Server error');
+      final result = await notifier.triggerRoutine('rtn-1', '2026-04-19');
+
+      expect(result, isFalse);
+      expect(notifier.lastActionError, 'Server error');
+    });
+
+    test('pauseRoutine returns true on success', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await notifier.pauseRoutine('rtn-1');
+
+      expect(result, isTrue);
+      expect(repo.lastPauseId, 'rtn-1');
+    });
+
+    test('pauseRoutine returns false on failure', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.actionError = RoutinesGeneralException('Cannot pause');
+      final result = await notifier.pauseRoutine('rtn-1');
+
+      expect(result, isFalse);
+      expect(notifier.lastActionError, 'Cannot pause');
+    });
+
+    test('approveProposal returns true and reloads on success', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.fetchRoutinesCount = 0;
+      repo.fetchProposalsCount = 0;
+      final result = await notifier.approveProposal('prop-1');
+
+      expect(result, isTrue);
+      expect(repo.lastApproveId, 'prop-1');
+      expect(repo.fetchRoutinesCount, 1);
+      expect(repo.fetchProposalsCount, 1);
+    });
+
+    test('approveProposal returns false on failure', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.actionError = RoutinesGeneralException('Approve failed');
+      final result = await notifier.approveProposal('prop-1');
+
+      expect(result, isFalse);
+      expect(notifier.lastActionError, 'Approve failed');
+    });
+
+    test('rejectProposal returns true and reloads on success', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.fetchRoutinesCount = 0;
+      final result = await notifier.rejectProposal('prop-1');
+
+      expect(result, isTrue);
+      expect(repo.lastRejectId, 'prop-1');
+      expect(repo.fetchRoutinesCount, 1);
+    });
+
+    test('rejectProposal returns false on failure', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.actionError = RoutinesGeneralException('Reject failed');
+      final result = await notifier.rejectProposal('prop-1');
+
+      expect(result, isFalse);
+      expect(notifier.lastActionError, 'Reject failed');
+    });
+
+    test('lastActionError clears on new action', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.actionError = RoutinesGeneralException('Error');
+      await notifier.triggerRoutine('rtn-1', '2026-04-19');
+      expect(notifier.lastActionError, 'Error');
+
+      repo.actionError = null;
+      await notifier.pauseRoutine('rtn-1');
+      expect(notifier.lastActionError, isNull);
+    });
+  });
+}

--- a/test/features/routines/presentation/routines_screen_test.dart
+++ b/test/features/routines/presentation/routines_screen_test.dart
@@ -1,0 +1,377 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:voice_agent/core/models/routine.dart';
+import 'package:voice_agent/features/routines/domain/routines_repository.dart';
+import 'package:voice_agent/features/routines/presentation/routines_providers.dart';
+import 'package:voice_agent/features/routines/presentation/routines_screen.dart';
+
+class _StubRepository implements RoutinesRepository {
+  List<Routine> routines;
+  List<RoutineProposal> proposals;
+  _StubRepository({
+    this.routines = const [],
+    this.proposals = const [],
+  });
+
+  @override
+  Future<List<Routine>> fetchRoutines(RoutineStatus status) async => routines;
+
+  @override
+  Future<List<RoutineProposal>> fetchProposals() async => proposals;
+
+  @override
+  Future<Routine> fetchRoutineDetail(String id) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<List<RoutineOccurrence>> fetchOccurrences(String id) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> activateRoutine(String id) async {}
+
+  @override
+  Future<void> pauseRoutine(String id) async {}
+
+  @override
+  Future<void> archiveRoutine(String id) async {}
+
+  @override
+  Future<void> triggerRoutine(String id, String scheduledFor) async {}
+
+  @override
+  Future<void> updateOccurrenceStatus(
+    String routineId,
+    String occurrenceId,
+    OccurrenceStatus status,
+  ) async {}
+
+  @override
+  Future<void> approveProposal(String proposalId) async {}
+
+  @override
+  Future<void> rejectProposal(String proposalId) async {}
+}
+
+Routine _sampleRoutine({
+  String id = 'rtn-1',
+  String name = 'Morning routine',
+  RoutineStatus status = RoutineStatus.active,
+  String? cadence = 'daily',
+  RoutineNextOccurrence? nextOccurrence,
+}) =>
+    Routine(
+      id: id,
+      sourceRecordId: 'src-1',
+      name: name,
+      rrule: 'FREQ=DAILY',
+      cadence: cadence,
+      status: status,
+      nextOccurrence: nextOccurrence,
+      createdAt: DateTime(2026, 4, 1),
+      updatedAt: DateTime(2026, 4, 18),
+    );
+
+RoutineProposal _sampleProposal({String id = 'prop-1'}) => RoutineProposal(
+      id: id,
+      name: 'Weekly review',
+      cadence: 'weekly',
+      items: const [RoutineProposalItem(text: 'Review items', sortOrder: 1)],
+      confidence: 0.85,
+      conversationId: 'conv-1',
+      createdAt: DateTime(2026, 4, 18),
+    );
+
+Future<void> _pumpScreen(
+  WidgetTester tester, {
+  RoutinesRepository? repository,
+}) async {
+  final repo = repository ?? _StubRepository();
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const RoutinesScreen(),
+      ),
+      GoRoute(
+        path: '/settings',
+        builder: (context, state) =>
+            const Scaffold(body: Text('Settings')),
+      ),
+      GoRoute(
+        path: '/routines/:id',
+        builder: (context, state) =>
+            Scaffold(body: Text('Detail ${state.pathParameters['id']}')),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        routinesRepositoryProvider.overrideWithValue(repo),
+      ],
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('RoutinesScreen', () {
+    testWidgets('renders AppBar with title', (tester) async {
+      await _pumpScreen(tester);
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text('Routines'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders gear icon that navigates to settings',
+        (tester) async {
+      await _pumpScreen(tester);
+
+      expect(find.byKey(const Key('routines-settings-icon')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('routines-settings-icon')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Settings'), findsOneWidget);
+    });
+
+    testWidgets('renders four tabs', (tester) async {
+      await _pumpScreen(tester);
+
+      expect(find.text('Active'), findsOneWidget);
+      expect(find.text('Draft'), findsOneWidget);
+      expect(find.text('Paused'), findsOneWidget);
+      expect(find.text('Archived'), findsOneWidget);
+    });
+
+    testWidgets('shows empty state when no routines', (tester) async {
+      await _pumpScreen(tester);
+
+      expect(find.byKey(const Key('routines-empty-state')), findsOneWidget);
+      expect(find.text('No active routines'), findsOneWidget);
+    });
+
+    testWidgets('renders routine cards', (tester) async {
+      final repo = _StubRepository(
+        routines: [_sampleRoutine()],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.text('Morning routine'), findsOneWidget);
+      expect(find.byKey(const Key('routine-card-rtn-1')), findsOneWidget);
+    });
+
+    testWidgets('routine card shows cadence', (tester) async {
+      final repo = _StubRepository(
+        routines: [_sampleRoutine(cadence: 'daily')],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.text('daily'), findsOneWidget);
+    });
+
+    testWidgets('routine card shows next occurrence date', (tester) async {
+      final repo = _StubRepository(
+        routines: [
+          _sampleRoutine(
+            nextOccurrence: const RoutineNextOccurrence(
+              date: '2026-04-20',
+              timeWindow: TimeWindow.day,
+            ),
+          ),
+        ],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.text('Next: 2026-04-20'), findsOneWidget);
+    });
+
+    testWidgets('active routine shows trigger and pause buttons',
+        (tester) async {
+      final repo = _StubRepository(
+        routines: [_sampleRoutine(status: RoutineStatus.active)],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      expect(
+        find.byKey(const Key('routine-trigger-rtn-1')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('routine-pause-rtn-1')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tapping routine card navigates to detail', (tester) async {
+      final repo = _StubRepository(
+        routines: [_sampleRoutine()],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      await tester.tap(find.text('Morning routine'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Detail rtn-1'), findsOneWidget);
+    });
+
+    testWidgets('renders proposal cards on active tab', (tester) async {
+      final repo = _StubRepository(
+        proposals: [_sampleProposal()],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.text('Proposals'), findsOneWidget);
+      expect(find.text('Weekly review'), findsOneWidget);
+      expect(find.byKey(const Key('proposal-card-prop-1')), findsOneWidget);
+    });
+
+    testWidgets('proposal card shows cadence chip', (tester) async {
+      final repo = _StubRepository(
+        proposals: [_sampleProposal()],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.text('weekly'), findsOneWidget);
+    });
+
+    testWidgets('proposal card shows items', (tester) async {
+      final repo = _StubRepository(
+        proposals: [_sampleProposal()],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.text('- Review items'), findsOneWidget);
+    });
+
+    testWidgets('proposal card has approve and reject buttons',
+        (tester) async {
+      final repo = _StubRepository(
+        proposals: [_sampleProposal()],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      expect(
+        find.byKey(const Key('proposal-approve-prop-1')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('proposal-reject-prop-1')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('reject shows confirmation dialog', (tester) async {
+      final repo = _StubRepository(
+        proposals: [_sampleProposal()],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      await tester.tap(find.byKey(const Key('proposal-reject-prop-1')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Reject proposal?'), findsOneWidget);
+      expect(
+        find.text('This proposal will be permanently dismissed.'),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('reject-confirm-button')), findsOneWidget);
+    });
+
+    testWidgets('reject cancel dismisses dialog', (tester) async {
+      final repo = _StubRepository(
+        proposals: [_sampleProposal()],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      await tester.tap(find.byKey(const Key('proposal-reject-prop-1')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Reject proposal?'), findsNothing);
+    });
+
+    testWidgets('error state shows retry button', (tester) async {
+      await _pumpScreen(tester, repository: _FailingRepository());
+
+      expect(find.byKey(const Key('routines-retry-button')), findsOneWidget);
+      expect(find.text('Fetch failed'), findsOneWidget);
+    });
+
+    testWidgets('switching tabs changes empty state text', (tester) async {
+      await _pumpScreen(tester);
+
+      await tester.tap(find.text('Draft'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No draft routines'), findsOneWidget);
+    });
+  });
+}
+
+class _FailingRepository implements RoutinesRepository {
+  @override
+  Future<List<Routine>> fetchRoutines(RoutineStatus status) async =>
+      throw RoutinesGeneralException('Fetch failed');
+
+  @override
+  Future<List<RoutineProposal>> fetchProposals() async =>
+      throw RoutinesGeneralException('Fetch failed');
+
+  @override
+  Future<Routine> fetchRoutineDetail(String id) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<List<RoutineOccurrence>> fetchOccurrences(String id) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> activateRoutine(String id) async {}
+
+  @override
+  Future<void> pauseRoutine(String id) async {}
+
+  @override
+  Future<void> archiveRoutine(String id) async {}
+
+  @override
+  Future<void> triggerRoutine(String id, String scheduledFor) async {}
+
+  @override
+  Future<void> updateOccurrenceStatus(
+    String routineId,
+    String occurrenceId,
+    OccurrenceStatus status,
+  ) async {}
+
+  @override
+  Future<void> approveProposal(String proposalId) async {}
+
+  @override
+  Future<void> rejectProposal(String proposalId) async {}
+}


### PR DESCRIPTION
## Summary

- Add `RoutinesNotifier` (StateNotifier) with dual-fetch composition, tab switching, and action methods (trigger, pause, approve, reject proposals)
- Add `RoutinesScreen` with 4-tab layout (Active/Draft/Paused/Archived), proposal cards on Active tab, routine cards with action buttons
- Add Riverpod provider wiring (`routinesRepositoryProvider`, `routinesNotifierProvider`)
- 18 notifier state-transition tests + 17 screen widget tests (all 591 project tests pass)

## Test plan

- [x] `flutter analyze` passes (zero new issues)
- [x] `flutter test` passes (591 tests, including 35 new)
- [x] Architecture dependency rule verified (no cross-feature imports)

Closes #198
