### PR TITLE
fix(routines): P022 review gaps — busy states, resume, confidence

### DIFF
--- a/lib/features/routines/presentation/routine_detail_screen.dart
+++ b/lib/features/routines/presentation/routine_detail_screen.dart
@@ -5,15 +5,29 @@ import 'package:voice_agent/features/routines/domain/routine_detail_state.dart';
 import 'package:voice_agent/features/routines/presentation/routine_detail_notifier.dart';
 import 'package:voice_agent/features/routines/presentation/routines_providers.dart';
 
-class RoutineDetailScreen extends ConsumerWidget {
+class RoutineDetailScreen extends ConsumerStatefulWidget {
   const RoutineDetailScreen({super.key, required this.routineId});
   final String routineId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(routineDetailNotifierProvider(routineId));
+  ConsumerState<RoutineDetailScreen> createState() =>
+      _RoutineDetailScreenState();
+}
+
+class _RoutineDetailScreenState extends ConsumerState<RoutineDetailScreen> {
+  final Set<String> _busyActions = {};
+
+  bool get _isAnyBusy => _busyActions.isNotEmpty;
+
+  void _setBusy(String action) => setState(() => _busyActions.add(action));
+  void _clearBusy(String action) => setState(() => _busyActions.remove(action));
+
+  @override
+  Widget build(BuildContext context) {
+    final state =
+        ref.watch(routineDetailNotifierProvider(widget.routineId));
     final notifier =
-        ref.read(routineDetailNotifierProvider(routineId).notifier);
+        ref.read(routineDetailNotifierProvider(widget.routineId).notifier);
 
     return Scaffold(
       appBar: AppBar(
@@ -41,14 +55,13 @@ class RoutineDetailScreen extends ConsumerWidget {
       RoutineDetailLoading() =>
         const Center(child: CircularProgressIndicator()),
       RoutineDetailLoaded(routine: final routine, occurrences: final occs) =>
-        _buildContent(context, routine, occs, notifier),
+        _buildContent(routine, occs, notifier),
       RoutineDetailError(message: final message) =>
-        _buildError(context, message, notifier),
+        _buildError(message, notifier),
     };
   }
 
   Widget _buildContent(
-    BuildContext context,
     Routine routine,
     List<RoutineOccurrence> occurrences,
     RoutineDetailNotifier notifier,
@@ -66,15 +79,17 @@ class RoutineDetailScreen extends ConsumerWidget {
           _OccurrencesSection(
             occurrences: occurrences,
             onUpdateStatus: (occId, status) =>
-                _handleUpdateOccurrence(context, notifier, occId, status),
+                _handleUpdateOccurrence(notifier, occId, status),
           ),
           const Divider(),
           _ActionsSection(
             routine: routine,
-            onActivate: () => _handleActivate(context, notifier),
-            onPause: () => _handlePause(context, notifier),
-            onArchive: () => _handleArchive(context, notifier),
-            onTrigger: () => _handleTrigger(context, notifier),
+            busyActions: _busyActions,
+            isAnyBusy: _isAnyBusy,
+            onActivate: () => _handleActivate(notifier),
+            onPause: () => _handlePause(notifier),
+            onArchive: () => _handleArchive(notifier),
+            onTrigger: () => _handleTrigger(notifier),
           ),
           const SizedBox(height: 32),
         ],
@@ -83,7 +98,6 @@ class RoutineDetailScreen extends ConsumerWidget {
   }
 
   Widget _buildError(
-    BuildContext context,
     String message,
     RoutineDetailNotifier notifier,
   ) {
@@ -105,12 +119,12 @@ class RoutineDetailScreen extends ConsumerWidget {
     );
   }
 
-  Future<void> _handleActivate(
-    BuildContext context,
-    RoutineDetailNotifier notifier,
-  ) async {
+  Future<void> _handleActivate(RoutineDetailNotifier notifier) async {
+    _setBusy('activate');
     final success = await notifier.activateRoutine();
-    if (!success && context.mounted) {
+    if (!mounted) return;
+    _clearBusy('activate');
+    if (!success) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
             content:
@@ -119,12 +133,12 @@ class RoutineDetailScreen extends ConsumerWidget {
     }
   }
 
-  Future<void> _handlePause(
-    BuildContext context,
-    RoutineDetailNotifier notifier,
-  ) async {
+  Future<void> _handlePause(RoutineDetailNotifier notifier) async {
+    _setBusy('pause');
     final success = await notifier.pauseRoutine();
-    if (!success && context.mounted) {
+    if (!mounted) return;
+    _clearBusy('pause');
+    if (!success) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
             content: Text(notifier.lastActionError ?? 'Failed to pause')),
@@ -132,10 +146,7 @@ class RoutineDetailScreen extends ConsumerWidget {
     }
   }
 
-  Future<void> _handleArchive(
-    BuildContext context,
-    RoutineDetailNotifier notifier,
-  ) async {
+  Future<void> _handleArchive(RoutineDetailNotifier notifier) async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -157,8 +168,11 @@ class RoutineDetailScreen extends ConsumerWidget {
     );
     if (confirmed != true) return;
 
+    _setBusy('archive');
     final success = await notifier.archiveRoutine();
-    if (!success && context.mounted) {
+    if (!mounted) return;
+    _clearBusy('archive');
+    if (!success) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
             content:
@@ -167,15 +181,15 @@ class RoutineDetailScreen extends ConsumerWidget {
     }
   }
 
-  Future<void> _handleTrigger(
-    BuildContext context,
-    RoutineDetailNotifier notifier,
-  ) async {
+  Future<void> _handleTrigger(RoutineDetailNotifier notifier) async {
+    _setBusy('trigger');
     final now = DateTime.now();
     final date =
         '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
     final success = await notifier.triggerRoutine(date);
-    if (!success && context.mounted) {
+    if (!mounted) return;
+    _clearBusy('trigger');
+    if (!success) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
             content:
@@ -185,14 +199,14 @@ class RoutineDetailScreen extends ConsumerWidget {
   }
 
   Future<void> _handleUpdateOccurrence(
-    BuildContext context,
     RoutineDetailNotifier notifier,
     String occurrenceId,
     OccurrenceStatus status,
   ) async {
     final success =
         await notifier.updateOccurrenceStatus(occurrenceId, status);
-    if (!success && context.mounted) {
+    if (!mounted) return;
+    if (!success) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
             content: Text(
@@ -341,12 +355,16 @@ class _OccurrencesSection extends StatelessWidget {
 class _ActionsSection extends StatelessWidget {
   const _ActionsSection({
     required this.routine,
+    required this.busyActions,
+    required this.isAnyBusy,
     required this.onActivate,
     required this.onPause,
     required this.onArchive,
     required this.onTrigger,
   });
   final Routine routine;
+  final Set<String> busyActions;
+  final bool isAnyBusy;
   final VoidCallback onActivate;
   final VoidCallback onPause;
   final VoidCallback onArchive;
@@ -362,35 +380,98 @@ class _ActionsSection extends StatelessWidget {
         children: [
           if (routine.status == RoutineStatus.draft ||
               routine.status == RoutineStatus.paused)
-            FilledButton.icon(
-              key: const Key('detail-activate-button'),
+            _ActionButton(
+              widgetKey: const Key('detail-activate-button'),
+              label: 'Activate',
+              icon: Icons.play_arrow,
+              isBusy: busyActions.contains('activate'),
+              isDisabled: isAnyBusy,
               onPressed: onActivate,
-              icon: const Icon(Icons.play_arrow),
-              label: const Text('Activate'),
+              filled: true,
             ),
           if (routine.status == RoutineStatus.active)
-            OutlinedButton.icon(
-              key: const Key('detail-pause-button'),
+            _ActionButton(
+              widgetKey: const Key('detail-pause-button'),
+              label: 'Pause',
+              icon: Icons.pause,
+              isBusy: busyActions.contains('pause'),
+              isDisabled: isAnyBusy,
               onPressed: onPause,
-              icon: const Icon(Icons.pause),
-              label: const Text('Pause'),
+              filled: false,
             ),
           if (routine.status == RoutineStatus.active)
-            FilledButton.icon(
-              key: const Key('detail-trigger-button'),
+            _ActionButton(
+              widgetKey: const Key('detail-trigger-button'),
+              label: 'Trigger Now',
+              icon: Icons.bolt,
+              isBusy: busyActions.contains('trigger'),
+              isDisabled: isAnyBusy,
               onPressed: onTrigger,
-              icon: const Icon(Icons.bolt),
-              label: const Text('Trigger Now'),
+              filled: true,
             ),
           if (routine.status != RoutineStatus.archived)
-            OutlinedButton.icon(
-              key: const Key('detail-archive-button'),
+            _ActionButton(
+              widgetKey: const Key('detail-archive-button'),
+              label: 'Archive',
+              icon: Icons.archive,
+              isBusy: busyActions.contains('archive'),
+              isDisabled: isAnyBusy,
               onPressed: onArchive,
-              icon: const Icon(Icons.archive),
-              label: const Text('Archive'),
+              filled: false,
             ),
         ],
       ),
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    required this.widgetKey,
+    required this.label,
+    required this.icon,
+    required this.isBusy,
+    required this.isDisabled,
+    required this.onPressed,
+    required this.filled,
+  });
+
+  final Key widgetKey;
+  final String label;
+  final IconData icon;
+  final bool isBusy;
+  final bool isDisabled;
+  final VoidCallback onPressed;
+  final bool filled;
+
+  @override
+  Widget build(BuildContext context) {
+    final child = isBusy
+        ? const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          )
+        : Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 18),
+              const SizedBox(width: 4),
+              Text(label),
+            ],
+          );
+
+    if (filled) {
+      return FilledButton(
+        key: widgetKey,
+        onPressed: isDisabled ? null : onPressed,
+        child: child,
+      );
+    }
+    return OutlinedButton(
+      key: widgetKey,
+      onPressed: isDisabled ? null : onPressed,
+      child: child,
     );
   }
 }

--- a/lib/features/routines/presentation/routines_notifier.dart
+++ b/lib/features/routines/presentation/routines_notifier.dart
@@ -67,6 +67,18 @@ class RoutinesNotifier extends StateNotifier<RoutinesState> {
     }
   }
 
+  Future<bool> activateRoutine(String id) async {
+    lastActionError = null;
+    try {
+      await _repository.activateRoutine(id);
+      await _reloadCurrentTab();
+      return true;
+    } on RoutinesException catch (e) {
+      lastActionError = e.message;
+      return false;
+    }
+  }
+
   Future<bool> pauseRoutine(String id) async {
     lastActionError = null;
     try {

--- a/lib/features/routines/presentation/routines_screen.dart
+++ b/lib/features/routines/presentation/routines_screen.dart
@@ -24,6 +24,8 @@ class _RoutinesScreenState extends ConsumerState<RoutinesScreen>
     RoutineStatus.archived,
   ];
 
+  final Set<String> _busyIds = {};
+
   @override
   void initState() {
     super.initState();
@@ -132,6 +134,7 @@ class _RoutinesScreenState extends ConsumerState<RoutinesScreen>
                 ],
                 ...routines.map((r) => _RoutineCard(
                       routine: r,
+                      isBusy: _busyIds.contains(r.id),
                       onTap: () => _navigateToDetail(r.id),
                       onTrigger:
                           r.status == RoutineStatus.active
@@ -140,6 +143,10 @@ class _RoutinesScreenState extends ConsumerState<RoutinesScreen>
                       onPause:
                           r.status == RoutineStatus.active
                               ? () => _handlePause(r.id)
+                              : null,
+                      onResume:
+                          r.status == RoutineStatus.paused
+                              ? () => _handleResume(r.id)
                               : null,
                     )),
               ],
@@ -174,11 +181,13 @@ class _RoutinesScreenState extends ConsumerState<RoutinesScreen>
   }
 
   Future<void> _handleTrigger(String id) async {
+    setState(() => _busyIds.add(id));
     final now = DateTime.now();
     final date =
         '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
     final notifier = ref.read(routinesNotifierProvider.notifier);
     final success = await notifier.triggerRoutine(id, date);
+    if (mounted) setState(() => _busyIds.remove(id));
     if (!success && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -189,13 +198,29 @@ class _RoutinesScreenState extends ConsumerState<RoutinesScreen>
   }
 
   Future<void> _handlePause(String id) async {
+    setState(() => _busyIds.add(id));
     final notifier = ref.read(routinesNotifierProvider.notifier);
     final success = await notifier.pauseRoutine(id);
+    if (mounted) setState(() => _busyIds.remove(id));
     if (!success && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
             content:
                 Text(notifier.lastActionError ?? 'Failed to pause')),
+      );
+    }
+  }
+
+  Future<void> _handleResume(String id) async {
+    setState(() => _busyIds.add(id));
+    final notifier = ref.read(routinesNotifierProvider.notifier);
+    final success = await notifier.activateRoutine(id);
+    if (mounted) setState(() => _busyIds.remove(id));
+    if (!success && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content:
+                Text(notifier.lastActionError ?? 'Failed to resume')),
       );
     }
   }
@@ -301,6 +326,14 @@ class _ProposalCard extends StatelessWidget {
                   Chip(label: Text(proposal.cadence!)),
               ],
             ),
+            const SizedBox(height: 4),
+            Text(
+              'Confidence: ${(proposal.confidence * 100).toStringAsFixed(0)}%',
+              key: const Key('proposal-confidence'),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.secondary,
+                  ),
+            ),
             const SizedBox(height: 8),
             ...proposal.items.take(3).map(
                   (item) => Padding(
@@ -336,14 +369,18 @@ class _ProposalCard extends StatelessWidget {
 class _RoutineCard extends StatelessWidget {
   const _RoutineCard({
     required this.routine,
+    required this.isBusy,
     required this.onTap,
     this.onTrigger,
     this.onPause,
+    this.onResume,
   });
   final Routine routine;
+  final bool isBusy;
   final VoidCallback onTap;
   final VoidCallback? onTrigger;
   final VoidCallback? onPause;
+  final VoidCallback? onResume;
 
   @override
   Widget build(BuildContext context) {
@@ -380,20 +417,35 @@ class _RoutineCard extends StatelessWidget {
                   ],
                 ),
               ),
-              if (onTrigger != null)
-                IconButton(
-                  key: Key('routine-trigger-${routine.id}'),
-                  icon: const Icon(Icons.play_arrow),
-                  tooltip: 'Trigger now',
-                  onPressed: onTrigger,
-                ),
-              if (onPause != null)
-                IconButton(
-                  key: Key('routine-pause-${routine.id}'),
-                  icon: const Icon(Icons.pause),
-                  tooltip: 'Pause',
-                  onPressed: onPause,
-                ),
+              if (isBusy)
+                const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              else ...[
+                if (onTrigger != null)
+                  IconButton(
+                    key: Key('routine-trigger-${routine.id}'),
+                    icon: const Icon(Icons.play_arrow),
+                    tooltip: 'Trigger now',
+                    onPressed: onTrigger,
+                  ),
+                if (onPause != null)
+                  IconButton(
+                    key: Key('routine-pause-${routine.id}'),
+                    icon: const Icon(Icons.pause),
+                    tooltip: 'Pause',
+                    onPressed: onPause,
+                  ),
+                if (onResume != null)
+                  IconButton(
+                    key: Key('routine-resume-${routine.id}'),
+                    icon: const Icon(Icons.play_circle_outline),
+                    tooltip: 'Resume',
+                    onPressed: onResume,
+                  ),
+              ],
             ],
           ),
         ),

--- a/test/features/routines/presentation/routine_detail_screen_test.dart
+++ b/test/features/routines/presentation/routine_detail_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -39,14 +41,21 @@ class _StubRepository implements RoutinesRepository {
   @override
   Future<void> activateRoutine(String id) async {}
 
+  Completer<void>? pauseCompleter;
+  Completer<void>? triggerCompleter;
+
   @override
-  Future<void> pauseRoutine(String id) async {}
+  Future<void> pauseRoutine(String id) async {
+    if (pauseCompleter != null) await pauseCompleter!.future;
+  }
 
   @override
   Future<void> archiveRoutine(String id) async {}
 
   @override
-  Future<void> triggerRoutine(String id, String scheduledFor) async {}
+  Future<void> triggerRoutine(String id, String scheduledFor) async {
+    if (triggerCompleter != null) await triggerCompleter!.future;
+  }
 
   @override
   Future<void> updateOccurrenceStatus(
@@ -325,6 +334,26 @@ void main() {
 
       expect(find.byKey(const Key('detail-retry-button')), findsOneWidget);
       expect(find.text('Not found'), findsOneWidget);
+    });
+
+    testWidgets('action buttons are enabled before any action',
+        (tester) async {
+      await _pumpScreen(tester);
+
+      final triggerButton = tester.widget<FilledButton>(
+        find.byKey(const Key('detail-trigger-button')),
+      );
+      expect(triggerButton.onPressed, isNotNull);
+
+      final pauseButton = tester.widget<OutlinedButton>(
+        find.byKey(const Key('detail-pause-button')),
+      );
+      expect(pauseButton.onPressed, isNotNull);
+
+      final archiveButton = tester.widget<OutlinedButton>(
+        find.byKey(const Key('detail-archive-button')),
+      );
+      expect(archiveButton.onPressed, isNotNull);
     });
   });
 }

--- a/test/features/routines/presentation/routines_notifier_test.dart
+++ b/test/features/routines/presentation/routines_notifier_test.dart
@@ -16,6 +16,7 @@ class _MockRepository implements RoutinesRepository {
   RoutineStatus? lastFetchStatus;
   String? lastTriggerId;
   String? lastTriggerDate;
+  String? lastActivateId;
   String? lastPauseId;
   String? lastApproveId;
   String? lastRejectId;
@@ -44,8 +45,10 @@ class _MockRepository implements RoutinesRepository {
       throw UnimplementedError();
 
   @override
-  Future<void> activateRoutine(String id) async =>
-      throw UnimplementedError();
+  Future<void> activateRoutine(String id) async {
+    lastActivateId = id;
+    if (actionError != null) throw actionError!;
+  }
 
   @override
   Future<void> pauseRoutine(String id) async {
@@ -262,6 +265,27 @@ void main() {
 
       expect(result, isFalse);
       expect(notifier.lastActionError, 'Cannot pause');
+    });
+
+    test('activateRoutine returns true on success', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await notifier.activateRoutine('rtn-1');
+
+      expect(result, isTrue);
+      expect(repo.lastActivateId, 'rtn-1');
+    });
+
+    test('activateRoutine returns false on failure', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.actionError = RoutinesGeneralException('Cannot activate');
+      final result = await notifier.activateRoutine('rtn-1');
+
+      expect(result, isFalse);
+      expect(notifier.lastActionError, 'Cannot activate');
     });
 
     test('approveProposal returns true and reloads on success', () async {

--- a/test/features/routines/presentation/routines_screen_test.dart
+++ b/test/features/routines/presentation/routines_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -38,8 +40,12 @@ class _StubRepository implements RoutinesRepository {
   @override
   Future<void> archiveRoutine(String id) async {}
 
+  Completer<void>? triggerCompleter;
+
   @override
-  Future<void> triggerRoutine(String id, String scheduledFor) async {}
+  Future<void> triggerRoutine(String id, String scheduledFor) async {
+    if (triggerCompleter != null) await triggerCompleter!.future;
+  }
 
   @override
   Future<void> updateOccurrenceStatus(
@@ -329,6 +335,50 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('No draft routines'), findsOneWidget);
+    });
+
+    testWidgets('paused routine shows resume button', (tester) async {
+      final repo = _StubRepository(
+        routines: [_sampleRoutine(status: RoutineStatus.paused)],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      expect(
+        find.byKey(const Key('routine-resume-rtn-1')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('routine-pause-rtn-1')), findsNothing);
+      expect(find.byKey(const Key('routine-trigger-rtn-1')), findsNothing);
+    });
+
+    testWidgets('proposal card shows confidence indicator', (tester) async {
+      final repo = _StubRepository(
+        proposals: [_sampleProposal()],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.byKey(const Key('proposal-confidence')), findsOneWidget);
+      expect(find.text('Confidence: 85%'), findsOneWidget);
+    });
+
+    testWidgets('trigger completes and buttons remain after action',
+        (tester) async {
+      final repo = _StubRepository(
+        routines: [_sampleRoutine(status: RoutineStatus.active)],
+      )..triggerCompleter = Completer<void>();
+
+      await _pumpScreen(tester, repository: repo);
+
+      // Trigger is present before action
+      expect(
+        find.byKey(const Key('routine-trigger-rtn-1')),
+        findsOneWidget,
+      );
+
+      repo.triggerCompleter!.complete();
+      await tester.pumpAndSettle();
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes gaps found during `/proposal-implementation-review` of P022.

- **P1 (AC15)**: Add per-button busy states to detail screen — `_ActionButton` widget shows spinner and disables siblings when any action is in-flight; per-card `_busyIds` in list screen
- **P2**: Add Resume button for paused routines in list screen — `onResume` callback + `activateRoutine` in `RoutinesNotifier`
- **P2**: Add confidence percentage indicator to proposal cards — `Key('proposal-confidence')` text

Also fixes `use_build_context_synchronously` lint in detail screen handler methods by using `this.context` instead of parameter-captured `BuildContext`.

## Test plan

- [x] `flutter analyze` passes (1 pre-existing unrelated warning)
- [x] `flutter test test/features/routines/` — 90 tests pass
- [x] New tests: resume button, confidence indicator, busy state enabled check
