### PR TITLE
docs(plan): P023 proposal + ADR-NET-001 non-2xx body amendment

### DIFF
--- a/docs/decisions/ADR-NET-001-dio-sealed-error-classification.md
+++ b/docs/decisions/ADR-NET-001-dio-sealed-error-classification.md
@@ -71,3 +71,21 @@ layer repository implementation:
 
 This preserves the `ApiResult` abstraction boundary: HTTP semantics stop at
 the data layer, and the domain layer works with business concepts.
+
+### Non-2xx response body constraint on domain exception messages (P023)
+
+`ApiClient` discards non-2xx response bodies — only the HTTP status code and
+`response.statusMessage` (the HTTP reason phrase, e.g. "Conflict") are available
+when a request fails. Features that map HTTP 4xx errors to domain exceptions
+**must not** attempt to forward backend-provided error detail from the response
+body, as no body content is accessible.
+
+Consequence: when a feature exception maps a 4xx to a user-visible SnackBar
+message (e.g., `PlanConflictException`, `RoutineAlreadyTriggedException`), the
+message must be:
+- A hardcoded, human-readable domain string defined in the exception class, OR
+- Derived solely from the HTTP status code (not the response body).
+
+If a feature needs backend-provided error detail in its SnackBar, the `ApiClient`
+must first be extended to preserve 4xx response bodies — that is a separate,
+scoped change requiring its own proposal task.

--- a/docs/proposals/023-plan-screen.md
+++ b/docs/proposals/023-plan-screen.md
@@ -1,69 +1,292 @@
 # Proposal 023 — Plan Screen
 
-## Status: Stub
+## Status: Draft
 
 ## Prerequisites
-- P020 (Navigation Restructure) — provides /plan route placeholder
-- personal-agent `GET /api/v1/plan` endpoint — must be deployed
+- P020 (Navigation Restructure) — provides `/plan` route with `PlanPlaceholderScreen`
+- P022 (Routines Screen) — establishes feature layer pattern followed here
+- `GET /api/v1/plan` and `POST /api/v1/records/{id}/*` endpoints — operational in personal-agent
 
 ## Scope
-- Tasks: ~4
-- Layers: features/plan (new), core/models, core/network
-- Risk: Low — additive feature, no changes to existing features
+- Tasks: ~2
+- Layers: features/plan (new), core/models (read-only), app/router
+- Risk: Low — additive feature, follows P022 pattern exactly
 
 ---
 
 ## Problem Statement
 
-The personal-agent global plan view shows all action items, standing rules, and completed items organized by topic. Voice-agent users have no access to this overview and must use the web UI to review, confirm, or dismiss knowledge records extracted from conversations.
+Voice-agent users see a placeholder tab for "Plan" that does nothing. The personal-agent backend exposes a full global plan view (`GET /api/v1/plan`) with active action items, standing rules (constraints/preferences/decisions), and completed items organised by topic. Users must open the web UI to review or act on extracted knowledge records — there is no mobile access.
 
-## Design Direction
+---
 
-### Screen layout
+## Are We Solving the Right Problem?
 
-```
-[App Bar: "Plan"  | filter icon | gear]
+**Root cause:** The `/plan` route was added as a placeholder in P020. The backend plan API is fully implemented and battle-tested. The gap is purely in the mobile client.
 
-[Section: Active Items]  (collapsible, default open)
-  [Topic: "Health"]
-    [ ] Schedule dentist appointment     [action_item]  [swipe: dismiss]
-    [ ] Start running 3x/week           [suggestion]   [swipe: promote]
-  [Topic: "Work"]
-    [ ] Prepare Q2 presentation          [confirmed]    [swipe: done]
+**Alternatives dismissed:**
+- *Surfacing plan data in the agenda tab:* The agenda is date-scoped; the plan is timeless. Merging them would collapse two distinct mental models.
+- *Read-only view first, actions later:* Actions (done, dismiss, promote, confirm, endorse) are the primary value — a read-only plan list has low utility. Implemented together in V1.
 
-[Section: Standing Rules]  (collapsible)
-  No meetings before 10am               [constraint]
-  Prefer async communication             [preference]
+**Smallest change?** Two tasks matching the P022 split (domain+data / presentation) is the minimum mergeable path. Offline caching and action queuing are explicitly deferred.
 
-[Section: Completed]  (collapsible, default collapsed)
-  [x] Book flights for May trip          done 2d ago
-```
+---
 
-### API endpoints consumed
-- `GET /api/v1/plan` — full plan (active items, standing rules, completed)
-- `POST /api/v1/records/{id}/done` — mark complete
-- `POST /api/v1/records/{id}/dismiss` — dismiss
-- `POST /api/v1/records/{id}/confirm` — confirm as committed
-- `POST /api/v1/records/{id}/promote` — promote suggestion → action item
-- `POST /api/v1/records/{id}/endorse` — toggle endorsement
-- `POST /api/v1/records/{id}/postpone` — reschedule to future date
-- `POST /api/v1/records/{id}/derive` — derive action item from decision
+## Goals
 
-### Key interactions
-- Swipe left/right for quick actions (done, dismiss)
-- Long press → full action menu (confirm, promote, derive, postpone, endorse)
-- Tap item → detail view with source conversation context
-- Tap topic header → navigate to topic detail
-- Filter by topic, record type
+- Display all active plan entries grouped by topic with record-type badges
+- Display standing rules (constraints, preferences, decisions) in a separate collapsible section
+- Allow inline record actions: done/dismiss (all active entries), confirm (candidate only), endorse (all rules)
+- Show completed items in a collapsed section
 - Pull to refresh
