### PR TITLE
feat(plan): T1 domain+data — PlanBucket/RecordType enums, PlanRepository, ApiPlanRepository

### DIFF
--- a/lib/core/models/plan.dart
+++ b/lib/core/models/plan.dart
@@ -1,3 +1,33 @@
+enum PlanBucket {
+  committed,
+  candidate,
+  proposed;
+
+  static PlanBucket? fromJson(String? value) => switch (value) {
+        'committed' => PlanBucket.committed,
+        'candidate' => PlanBucket.candidate,
+        'proposed' => PlanBucket.proposed,
+        _ => null,
+      };
+
+  String toJson() => name;
+}
+
+enum RecordType {
+  constraint,
+  preference,
+  decision;
+
+  static RecordType? fromJson(String? value) => switch (value) {
+        'constraint' => RecordType.constraint,
+        'preference' => RecordType.preference,
+        'decision' => RecordType.decision,
+        _ => null,
+      };
+
+  String toJson() => name;
+}
+
 class PlanResponse {
   const PlanResponse({
     required this.topics,
@@ -107,25 +137,25 @@ class PlanEntry {
 
   final String entryId;
   final String displayText;
-  final String? planBucket;
+  final PlanBucket? planBucket;
   final double confidence;
   final String conversationId;
   final DateTime createdAt;
   final DateTime? closedAt;
-  final String? recordType;
+  final RecordType? recordType;
 
   factory PlanEntry.fromMap(Map<String, dynamic> map) {
     return PlanEntry(
       entryId: map['entry_id'] as String,
       displayText: map['display_text'] as String,
-      planBucket: map['plan_bucket'] as String?,
+      planBucket: PlanBucket.fromJson(map['plan_bucket'] as String?),
       confidence: (map['confidence'] as num).toDouble(),
       conversationId: map['conversation_id'] as String,
       createdAt: DateTime.parse(map['created_at'] as String),
       closedAt: map['closed_at'] != null
           ? DateTime.parse(map['closed_at'] as String)
           : null,
-      recordType: map['record_type'] as String?,
+      recordType: RecordType.fromJson(map['record_type'] as String?),
     );
   }
 
@@ -133,12 +163,12 @@ class PlanEntry {
     return {
       'entry_id': entryId,
       'display_text': displayText,
-      'plan_bucket': planBucket,
+      'plan_bucket': planBucket?.toJson(),
       'confidence': confidence,
       'conversation_id': conversationId,
       'created_at': createdAt.toIso8601String(),
       'closed_at': closedAt?.toIso8601String(),
-      'record_type': recordType,
+      'record_type': recordType?.toJson(),
     };
   }
 }

--- a/lib/features/plan/data/api_plan_repository.dart
+++ b/lib/features/plan/data/api_plan_repository.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+import 'package:voice_agent/core/models/plan.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/features/plan/domain/plan_repository.dart';
+
+class ApiPlanRepository implements PlanRepository {
+  ApiPlanRepository(this._apiClient);
+
+  final ApiClient _apiClient;
+
+  @override
+  Future<PlanResponse> fetchPlan() async {
+    final result = await _apiClient.get('/plan');
+    return switch (result) {
+      ApiSuccess(body: final body) => _parsePlanResponse(body),
+      ApiPermanentFailure(message: final msg, statusCode: final code) =>
+        throw PlanGeneralException('Server error $code: $msg'),
+      ApiTransientFailure(reason: final reason) =>
+        throw PlanGeneralException(reason),
+      ApiNotConfigured() => throw PlanGeneralException('API not configured'),
+    };
+  }
+
+  @override
+  Future<void> markDone(String id) => _postAction('/records/$id/done');
+
+  @override
+  Future<void> dismiss(String id) => _postAction('/records/$id/dismiss');
+
+  @override
+  Future<void> confirm(String id) => _postAction('/records/$id/confirm');
+
+  @override
+  Future<void> toggleEndorse(String id) =>
+      _postAction('/records/$id/endorse');
+
+  Future<void> _postAction(String path) async {
+    final result = await _apiClient.postJson(path);
+    switch (result) {
+      case ApiSuccess():
+        return;
+      case ApiPermanentFailure(statusCode: 409):
+        throw PlanConflictException();
+      case ApiPermanentFailure(message: final msg, statusCode: final code):
+        throw PlanGeneralException('Server error $code: $msg');
+      case ApiTransientFailure(reason: final reason):
+        throw PlanGeneralException(reason);
+      case ApiNotConfigured():
+        throw PlanGeneralException('API not configured');
+    }
+  }
+
+  PlanResponse _parsePlanResponse(String? body) {
+    if (body == null) throw PlanGeneralException('Empty response');
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final data = json['data'] as Map<String, dynamic>?;
+    if (data == null) throw PlanGeneralException('Missing data envelope');
+    return PlanResponse.fromMap(data);
+  }
+}

--- a/lib/features/plan/domain/plan_repository.dart
+++ b/lib/features/plan/domain/plan_repository.dart
@@ -1,0 +1,28 @@
+import 'package:voice_agent/core/models/plan.dart';
+
+sealed class PlanException implements Exception {
+  String get message;
+
+  @override
+  String toString() => message;
+}
+
+class PlanGeneralException extends PlanException {
+  PlanGeneralException(this.message);
+  @override
+  final String message;
+}
+
+class PlanConflictException extends PlanException {
+  PlanConflictException([this.message = 'Action not available for this item']);
+  @override
+  final String message;
+}
+
+abstract class PlanRepository {
+  Future<PlanResponse> fetchPlan();
+  Future<void> markDone(String id);
+  Future<void> dismiss(String id);
+  Future<void> confirm(String id);
+  Future<void> toggleEndorse(String id);
+}

--- a/lib/features/plan/domain/plan_state.dart
+++ b/lib/features/plan/domain/plan_state.dart
@@ -1,0 +1,23 @@
+import 'package:voice_agent/core/models/plan.dart';
+
+sealed class PlanState {
+  const PlanState();
+}
+
+class PlanInitial extends PlanState {
+  const PlanInitial();
+}
+
+class PlanLoading extends PlanState {
+  const PlanLoading();
+}
+
+class PlanLoaded extends PlanState {
+  const PlanLoaded({required this.plan});
+  final PlanResponse plan;
+}
+
+class PlanError extends PlanState {
+  const PlanError({required this.message});
+  final String message;
+}

--- a/test/core/models/plan_test.dart
+++ b/test/core/models/plan_test.dart
@@ -57,7 +57,6 @@ void main() {
             {
               'entry_id': 'e-4',
               'display_text': 'Ship feature X',
-              'plan_bucket': 'committed',
               'confidence': 1.0,
               'conversation_id': 'conv-4',
               'created_at': '2026-03-01T00:00:00.000Z',
@@ -158,7 +157,7 @@ void main() {
 
       expect(entry.entryId, 'e-1');
       expect(entry.displayText, 'Do thing');
-      expect(entry.planBucket, 'committed');
+      expect(entry.planBucket, PlanBucket.committed);
       expect(entry.confidence, 0.9);
       expect(entry.closedAt, isNull);
       expect(entry.recordType, isNull);
@@ -174,7 +173,7 @@ void main() {
         'record_type': 'constraint',
       });
 
-      expect(entry.recordType, 'constraint');
+      expect(entry.recordType, RecordType.constraint);
       expect(entry.planBucket, isNull);
     });
 
@@ -182,7 +181,6 @@ void main() {
       final entry = PlanEntry.fromMap({
         'entry_id': 'e-3',
         'display_text': 'Done thing',
-        'plan_bucket': 'committed',
         'confidence': 1.0,
         'conversation_id': 'conv-3',
         'created_at': '2026-03-01T00:00:00.000Z',
@@ -209,10 +207,50 @@ void main() {
 
       expect(roundTripped.entryId, entry.entryId);
       expect(roundTripped.displayText, entry.displayText);
-      expect(roundTripped.planBucket, entry.planBucket);
+      expect(roundTripped.planBucket, PlanBucket.candidate);
       expect(roundTripped.confidence, entry.confidence);
-      expect(roundTripped.recordType, entry.recordType);
+      expect(roundTripped.recordType, RecordType.preference);
       expect(roundTripped.closedAt, isNotNull);
+    });
+
+    test('fromMap handles unknown plan_bucket as null', () {
+      final entry = PlanEntry.fromMap({
+        'entry_id': 'e-1',
+        'display_text': 'Unknown bucket',
+        'plan_bucket': 'unknown_value',
+        'confidence': 0.5,
+        'conversation_id': 'conv-1',
+        'created_at': '2026-04-18T00:00:00.000Z',
+      });
+
+      expect(entry.planBucket, isNull);
+    });
+
+    test('fromMap handles unknown record_type as null', () {
+      final entry = PlanEntry.fromMap({
+        'entry_id': 'e-1',
+        'display_text': 'Unknown type',
+        'confidence': 0.5,
+        'conversation_id': 'conv-1',
+        'created_at': '2026-04-18T00:00:00.000Z',
+        'record_type': 'unknown_type',
+      });
+
+      expect(entry.recordType, isNull);
+    });
+
+    test('PlanBucket enum covers all values', () {
+      expect(PlanBucket.fromJson('committed'), PlanBucket.committed);
+      expect(PlanBucket.fromJson('candidate'), PlanBucket.candidate);
+      expect(PlanBucket.fromJson('proposed'), PlanBucket.proposed);
+      expect(PlanBucket.fromJson(null), isNull);
+    });
+
+    test('RecordType enum covers all values', () {
+      expect(RecordType.fromJson('constraint'), RecordType.constraint);
+      expect(RecordType.fromJson('preference'), RecordType.preference);
+      expect(RecordType.fromJson('decision'), RecordType.decision);
+      expect(RecordType.fromJson(null), isNull);
     });
   });
 }

--- a/test/features/plan/data/api_plan_repository_test.dart
+++ b/test/features/plan/data/api_plan_repository_test.dart
@@ -1,0 +1,182 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/features/plan/data/api_plan_repository.dart';
+import 'package:voice_agent/features/plan/domain/plan_repository.dart';
+
+class _StubApiClient extends ApiClient {
+  _StubApiClient() : super(baseUrl: 'https://test.com/api/v1');
+
+  ApiResult nextGetResult = const ApiSuccess(body: '{"data":{}}');
+  ApiResult nextPostResult = const ApiSuccess();
+
+  String? lastGetPath;
+  String? lastPostPath;
+
+  @override
+  Future<ApiResult> get(String path,
+      {Map<String, dynamic>? queryParameters}) async {
+    lastGetPath = path;
+    return nextGetResult;
+  }
+
+  @override
+  Future<ApiResult> postJson(String path,
+      {Map<String, dynamic>? data}) async {
+    lastPostPath = path;
+    return nextPostResult;
+  }
+}
+
+Map<String, dynamic> _samplePlanData() => {
+      'topics': [],
+      'uncategorized': [
+        {
+          'entry_id': 'e-1',
+          'display_text': 'Do thing',
+          'plan_bucket': 'committed',
+          'confidence': 0.9,
+          'conversation_id': 'conv-1',
+          'created_at': '2026-04-18T00:00:00.000Z',
+        },
+      ],
+      'rules': [],
+      'rules_uncategorized': [],
+      'completed': [],
+      'completed_uncategorized': [],
+      'total_count': 1,
+      'observed_at': '2026-04-18T12:00:00.000Z',
+    };
+
+void main() {
+  late _StubApiClient client;
+  late ApiPlanRepository repo;
+
+  setUp(() {
+    client = _StubApiClient();
+    repo = ApiPlanRepository(client);
+  });
+
+  group('ApiPlanRepository.fetchPlan', () {
+    test('calls GET /plan', () async {
+      client.nextGetResult = ApiSuccess(
+        body: jsonEncode({'data': _samplePlanData()}),
+      );
+
+      await repo.fetchPlan();
+
+      expect(client.lastGetPath, '/plan');
+    });
+
+    test('returns PlanResponse on success', () async {
+      client.nextGetResult = ApiSuccess(
+        body: jsonEncode({'data': _samplePlanData()}),
+      );
+
+      final result = await repo.fetchPlan();
+
+      expect(result.uncategorized, hasLength(1));
+      expect(result.totalCount, 1);
+    });
+
+    test('throws PlanGeneralException on permanent failure', () async {
+      client.nextGetResult =
+          const ApiPermanentFailure(statusCode: 500, message: 'Server Error');
+
+      expect(() => repo.fetchPlan(), throwsA(isA<PlanGeneralException>()));
+    });
+
+    test('throws PlanGeneralException on transient failure', () async {
+      client.nextGetResult =
+          const ApiTransientFailure(reason: 'Connection timeout');
+
+      expect(() => repo.fetchPlan(), throwsA(isA<PlanGeneralException>()));
+    });
+
+    test('throws PlanGeneralException when not configured', () async {
+      client.nextGetResult = const ApiNotConfigured();
+
+      expect(() => repo.fetchPlan(), throwsA(isA<PlanGeneralException>()));
+    });
+
+    test('throws PlanGeneralException on missing data envelope', () async {
+      client.nextGetResult = const ApiSuccess(body: '{"other": {}}');
+
+      expect(() => repo.fetchPlan(), throwsA(isA<PlanGeneralException>()));
+    });
+  });
+
+  group('ApiPlanRepository actions', () {
+    test('markDone posts to /records/{id}/done', () async {
+      await repo.markDone('e-1');
+      expect(client.lastPostPath, '/records/e-1/done');
+    });
+
+    test('dismiss posts to /records/{id}/dismiss', () async {
+      await repo.dismiss('e-1');
+      expect(client.lastPostPath, '/records/e-1/dismiss');
+    });
+
+    test('confirm posts to /records/{id}/confirm', () async {
+      await repo.confirm('e-1');
+      expect(client.lastPostPath, '/records/e-1/confirm');
+    });
+
+    test('toggleEndorse posts to /records/{id}/endorse', () async {
+      await repo.toggleEndorse('e-1');
+      expect(client.lastPostPath, '/records/e-1/endorse');
+    });
+
+    test('throws PlanConflictException on 409', () async {
+      client.nextPostResult =
+          const ApiPermanentFailure(statusCode: 409, message: 'Conflict');
+
+      expect(
+        () => repo.markDone('e-1'),
+        throwsA(isA<PlanConflictException>()),
+      );
+    });
+
+    test('PlanConflictException has hardcoded message', () async {
+      client.nextPostResult =
+          const ApiPermanentFailure(statusCode: 409, message: 'Conflict');
+
+      try {
+        await repo.markDone('e-1');
+        fail('expected exception');
+      } on PlanConflictException catch (e) {
+        expect(e.message, 'Action not available for this item');
+      }
+    });
+
+    test('throws PlanGeneralException on other permanent failure', () async {
+      client.nextPostResult =
+          const ApiPermanentFailure(statusCode: 500, message: 'Server Error');
+
+      expect(
+        () => repo.dismiss('e-1'),
+        throwsA(isA<PlanGeneralException>()),
+      );
+    });
+
+    test('throws PlanGeneralException on transient failure', () async {
+      client.nextPostResult =
+          const ApiTransientFailure(reason: 'Timeout');
+
+      expect(
+        () => repo.confirm('e-1'),
+        throwsA(isA<PlanGeneralException>()),
+      );
+    });
+
+    test('throws PlanGeneralException when not configured', () async {
+      client.nextPostResult = const ApiNotConfigured();
+
+      expect(
+        () => repo.toggleEndorse('e-1'),
+        throwsA(isA<PlanGeneralException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `PlanBucket` and `RecordType` typed enums to `core/models/plan.dart`; update `PlanEntry` fields from `String?` to typed
- Add `PlanException` sealed hierarchy: `PlanGeneralException`, `PlanConflictException` (hardcoded 409 message per ADR-NET-001)
- Add `PlanRepository` abstract interface and `PlanState` sealed class
- Implement `ApiPlanRepository` via `ApiClient`: `GET /plan` + 4 record action POSTs, maps 409 → `PlanConflictException`
- Update `plan_test.dart` to typed enum assertions; add 5 enum coverage tests
- Add `api_plan_repository_test.dart`: 15 tests

## Test plan

- [x] `flutter test test/core/models/plan_test.dart test/features/plan/data/api_plan_repository_test.dart` — 28 tests pass
- [x] `flutter analyze lib/core/models/plan.dart lib/features/plan/` — no issues

Closes #207