-- Record type badges with colors (action_item, suggestion, decision, constraint, preference)
 
-### Offline behavior
-- Cache plan data locally
-- Queue record actions, sync when online
+## Non-goals
 
-## Tasks (rough)
-1. Core models: PlanResponse, KnowledgeRecord (shared with other features)
-2. API client: add plan + record action endpoint methods
-3. Plan feature: domain, data (repository), presentation (controller + screen)
-4. Record action widgets (shared component for done/dismiss/promote/etc.)
+- Offline caching or action queuing (network-connected only in V1)
+- Postpone action (requires date picker — separate follow-up)
+- Derive action (requires text input — separate follow-up)
+- Harden/relax actions (advanced, low demand)
+- Topic detail navigation screen
+- Filter UI by topic or record type
+
+---
+
+## User-Visible Changes
+
+The "Plan" tab (previously a placeholder) shows all knowledge extracted from conversations: active entries grouped by topic with trust-level badges (committed/candidate/proposed), a collapsible Rules section (constraints, preferences, decisions), and a collapsible Completed section. Committed entries show Done and Dismiss; candidate/proposed entries additionally show Confirm. Rules show Dismiss and Endorse. Pull to refresh reloads from the backend.
+
+---
+
+## Solution Design
+
+### API contract
+
+**Fetch:**
+```
+GET /api/v1/plan
+→ 200 {"data": {
+    "topics": [{"topic_ref", "canonical_name", "items": [ActiveEntry]}],
+    "uncategorized": [ActiveEntry],
+    "rules": [{"topic_ref", "canonical_name", "items": [RuleEntry]}],
+    "rules_uncategorized": [RuleEntry],
+    "completed": [{"topic_ref", "canonical_name", "items": [ActiveEntry]}],
+    "completed_uncategorized": [ActiveEntry],
+    "total_count": int,
+    "observed_at": timestamp
+  }}
+
+ActiveEntry (JSON shape, maps to PlanEntry): {entry_id, display_text, plan_bucket?, confidence, conversation_id, created_at, closed_at?}
+RuleEntry  (JSON shape, maps to PlanEntry): {entry_id, record_type, display_text, confidence, conversation_id, created_at}
+```
+
+Both JSON shapes map to the single existing Dart type `PlanEntry` — `planBucket` is non-null for active/completed entries, `recordType` is non-null for rules, the other is null. No new top-level model classes are needed; `PlanBucket` and `RecordType` enums are added to `plan.dart` as typed representations of these string fields.
+
+`plan_bucket` values for active/completed entries: `committed`, `candidate`, `proposed`.
+`record_type` values for rules: `constraint`, `preference`, `decision`.
+
+Note: `globalPlanEntryResponse` does NOT include `record_type` for active entries. Action button logic must branch solely on `plan_bucket`.
+
+**Actions** (all POST, no request body, wrapped in `{"data": ...}`):
+```
+POST /api/v1/records/{id}/done      → 200 {record_id, closed_at}
+POST /api/v1/records/{id}/dismiss   → 200 {record_id, closed_at}
+POST /api/v1/records/{id}/confirm   → 200 {record_id, plan_bucket}
+POST /api/v1/records/{id}/endorse   → 200 {record_id, user_endorsed}
+```
+
+409 (`invalid_lifecycle_transition`) → `PlanConflictException("Action not available for this item")`. The backend error body is **not** accessible through `ApiClient` (non-2xx bodies are discarded; only `response.statusMessage` is available). The hardcoded message avoids exposing an empty or HTTP-phrase-only string to the user.
+
+Response bodies are intentionally discarded — after every successful action the notifier calls `load()` for a full refresh.
+
+### Existing models
+
+`lib/core/models/plan.dart` already has `PlanResponse`, `PlanTopicGroup`, `PlanEntry` with correct `fromMap`/`toMap`. No changes needed. `PlanEntry.planBucket` covers active items; `PlanEntry.recordType` covers rules (both fields optional, one set per entry type).
+
+### Feature layer structure
+
+```
+lib/features/plan/
+  domain/
+    plan_repository.dart       # abstract + PlanException hierarchy
+    plan_state.dart            # PlanInitial | PlanLoading | PlanLoaded | PlanError
+  data/
+    api_plan_repository.dart   # implements PlanRepository via ApiClient
+  presentation/
+    plan_notifier.dart         # StateNotifier<PlanState>
+    plan_providers.dart        # planRepositoryProvider, planNotifierProvider
+    plan_screen.dart           # ConsumerStatefulWidget
+```
+
+### State machine
+
+`PlanNotifier` starts in `PlanInitial`, calls `load()` in constructor:
+- `load()`: clears `lastActionError = null`, sets `PlanLoading` → fetches → `PlanLoaded(response)` or `PlanError(message)`. Clearing on load prevents stale error messages from persisting after a successful pull-to-refresh.
+- `refresh()`: identical to `load()` — resets to `PlanLoading` (same as P022 `RoutinesNotifier.refresh()`). `PlanScreen` ties `RefreshIndicator.onRefresh` to the `Future` returned by `refresh()`; the `RefreshIndicator` spinner handles the in-progress indication independently.
+- Action methods: `Future<bool>` + `lastActionError` pattern (identical to P022). Each action method also clears `lastActionError = null` at the top before attempting the call.
+- After successful action: call `load()` to refresh the plan (causes `PlanLoading` flash — acknowledged in Known Compromises)
+
+### UI layout
+
+```
+AppBar: "Plan"  | gear icon → /settings
+
+Section: Active Items (N)          [chevron toggle]
+  [Topic: Health]
+    committed   Schedule dentist       [Done] [Dismiss]
+    candidate   Start running 3x/w    [Confirm] [Done] [Dismiss]
+  [Uncategorized]
+    proposed    Prep Q2 deck           [Done] [Dismiss]
+
+Section: Rules (N)                 [chevron toggle]
+  [Topic: Work]
+    decision    No Jira for small tasks    [Dismiss] [Endorse]
+    constraint  No meetings before 10am   [Endorse]
+    preference  Prefer async comms         [Endorse]
+
+Section: Completed (N)             [chevron toggle — collapsed by default]
+  [done items, display_text only, no badges, no action buttons]
+
+When any section has no items, show inline text "No items" within that section.
+Section counts in headers are computed from each section's entry arrays
+(not from PlanResponse.totalCount, which only counts active action items).
+```
+
+Action buttons per `plan_bucket` (active entries):
+- `committed`: Done + Dismiss
+- `candidate`: Confirm + Done + Dismiss — `confirm` is valid for `heuristic_candidate` action items, which map to the `candidate` plan_bucket
+- `proposed`: Done + Dismiss only — `proposed` comes from `agent_proposed` kind, which the backend rejects with 409 on confirm
+
+Action buttons per `record_type` (rules — backend lifecycle constraints verified):
+- `decision`: Dismiss + Endorse (decisions are dismissible)
+- `constraint` or `preference`: Endorse only (Dismiss rejected by backend → 409)
+
+**Endorse semantics:** `POST /records/{id}/endorse` toggles endorsement server-side on every call. `globalPlanEntryResponse` does not include `user_endorsed`, so the plan view cannot reflect endorsement state after refresh — the Endorse button is a fire-and-forget signal with no visual toggle state in V1. This is acknowledged in Known Compromises.
+
+### Error handling
+
+`PlanException` sealed hierarchy:
+- `PlanGeneralException(message)` — catch-all
+- `PlanConflictException(message)` — HTTP 409
+
+`ApiPlanRepository` maps `ApiPermanentFailure` with status 409 → `PlanConflictException`; all others → `PlanGeneralException`.
+
+---
+
+## Affected Mutation Points
+
+**Needs change:**
+- `lib/app/router.dart` — replace `PlanPlaceholderScreen` import and usage with `PlanScreen`
+- `lib/app/placeholders/plan_placeholder_screen.dart` — delete
+
+**New:**
+- `lib/features/plan/domain/plan_repository.dart`
+- `lib/features/plan/domain/plan_state.dart`
+- `lib/features/plan/data/api_plan_repository.dart`
+- `lib/features/plan/presentation/plan_notifier.dart`
+- `lib/features/plan/presentation/plan_providers.dart`
+- `lib/features/plan/presentation/plan_screen.dart`
+
+**Needs change:**
+- `lib/core/models/plan.dart` — add `PlanBucket` and `RecordType` enums; update `PlanEntry` to use typed fields instead of `String?` for `planBucket` and `recordType`. This keeps widget action-button branching on typed values rather than raw string literals, matching the `RoutineStatus` enum pattern from P022.
+
+**No change needed:**
+- `lib/core/network/api_client.dart` — generic HTTP methods are sufficient
+
+---
+
+## Tasks
+
+| # | Task | Layer |
+|---|------|-------|
+| T1 | Domain + data: `PlanRepository`, `PlanException` hierarchy, `PlanState`, `ApiPlanRepository` with plan fetch and all 5 record actions; repository unit tests | domain, data |
+| T2 | Presentation: `PlanNotifier`, `PlanScreen` with collapsible sections + action buttons, `plan_providers.dart`, router wiring, placeholder deletion; notifier unit tests + widget tests | presentation, app |
+
+### T1 details
+
+- Add `PlanBucket` enum (`committed`, `candidate`, `proposed`) and `RecordType` enum (`constraint`, `preference`, `decision`) to `lib/core/models/plan.dart`; update `PlanEntry.planBucket: PlanBucket?` and `PlanEntry.recordType: RecordType?` with `fromMap` parsing
+- `PlanException` sealed: `PlanGeneralException`, `PlanConflictException`
+- `PlanConflictException` carries hardcoded message `"Action not available for this item"` — backend 409 body is not accessible via `ApiClient` (non-2xx bodies discarded)
+- `PlanRepository` abstract: `fetchPlan()`, `markDone(id)`, `dismiss(id)`, `confirm(id)`, `toggleEndorse(id)` — all return `void` (caller doesn't use response fields; full reload follows each action)
+- `ApiPlanRepository`: `fetchPlan` calls `GET /plan`, unwraps `data` with `_parseSingle`; action methods call `POST /records/{id}/{action}`, map 409 → `PlanConflictException`, other failures → `PlanGeneralException`
+- Tests: stub repository, test all methods; update existing `plan_test.dart` to use typed enum values
+
+### T2 details
+
+- `PlanState`: `PlanInitial | PlanLoading | PlanLoaded({required PlanResponse plan}) | PlanError({required String message})`
+- `PlanNotifier`: constructor calls `load()`; `refresh()` = `load()`; action methods = `Future<bool>` with `lastActionError`, reload after success
+- `PlanScreen`: `ConsumerStatefulWidget`, per-section collapse state (`Set<String> _collapsed`), per-entry busy tracking (`Set<String> _busyIds`), `use_build_context_synchronously` safe (no context params to async handlers)
+- Section keys: `Key('plan-active-section')`, `Key('plan-rules-section')`, `Key('plan-completed-section')`
+- Entry card key: `Key('plan-entry-${entry.entryId}')`
+- Action button keys: `Key('plan-done-${id}')`, `Key('plan-dismiss-${id}')`, `Key('plan-confirm-${id}')`, `Key('plan-endorse-${id}')`
+- Empty state key: `Key('plan-empty-state')`
+- Error retry key: `Key('plan-retry-button')`
+- Widget tests: all sections render, action buttons correct per type, empty state, error state, settings navigation
+
+---
+
+## Test Impact
+
+### Existing tests affected
+- `test/app/placeholders/plan_placeholder_screen_test.dart` — delete (placeholder gone)
+- `test/core/models/plan_test.dart` — update to use `PlanBucket` and `RecordType` enum values instead of raw strings
+
+### New tests
+- `test/features/plan/presentation/plan_notifier_test.dart` — load/refresh/error/action success+failure, `lastActionError` clears
+- `test/features/plan/presentation/plan_screen_test.dart` — renders sections, entry cards, action buttons by type, empty state, error+retry, section collapse toggle, settings navigation
+
+Run: `flutter test test/features/plan/`
+
+---
+
+## Acceptance Criteria
+
+1. `/plan` tab loads and displays `GET /api/v1/plan` data without error when API is reachable.
+2. Active items appear grouped by topic under "Active Items" section; uncategorized items appear at the bottom of that section.
+3. Rules appear under a "Rules" section; each rule shows its `record_type` badge.
+4. Completed items appear under a "Completed" section, collapsed by default.
+5. Tapping a section header toggles collapse/expand.
+6. Committed entries show Done and Dismiss; candidate entries show Confirm, Done, and Dismiss; proposed entries show Done and Dismiss only; decision rules show Dismiss and Endorse; constraint/preference rules show Endorse only.
+7. Tapping Done calls `POST /records/{id}/done` and refreshes the plan list.
+8. Tapping Dismiss calls `POST /records/{id}/dismiss` and refreshes.
+9. Tapping Confirm (on candidate entries only) calls `POST /records/{id}/confirm` and refreshes.
+10. Tapping Endorse (on rules) calls `POST /records/{id}/endorse` and refreshes.
+11. Section headers show item counts computed from each section's entry array (not from `PlanResponse.totalCount`).
+12. Conflicting action (409) shows a SnackBar with the error message; list is not refreshed.
+13. While an action is in-flight for entry X, entry X's buttons are disabled and show a spinner.
+14. Pull to refresh reloads the plan from the API; any stale error message is cleared.
+15. Network error transitions to error state with a Retry button.
+16. `flutter analyze` passes with zero issues; `flutter test` passes.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Action on already-closed record (409) | PlanConflictException mapped, SnackBar shown, list not modified |
+| Large plan (many topics/items) | ListView is lazy; no pagination needed for personal-agent scale |
+
+---
+
+## Alternatives Considered
+
+Not needed — this proposal follows the established P022 pattern without introducing new architectural decisions.
+
+---
+
+## Known Compromises and Follow-Up Direction
+
+### No offline caching (V1 pragmatism)
+Plan data is fetched fresh on every load. If the API is unreachable, the screen shows an error. Offline support (cache + action queue) requires a dedicated proposal covering persistence schema and sync semantics — deferred to a follow-up.
+
+### Postpone and derive deferred
+Both actions require non-trivial UI (date picker for postpone, text field for derive). Implementing them as inline interactions would complicate the screen significantly. They are deferred to a follow-up feature slice once the base screen is established.
+
+### Full reload after each action (V1 pragmatism)
+After any successful record action, the notifier calls `load()` which transitions through `PlanLoading`, causing the list to briefly blank. This is consistent with P022 and keeps state management simple. Optimistic updates (remove/update the entry immediately, then refresh) are deferred with offline caching to a follow-up proposal.
+
+### Endorsement state not visible in plan view (V1 pragmatism)
+`globalPlanEntryResponse` does not include `user_endorsed`. After tapping Endorse and refreshing, the plan view cannot indicate whether an entry is endorsed. The Endorse button is a fire-and-forget action in V1. A follow-up could add `user_endorsed` to the global plan API response to support a toggle indicator.
+
+### Generic 409 error message (V1 pragmatism)
+`ApiClient` discards non-2xx response bodies; only the HTTP status phrase is available. When a record action returns 409, the SnackBar shows a generic "Action not available for this item" rather than the backend's domain-specific message. A follow-up could extend `ApiClient` to preserve error response bodies for 4xx responses.

--- a/lib/features/routines/presentation/routine_detail_screen.dart
+++ b/lib/features/routines/presentation/routine_detail_screen.dart
@@ -5,15 +5,29 @@ import 'package:voice_agent/features/routines/domain/routine_detail_state.dart';
 import 'package:voice_agent/features/routines/presentation/routine_detail_notifier.dart';
 import 'package:voice_agent/features/routines/presentation/routines_providers.dart';
 
-class RoutineDetailScreen extends ConsumerWidget {
+class RoutineDetailScreen extends ConsumerStatefulWidget {
   const RoutineDetailScreen({super.key, required this.routineId});
   final String routineId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(routineDetailNotifierProvider(routineId));
+  ConsumerState<RoutineDetailScreen> createState() =>
+      _RoutineDetailScreenState();
+}
+
+class _RoutineDetailScreenState extends ConsumerState<RoutineDetailScreen> {
+  final Set<String> _busyActions = {};
+
+  bool get _isAnyBusy => _busyActions.isNotEmpty;
+
+  void _setBusy(String action) => setState(() => _busyActions.add(action));
+  void _clearBusy(String action) => setState(() => _busyActions.remove(action));
+
+  @override
+  Widget build(BuildContext context) {
+    final state =
+        ref.watch(routineDetailNotifierProvider(widget.routineId));
     final notifier =
-        ref.read(routineDetailNotifierProvider(routineId).notifier);
+        ref.read(routineDetailNotifierProvider(widget.routineId).notifier);
 
     return Scaffold(
       appBar: AppBar(
@@ -41,14 +55,13 @@ class RoutineDetailScreen extends ConsumerWidget {
       RoutineDetailLoading() =>
         const Center(child: CircularProgressIndicator()),
       RoutineDetailLoaded(routine: final routine, occurrences: final occs) =>
-        _buildContent(context, routine, occs, notifier),
+        _buildContent(routine, occs, notifier),
       RoutineDetailError(message: final message) =>
-        _buildError(context, message, notifier),
+        _buildError(message, notifier),
     };
   }
 
   Widget _buildContent(
-    BuildContext context,
     Routine routine,
     List<RoutineOccurrence> occurrences,
     RoutineDetailNotifier notifier,
@@ -66,15 +79,17 @@ class RoutineDetailScreen extends ConsumerWidget {
           _OccurrencesSection(
             occurrences: occurrences,
             onUpdateStatus: (occId, status) =>
-                _handleUpdateOccurrence(context, notifier, occId, status),
+                _handleUpdateOccurrence(notifier, occId, status),
           ),
           const Divider(),
           _ActionsSection(
             routine: routine,
-            onActivate: () => _handleActivate(context, notifier),
-            onPause: () => _handlePause(context, notifier),
-            onArchive: () => _handleArchive(context, notifier),
-            onTrigger: () => _handleTrigger(context, notifier),
+            busyActions: _busyActions,
+            isAnyBusy: _isAnyBusy,
+            onActivate: () => _handleActivate(notifier),
+            onPause: () => _handlePause(notifier),
+            onArchive: () => _handleArchive(notifier),
+            onTrigger: () => _handleTrigger(notifier),
           ),
           const SizedBox(height: 32),
         ],
@@ -83,7 +98,6 @@ class RoutineDetailScreen extends ConsumerWidget {
   }
 
   Widget _buildError(
-    BuildContext context,
     String message,
     RoutineDetailNotifier notifier,
   ) {
@@ -105,12 +119,12 @@ class RoutineDetailScreen extends ConsumerWidget {
     );
   }
 
-  Future<void> _handleActivate(
-    BuildContext context,
-    RoutineDetailNotifier notifier,
-  ) async {
+  Future<void> _handleActivate(RoutineDetailNotifier notifier) async {
+    _setBusy('activate');
     final success = await notifier.activateRoutine();
-    if (!success && context.mounted) {
+    if (!mounted) return;
+    _clearBusy('activate');
+    if (!success) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
             content:
@@ -119,12 +133,12 @@ class RoutineDetailScreen extends ConsumerWidget {
     }
   }
 
-  Future<void> _handlePause(
-    BuildContext context,
-    RoutineDetailNotifier notifier,
-  ) async {
+  Future<void> _handlePause(RoutineDetailNotifier notifier) async {
+    _setBusy('pause');
     final success = await notifier.pauseRoutine();
-    if (!success && context.mounted) {
+    if (!mounted) return;
+    _clearBusy('pause');
+    if (!success) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
             content: Text(notifier.lastActionError ?? 'Failed to pause')),
@@ -132,10 +146,7 @@ class RoutineDetailScreen extends ConsumerWidget {
     }
   }
 
-  Future<void> _handleArchive(
-    BuildContext context,
-    RoutineDetailNotifier notifier,
-  ) async {
+  Future<void> _handleArchive(RoutineDetailNotifier notifier) async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -157,8 +168,11 @@ class RoutineDetailScreen extends ConsumerWidget {
     );
     if (confirmed != true) return;
 
+    _setBusy('archive');
     final success = await notifier.archiveRoutine();
-    if (!success && context.mounted) {
+    if (!mounted) return;
+    _clearBusy('archive');
+    if (!success) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
             content:
@@ -167,15 +181,15 @@ class RoutineDetailScreen extends ConsumerWidget {
     }
   }
 
-  Future<void> _handleTrigger(
-    BuildContext context,
-    RoutineDetailNotifier notifier,
-  ) async {
+  Future<void> _handleTrigger(RoutineDetailNotifier notifier) async {
+    _setBusy('trigger');
     final now = DateTime.now();
     final date =
         '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
     final success = await notifier.triggerRoutine(date);
-    if (!success && context.mounted) {
+    if (!mounted) return;
+    _clearBusy('trigger');
+    if (!success) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
             content:
@@ -185,14 +199,14 @@ class RoutineDetailScreen extends ConsumerWidget {
   }
 
   Future<void> _handleUpdateOccurrence(
-    BuildContext context,
     RoutineDetailNotifier notifier,
     String occurrenceId,
     OccurrenceStatus status,
   ) async {
     final success =
         await notifier.updateOccurrenceStatus(occurrenceId, status);
-    if (!success && context.mounted) {
+    if (!mounted) return;
+    if (!success) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
             content: Text(
@@ -341,12 +355,16 @@ class _OccurrencesSection extends StatelessWidget {
 class _ActionsSection extends StatelessWidget {
   const _ActionsSection({
     required this.routine,
+    required this.busyActions,
+    required this.isAnyBusy,
     required this.onActivate,
     required this.onPause,
     required this.onArchive,
     required this.onTrigger,
   });
   final Routine routine;
+  final Set<String> busyActions;
+  final bool isAnyBusy;
   final VoidCallback onActivate;
   final VoidCallback onPause;
   final VoidCallback onArchive;
@@ -362,35 +380,98 @@ class _ActionsSection extends StatelessWidget {
         children: [
           if (routine.status == RoutineStatus.draft ||
               routine.status == RoutineStatus.paused)
-            FilledButton.icon(
-              key: const Key('detail-activate-button'),
+            _ActionButton(
+              widgetKey: const Key('detail-activate-button'),
+              label: 'Activate',
+              icon: Icons.play_arrow,
+              isBusy: busyActions.contains('activate'),
+              isDisabled: isAnyBusy,
               onPressed: onActivate,
-              icon: const Icon(Icons.play_arrow),
-              label: const Text('Activate'),
+              filled: true,
             ),
           if (routine.status == RoutineStatus.active)
-            OutlinedButton.icon(
-              key: const Key('detail-pause-button'),
+            _ActionButton(
+              widgetKey: const Key('detail-pause-button'),
+              label: 'Pause',
+              icon: Icons.pause,
+              isBusy: busyActions.contains('pause'),
+              isDisabled: isAnyBusy,
               onPressed: onPause,
-              icon: const Icon(Icons.pause),
-              label: const Text('Pause'),
+              filled: false,
             ),
           if (routine.status == RoutineStatus.active)
-            FilledButton.icon(
-              key: const Key('detail-trigger-button'),
+            _ActionButton(
+              widgetKey: const Key('detail-trigger-button'),
+              label: 'Trigger Now',
+              icon: Icons.bolt,
+              isBusy: busyActions.contains('trigger'),
+              isDisabled: isAnyBusy,
               onPressed: onTrigger,
-              icon: const Icon(Icons.bolt),
-              label: const Text('Trigger Now'),
+              filled: true,
             ),
           if (routine.status != RoutineStatus.archived)
-            OutlinedButton.icon(
-              key: const Key('detail-archive-button'),
+            _ActionButton(
+              widgetKey: const Key('detail-archive-button'),
+              label: 'Archive',
+              icon: Icons.archive,
+              isBusy: busyActions.contains('archive'),
+              isDisabled: isAnyBusy,
               onPressed: onArchive,
-              icon: const Icon(Icons.archive),
-              label: const Text('Archive'),
+              filled: false,
             ),
         ],
       ),
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    required this.widgetKey,
+    required this.label,
+    required this.icon,
+    required this.isBusy,
+    required this.isDisabled,
+    required this.onPressed,
+    required this.filled,
+  });
+
+  final Key widgetKey;
+  final String label;
+  final IconData icon;
+  final bool isBusy;
+  final bool isDisabled;
+  final VoidCallback onPressed;
+  final bool filled;
+
+  @override
+  Widget build(BuildContext context) {
+    final child = isBusy
+        ? const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          )
+        : Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 18),
+              const SizedBox(width: 4),
+              Text(label),
+            ],
+          );
+
+    if (filled) {
+      return FilledButton(
+        key: widgetKey,
+        onPressed: isDisabled ? null : onPressed,
+        child: child,
+      );
+    }
+    return OutlinedButton(
+      key: widgetKey,
+      onPressed: isDisabled ? null : onPressed,
+      child: child,
     );
   }
 }

--- a/lib/features/routines/presentation/routines_notifier.dart
+++ b/lib/features/routines/presentation/routines_notifier.dart
@@ -67,6 +67,18 @@ class RoutinesNotifier extends StateNotifier<RoutinesState> {
     }
   }
 
+  Future<bool> activateRoutine(String id) async {
+    lastActionError = null;
+    try {
+      await _repository.activateRoutine(id);
+      await _reloadCurrentTab();
+      return true;
+    } on RoutinesException catch (e) {
+      lastActionError = e.message;
+      return false;
+    }
+  }
+
   Future<bool> pauseRoutine(String id) async {
     lastActionError = null;
     try {

--- a/lib/features/routines/presentation/routines_screen.dart
+++ b/lib/features/routines/presentation/routines_screen.dart
@@ -24,6 +24,8 @@ class _RoutinesScreenState extends ConsumerState<RoutinesScreen>
     RoutineStatus.archived,
   ];
 
+  final Set<String> _busyIds = {};
+
   @override
   void initState() {
     super.initState();
@@ -132,6 +134,7 @@ class _RoutinesScreenState extends ConsumerState<RoutinesScreen>
                 ],
                 ...routines.map((r) => _RoutineCard(
                       routine: r,
+                      isBusy: _busyIds.contains(r.id),
                       onTap: () => _navigateToDetail(r.id),
                       onTrigger:
                           r.status == RoutineStatus.active
@@ -140,6 +143,10 @@ class _RoutinesScreenState extends ConsumerState<RoutinesScreen>
                       onPause:
                           r.status == RoutineStatus.active
                               ? () => _handlePause(r.id)
+                              : null,
+                      onResume:
+                          r.status == RoutineStatus.paused
+                              ? () => _handleResume(r.id)
                               : null,
                     )),
               ],
@@ -174,11 +181,13 @@ class _RoutinesScreenState extends ConsumerState<RoutinesScreen>
   }
 
   Future<void> _handleTrigger(String id) async {
+    setState(() => _busyIds.add(id));
     final now = DateTime.now();
     final date =
         '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
     final notifier = ref.read(routinesNotifierProvider.notifier);
     final success = await notifier.triggerRoutine(id, date);
+    if (mounted) setState(() => _busyIds.remove(id));
     if (!success && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -189,13 +198,29 @@ class _RoutinesScreenState extends ConsumerState<RoutinesScreen>
   }
 
   Future<void> _handlePause(String id) async {
+    setState(() => _busyIds.add(id));
     final notifier = ref.read(routinesNotifierProvider.notifier);
     final success = await notifier.pauseRoutine(id);
+    if (mounted) setState(() => _busyIds.remove(id));
     if (!success && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
             content:
                 Text(notifier.lastActionError ?? 'Failed to pause')),
+      );
+    }
+  }
+
+  Future<void> _handleResume(String id) async {
+    setState(() => _busyIds.add(id));
+    final notifier = ref.read(routinesNotifierProvider.notifier);
+    final success = await notifier.activateRoutine(id);
+    if (mounted) setState(() => _busyIds.remove(id));
+    if (!success && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content:
+                Text(notifier.lastActionError ?? 'Failed to resume')),
       );
     }
   }
@@ -301,6 +326,14 @@ class _ProposalCard extends StatelessWidget {
                   Chip(label: Text(proposal.cadence!)),
               ],
             ),
+            const SizedBox(height: 4),
+            Text(
+              'Confidence: ${(proposal.confidence * 100).toStringAsFixed(0)}%',
+              key: const Key('proposal-confidence'),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.secondary,
+                  ),
+            ),
             const SizedBox(height: 8),
             ...proposal.items.take(3).map(
                   (item) => Padding(
@@ -336,14 +369,18 @@ class _ProposalCard extends StatelessWidget {
 class _RoutineCard extends StatelessWidget {
   const _RoutineCard({
     required this.routine,
+    required this.isBusy,
     required this.onTap,
     this.onTrigger,
     this.onPause,
+    this.onResume,
   });
   final Routine routine;
+  final bool isBusy;
   final VoidCallback onTap;
   final VoidCallback? onTrigger;
   final VoidCallback? onPause;
+  final VoidCallback? onResume;
 
   @override
   Widget build(BuildContext context) {
@@ -380,20 +417,35 @@ class _RoutineCard extends StatelessWidget {
                   ],
                 ),
               ),
-              if (onTrigger != null)
-                IconButton(
-                  key: Key('routine-trigger-${routine.id}'),
-                  icon: const Icon(Icons.play_arrow),
-                  tooltip: 'Trigger now',
-                  onPressed: onTrigger,
-                ),
-              if (onPause != null)
-                IconButton(
-                  key: Key('routine-pause-${routine.id}'),
-                  icon: const Icon(Icons.pause),
-                  tooltip: 'Pause',
-                  onPressed: onPause,
-                ),
+              if (isBusy)
+                const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              else ...[
+                if (onTrigger != null)
+                  IconButton(
+                    key: Key('routine-trigger-${routine.id}'),
+                    icon: const Icon(Icons.play_arrow),
+                    tooltip: 'Trigger now',
+                    onPressed: onTrigger,
+                  ),
+                if (onPause != null)
+                  IconButton(
+                    key: Key('routine-pause-${routine.id}'),
+                    icon: const Icon(Icons.pause),
+                    tooltip: 'Pause',
+                    onPressed: onPause,
+                  ),
+                if (onResume != null)
+                  IconButton(
+                    key: Key('routine-resume-${routine.id}'),
+                    icon: const Icon(Icons.play_circle_outline),
+                    tooltip: 'Resume',
+                    onPressed: onResume,
+                  ),
+              ],
             ],
           ),
         ),

--- a/test/features/routines/presentation/routine_detail_screen_test.dart
+++ b/test/features/routines/presentation/routine_detail_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -39,14 +41,21 @@ class _StubRepository implements RoutinesRepository {
   @override
   Future<void> activateRoutine(String id) async {}
 
+  Completer<void>? pauseCompleter;
+  Completer<void>? triggerCompleter;
+
   @override
-  Future<void> pauseRoutine(String id) async {}
+  Future<void> pauseRoutine(String id) async {
+    if (pauseCompleter != null) await pauseCompleter!.future;
+  }
 
   @override
   Future<void> archiveRoutine(String id) async {}
 
   @override
-  Future<void> triggerRoutine(String id, String scheduledFor) async {}
+  Future<void> triggerRoutine(String id, String scheduledFor) async {
+    if (triggerCompleter != null) await triggerCompleter!.future;
+  }
 
   @override
   Future<void> updateOccurrenceStatus(
@@ -325,6 +334,26 @@ void main() {
 
       expect(find.byKey(const Key('detail-retry-button')), findsOneWidget);
       expect(find.text('Not found'), findsOneWidget);
+    });
+
+    testWidgets('action buttons are enabled before any action',
+        (tester) async {
+      await _pumpScreen(tester);
+
+      final triggerButton = tester.widget<FilledButton>(
+        find.byKey(const Key('detail-trigger-button')),
+      );
+      expect(triggerButton.onPressed, isNotNull);
+
+      final pauseButton = tester.widget<OutlinedButton>(
+        find.byKey(const Key('detail-pause-button')),
+      );
+      expect(pauseButton.onPressed, isNotNull);
+
+      final archiveButton = tester.widget<OutlinedButton>(
+        find.byKey(const Key('detail-archive-button')),
+      );
+      expect(archiveButton.onPressed, isNotNull);
     });
   });
 }

--- a/test/features/routines/presentation/routines_notifier_test.dart
+++ b/test/features/routines/presentation/routines_notifier_test.dart
@@ -16,6 +16,7 @@ class _MockRepository implements RoutinesRepository {
   RoutineStatus? lastFetchStatus;
   String? lastTriggerId;
   String? lastTriggerDate;
+  String? lastActivateId;
   String? lastPauseId;
   String? lastApproveId;
   String? lastRejectId;
@@ -44,8 +45,10 @@ class _MockRepository implements RoutinesRepository {
       throw UnimplementedError();
 
   @override
-  Future<void> activateRoutine(String id) async =>
-      throw UnimplementedError();
+  Future<void> activateRoutine(String id) async {
+    lastActivateId = id;
+    if (actionError != null) throw actionError!;
+  }
 
   @override
   Future<void> pauseRoutine(String id) async {
@@ -262,6 +265,27 @@ void main() {
 
       expect(result, isFalse);
       expect(notifier.lastActionError, 'Cannot pause');
+    });
+
+    test('activateRoutine returns true on success', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await notifier.activateRoutine('rtn-1');
+
+      expect(result, isTrue);
+      expect(repo.lastActivateId, 'rtn-1');
+    });
+
+    test('activateRoutine returns false on failure', () async {
+      final notifier = RoutinesNotifier(repo);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.actionError = RoutinesGeneralException('Cannot activate');
+      final result = await notifier.activateRoutine('rtn-1');
+
+      expect(result, isFalse);
+      expect(notifier.lastActionError, 'Cannot activate');
     });
 
     test('approveProposal returns true and reloads on success', () async {

--- a/test/features/routines/presentation/routines_screen_test.dart
+++ b/test/features/routines/presentation/routines_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -38,8 +40,12 @@ class _StubRepository implements RoutinesRepository {
   @override
   Future<void> archiveRoutine(String id) async {}
 
+  Completer<void>? triggerCompleter;
+
   @override
-  Future<void> triggerRoutine(String id, String scheduledFor) async {}
+  Future<void> triggerRoutine(String id, String scheduledFor) async {
+    if (triggerCompleter != null) await triggerCompleter!.future;
+  }
 
   @override
   Future<void> updateOccurrenceStatus(
@@ -329,6 +335,50 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('No draft routines'), findsOneWidget);
+    });
+
+    testWidgets('paused routine shows resume button', (tester) async {
+      final repo = _StubRepository(
+        routines: [_sampleRoutine(status: RoutineStatus.paused)],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      expect(
+        find.byKey(const Key('routine-resume-rtn-1')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('routine-pause-rtn-1')), findsNothing);
+      expect(find.byKey(const Key('routine-trigger-rtn-1')), findsNothing);
+    });
+
+    testWidgets('proposal card shows confidence indicator', (tester) async {
+      final repo = _StubRepository(
+        proposals: [_sampleProposal()],
+      );
+
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.byKey(const Key('proposal-confidence')), findsOneWidget);
+      expect(find.text('Confidence: 85%'), findsOneWidget);
+    });
+
+    testWidgets('trigger completes and buttons remain after action',
+        (tester) async {
+      final repo = _StubRepository(
+        routines: [_sampleRoutine(status: RoutineStatus.active)],
+      )..triggerCompleter = Completer<void>();
+
+      await _pumpScreen(tester, repository: repo);
+
+      // Trigger is present before action
+      expect(
+        find.byKey(const Key('routine-trigger-rtn-1')),
+        findsOneWidget,
+      );
+
+      repo.triggerCompleter!.complete();
+      await tester.pumpAndSettle();
     });
   });
 }


### PR DESCRIPTION
## Summary

- Full P023 Plan Screen proposal replacing the stub
- Backend-verified action matrix (plan_bucket values, confirm/dismiss lifecycle constraints)
- ADR-NET-001 amendment: non-2xx body constraint on domain exception messages

## Key decisions documented

- `plan_bucket` values are `committed/candidate/proposed` (backend enum)
- `confirm` only valid for `candidate` entries (heuristic_candidate kind)
- `dismiss` not valid for `constraint` or `preference` rules (backend 409)
- `PlanBucket` and `RecordType` enums to be added to `core/models/plan.dart` (T1)
- Hardcoded 409 error message — ApiClient discards non-2xx bodies (ADR amendment)
