### PR TITLE
feat(chat): P024-T1 domain + data layer

### DIFF
--- a/lib/core/providers/api_client_provider.dart
+++ b/lib/core/providers/api_client_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/core/network/sse_client.dart';
 
 final apiClientProvider = Provider<ApiClient>((ref) {
   final config = ref.watch(appConfigProvider);
@@ -8,6 +9,10 @@ final apiClientProvider = Provider<ApiClient>((ref) {
     baseUrl: deriveBaseUrl(config.apiUrl),
     token: config.apiToken,
   );
+});
+
+final sseClientProvider = Provider<SseClient>((ref) {
+  return SseClient(apiClient: ref.watch(apiClientProvider));
 });
 
 String? deriveBaseUrl(String? apiUrl) {

--- a/lib/features/chat/data/api_chat_repository.dart
+++ b/lib/features/chat/data/api_chat_repository.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+
+import 'package:voice_agent/core/models/conversation.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/core/network/sse_client.dart';
+import 'package:voice_agent/features/chat/domain/chat_repository.dart';
+
+class ChatException implements Exception {
+  const ChatException(this.message);
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class ApiChatRepository implements ChatRepository {
+  ApiChatRepository({
+    required ApiClient apiClient,
+    required SseClient sseClient,
+  })  : _apiClient = apiClient,
+        _sseClient = sseClient;
+
+  final ApiClient _apiClient;
+  final SseClient _sseClient;
+
+  @override
+  Future<List<Conversation>> listConversations() async {
+    final result = await _apiClient.get('/conversations');
+    final body = _unwrap(result);
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    return (json['data'] as List)
+        .map((e) => Conversation.fromMap(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<List<ConversationEvent>> getEvents(String conversationId) async {
+    final result =
+        await _apiClient.get('/conversations/$conversationId/events');
+    final body = _unwrap(result);
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    return (json['data'] as List)
+        .map((e) => ConversationEvent.fromMap(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<List<ConversationRecord>> getRecords(String conversationId) async {
+    final result =
+        await _apiClient.get('/conversations/$conversationId/records');
+    final body = _unwrap(result);
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    return (json['data'] as List)
+        .map((e) => ConversationRecord.fromMap(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Stream<SseEvent> streamChat({
+    required String sessionId,
+    required String content,
+    required String idempotencyKey,
+    String? model,
+    String? backend,
+  }) {
+    final body = <String, dynamic>{
+      'session_id': sessionId,
+      'content': content,
+      'idempotency_key': idempotencyKey,
+    };
+    if (model != null) body['model'] = model;
+    if (backend != null) body['backend'] = backend;
+    return _sseClient.post('/chat/stream', data: body);
+  }
+
+  @override
+  Future<void> cancelChat({
+    required String sessionId,
+    required String idempotencyKey,
+  }) async {
+    final result = await _apiClient.postJson('/chat/cancel', data: {
+      'session_id': sessionId,
+      'idempotency_key': idempotencyKey,
+    });
+    _throwOnFailure(result);
+  }
+
+  @override
+  Future<Conversation?> getConversation(String conversationId) async {
+    final conversations = await listConversations();
+    try {
+      return conversations.firstWhere(
+        (c) => c.conversationId == conversationId,
+      );
+    } on StateError {
+      return null;
+    }
+  }
+
+  @override
+  Future<List<ModelInfo>> getModels({String? backend}) async {
+    final result = await _apiClient.get(
+      '/chat/models',
+      queryParameters: backend != null ? {'backend': backend} : null,
+    );
+    final body = _unwrap(result);
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    return (json['models'] as List)
+        .map((e) => ModelInfo.fromMap(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<BackendOptions> getBackends() async {
+    final result = await _apiClient.get('/chat/backends');
+    final body = _unwrap(result);
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final backends = (json['backends'] as List)
+        .map((e) => BackendInfo.fromMap(e as Map<String, dynamic>))
+        .toList();
+    return BackendOptions(
+      backends: backends,
+      defaultBackend: json['default_backend'] as String?,
+    );
+  }
+
+  @override
+  Future<bool> toggleEndorse(String recordId) async {
+    final result =
+        await _apiClient.postJson('/records/$recordId/endorse');
+    final body = _unwrap(result);
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    return json['user_endorsed'] as bool;
+  }
+
+  String _unwrap(ApiResult result) {
+    return switch (result) {
+      ApiSuccess(body: final b) when b != null => b,
+      ApiSuccess() => throw const ChatException('Empty response'),
+      ApiNotConfigured() => throw const ChatException('API not configured'),
+      ApiPermanentFailure(message: final m) => throw ChatException(m),
+      ApiTransientFailure(reason: final r) => throw ChatException(r),
+    };
+  }
+
+  void _throwOnFailure(ApiResult result) {
+    switch (result) {
+      case ApiSuccess():
+        return;
+      case ApiNotConfigured():
+        throw const ChatException('API not configured');
+      case ApiPermanentFailure(message: final m):
+        throw ChatException(m);
+      case ApiTransientFailure(reason: final r):
+        throw ChatException(r);
+    }
+  }
+}

--- a/lib/features/chat/domain/chat_repository.dart
+++ b/lib/features/chat/domain/chat_repository.dart
@@ -1,0 +1,103 @@
+import 'package:voice_agent/core/models/conversation.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/network/sse_client.dart';
+
+class ModelInfo {
+  const ModelInfo({
+    required this.id,
+    required this.name,
+    required this.backendId,
+  });
+
+  final String id;
+  final String name;
+  final String backendId;
+
+  factory ModelInfo.fromMap(Map<String, dynamic> map) {
+    return ModelInfo(
+      id: map['id'] as String,
+      name: map['name'] as String,
+      backendId: map['backend'] as String,
+    );
+  }
+}
+
+class BackendInfo {
+  const BackendInfo({
+    required this.id,
+    required this.name,
+    required this.available,
+  });
+
+  final String id;
+  final String name;
+  final bool available;
+
+  factory BackendInfo.fromMap(Map<String, dynamic> map) {
+    return BackendInfo(
+      id: map['id'] as String,
+      name: map['name'] as String,
+      available: map['available'] as bool,
+    );
+  }
+}
+
+class BackendOptions {
+  const BackendOptions({required this.backends, this.defaultBackend});
+
+  final List<BackendInfo> backends;
+  final String? defaultBackend;
+}
+
+class ChatResult {
+  const ChatResult({
+    required this.conversationId,
+    required this.userEventId,
+    this.agentEventId,
+    required this.reply,
+    this.backend,
+  });
+
+  final String conversationId;
+  final String userEventId;
+  final String? agentEventId;
+  final String reply;
+  final String? backend;
+
+  factory ChatResult.fromMap(Map<String, dynamic> map) {
+    return ChatResult(
+      conversationId: map['conversation_id'] as String,
+      userEventId: map['user_event_id'] as String,
+      agentEventId: map['agent_event_id'] as String?,
+      reply: map['reply'] as String,
+      backend: map['backend'] as String?,
+    );
+    // knowledge_extraction and warnings intentionally ignored in V1
+  }
+}
+
+String recordDisplayText(ConversationRecord r) {
+  final text = r.payload['text'] as String?;
+  return text?.isNotEmpty == true ? text! : r.subjectRef;
+}
+
+abstract class ChatRepository {
+  Future<List<Conversation>> listConversations();
+  Future<List<ConversationEvent>> getEvents(String conversationId);
+  Future<List<ConversationRecord>> getRecords(String conversationId);
+  Stream<SseEvent> streamChat({
+    required String sessionId,
+    required String content,
+    required String idempotencyKey,
+    String? model,
+    String? backend,
+  });
+  Future<void> cancelChat({
+    required String sessionId,
+    required String idempotencyKey,
+  });
+  Future<Conversation?> getConversation(String conversationId);
+  Future<List<ModelInfo>> getModels({String? backend});
+  Future<BackendOptions> getBackends();
+  Future<bool> toggleEndorse(String recordId);
+}

--- a/lib/features/chat/domain/chat_state.dart
+++ b/lib/features/chat/domain/chat_state.dart
@@ -1,0 +1,95 @@
+import 'package:voice_agent/core/models/conversation.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/features/chat/domain/chat_repository.dart';
+
+sealed class ChatListState {
+  const ChatListState();
+}
+
+class ChatListLoading extends ChatListState {
+  const ChatListLoading();
+}
+
+class ChatListLoaded extends ChatListState {
+  const ChatListLoaded(this.conversations);
+  final List<Conversation> conversations;
+}
+
+class ChatListError extends ChatListState {
+  const ChatListError(this.message);
+  final String message;
+}
+
+sealed class ThreadState {
+  const ThreadState();
+}
+
+class ThreadLoading extends ThreadState {
+  const ThreadLoading();
+}
+
+class ThreadEmpty extends ThreadState {
+  const ThreadEmpty({
+    required this.sessionId,
+    required this.models,
+    required this.backends,
+    this.selectedModel,
+    this.selectedBackend,
+  });
+
+  final String sessionId;
+  final List<ModelInfo> models;
+  final List<BackendInfo> backends;
+  final String? selectedModel;
+  final String? selectedBackend;
+}
+
+class ThreadLoaded extends ThreadState {
+  const ThreadLoaded({
+    required this.conversation,
+    required this.events,
+    required this.records,
+    required this.models,
+    required this.backends,
+    this.selectedModel,
+    this.selectedBackend,
+  });
+
+  final Conversation conversation;
+  final List<ConversationEvent> events;
+  final List<ConversationRecord> records;
+  final List<ModelInfo> models;
+  final List<BackendInfo> backends;
+  final String? selectedModel;
+  final String? selectedBackend;
+}
+
+class ThreadStreaming extends ThreadState {
+  const ThreadStreaming({
+    this.conversation,
+    required this.events,
+    required this.records,
+    required this.models,
+    required this.backends,
+    this.selectedModel,
+    this.selectedBackend,
+    required this.pendingUserMessage,
+    this.toolProgress,
+  });
+
+  final Conversation? conversation;
+  final List<ConversationEvent> events;
+  final List<ConversationRecord> records;
+  final List<ModelInfo> models;
+  final List<BackendInfo> backends;
+  final String? selectedModel;
+  final String? selectedBackend;
+  final String pendingUserMessage;
+  final String? toolProgress;
+}
+
+class ThreadError extends ThreadState {
+  const ThreadError(this.message, this.previousState);
+  final String message;
+  final ThreadState? previousState;
+}

--- a/test/features/chat/data/api_chat_repository_test.dart
+++ b/test/features/chat/data/api_chat_repository_test.dart
@@ -1,0 +1,467 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/core/network/sse_client.dart';
+import 'package:voice_agent/features/chat/data/api_chat_repository.dart';
+
+class _StubApiClient extends ApiClient {
+  _StubApiClient() : super(baseUrl: 'https://test.com/api/v1');
+
+  ApiResult nextGetResult = const ApiSuccess(body: '{}');
+  ApiResult nextPostResult = const ApiSuccess(body: '{}');
+
+  String? lastGetPath;
+  Map<String, dynamic>? lastGetParams;
+  String? lastPostPath;
+  Map<String, dynamic>? lastPostData;
+
+  @override
+  Future<ApiResult> get(
+    String path, {
+    Map<String, dynamic>? queryParameters,
+  }) async {
+    lastGetPath = path;
+    lastGetParams = queryParameters;
+    return nextGetResult;
+  }
+
+  @override
+  Future<ApiResult> postJson(String path, {Map<String, dynamic>? data}) async {
+    lastPostPath = path;
+    lastPostData = data;
+    return nextPostResult;
+  }
+}
+
+class _StubSseClient extends SseClient {
+  _StubSseClient() : super(apiClient: ApiClient(baseUrl: null));
+
+  Stream<SseEvent>? nextStream;
+  String? lastPath;
+  Map<String, dynamic>? lastData;
+
+  @override
+  Stream<SseEvent> post(String path, {required Map<String, dynamic> data}) {
+    lastPath = path;
+    lastData = data;
+    return nextStream ?? const Stream.empty();
+  }
+}
+
+Map<String, dynamic> _sampleConversation({String id = 'conv-1'}) => {
+      'conversation_id': id,
+      'session_id': 'sess-1',
+      'status': 'open',
+      'created_at': '2026-01-01T00:00:00Z',
+      'event_count': 2,
+      'last_event_at': '2026-01-01T01:00:00Z',
+      'first_message_preview': 'Hello',
+      'subject_record_id': null,
+      'subject_record_text': null,
+      'subject_record_status': null,
+    };
+
+Map<String, dynamic> _sampleEvent() => {
+      'event_id': 'evt-1',
+      'conversation_id': 'conv-1',
+      'sequence': 1,
+      'role': 'user',
+      'content': 'Hello there',
+      'occurred_at': null,
+      'received_at': '2026-01-01T00:00:00Z',
+    };
+
+Map<String, dynamic> _sampleRecord() => {
+      'record_id': 'rec-1',
+      'conversation_id': 'conv-1',
+      'record_type': 'topic',
+      'subject_ref': 'meeting',
+      'payload': {'text': 'Team meeting'},
+      'confidence': 0.9,
+      'origin_role': 'agent',
+      'assertion_mode': 'assert',
+      'user_endorsed': false,
+      'source_event_refs': [],
+    };
+
+Map<String, dynamic> _sampleModel() => {
+      'id': 'model-1',
+      'name': 'GPT-4',
+      'backend': 'openai',
+    };
+
+Map<String, dynamic> _sampleBackend({bool available = true}) => {
+      'id': 'groq',
+      'name': 'Groq',
+      'available': available,
+    };
+
+void main() {
+  late _StubApiClient apiClient;
+  late _StubSseClient sseClient;
+  late ApiChatRepository repo;
+
+  setUp(() {
+    apiClient = _StubApiClient();
+    sseClient = _StubSseClient();
+    repo = ApiChatRepository(apiClient: apiClient, sseClient: sseClient);
+  });
+
+  group('listConversations', () {
+    test('parses conversations from data envelope', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode({'data': [_sampleConversation()]}),
+      );
+
+      final conversations = await repo.listConversations();
+
+      expect(conversations, hasLength(1));
+      expect(conversations.first.conversationId, 'conv-1');
+      expect(apiClient.lastGetPath, '/conversations');
+    });
+
+    test('returns empty list when data is empty', () async {
+      apiClient.nextGetResult =
+          const ApiSuccess(body: '{"data": []}');
+
+      final conversations = await repo.listConversations();
+
+      expect(conversations, isEmpty);
+    });
+
+    test('throws ChatException on ApiNotConfigured', () async {
+      apiClient.nextGetResult = const ApiNotConfigured();
+
+      expect(
+        () => repo.listConversations(),
+        throwsA(
+          isA<ChatException>().having(
+            (e) => e.message,
+            'message',
+            contains('not configured'),
+          ),
+        ),
+      );
+    });
+
+    test('throws ChatException on ApiPermanentFailure', () async {
+      apiClient.nextGetResult = const ApiPermanentFailure(
+        statusCode: 500,
+        message: 'Internal error',
+      );
+
+      expect(
+        () => repo.listConversations(),
+        throwsA(isA<ChatException>()),
+      );
+    });
+
+    test('throws ChatException on ApiTransientFailure', () async {
+      apiClient.nextGetResult = const ApiTransientFailure(
+        reason: 'Timeout',
+      );
+
+      expect(
+        () => repo.listConversations(),
+        throwsA(isA<ChatException>()),
+      );
+    });
+  });
+
+  group('getEvents', () {
+    test('fetches events for conversation', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode({'data': [_sampleEvent()]}),
+      );
+
+      final events = await repo.getEvents('conv-1');
+
+      expect(events, hasLength(1));
+      expect(events.first.eventId, 'evt-1');
+      expect(apiClient.lastGetPath, '/conversations/conv-1/events');
+    });
+
+    test('throws on failure', () async {
+      apiClient.nextGetResult = const ApiNotConfigured();
+
+      expect(() => repo.getEvents('conv-1'), throwsA(isA<ChatException>()));
+    });
+  });
+
+  group('getRecords', () {
+    test('fetches records for conversation', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode({'data': [_sampleRecord()]}),
+      );
+
+      final records = await repo.getRecords('conv-1');
+
+      expect(records, hasLength(1));
+      expect(records.first.recordId, 'rec-1');
+      expect(apiClient.lastGetPath, '/conversations/conv-1/records');
+    });
+
+    test('throws on failure', () async {
+      apiClient.nextGetResult = const ApiTransientFailure(reason: 'error');
+
+      expect(() => repo.getRecords('conv-1'), throwsA(isA<ChatException>()));
+    });
+  });
+
+  group('getConversation', () {
+    test('returns matching conversation by id', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode({
+          'data': [
+            _sampleConversation(id: 'conv-1'),
+            _sampleConversation(id: 'conv-2'),
+          ],
+        }),
+      );
+
+      final conv = await repo.getConversation('conv-2');
+
+      expect(conv, isNotNull);
+      expect(conv!.conversationId, 'conv-2');
+    });
+
+    test('returns null when id not found', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode({'data': [_sampleConversation(id: 'conv-1')]}),
+      );
+
+      final conv = await repo.getConversation('conv-999');
+
+      expect(conv, isNull);
+    });
+  });
+
+  group('getModels', () {
+    test('fetches models from models key', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode({'models': [_sampleModel()]}),
+      );
+
+      final models = await repo.getModels();
+
+      expect(models, hasLength(1));
+      expect(models.first.id, 'model-1');
+      expect(models.first.backendId, 'openai');
+      expect(apiClient.lastGetPath, '/chat/models');
+    });
+
+    test('sends backend query parameter when specified', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode({'models': []}),
+      );
+
+      await repo.getModels(backend: 'groq');
+
+      expect(apiClient.lastGetParams, {'backend': 'groq'});
+    });
+
+    test('omits backend query parameter when null', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode({'models': []}),
+      );
+
+      await repo.getModels();
+
+      expect(apiClient.lastGetParams, isNull);
+    });
+
+    test('throws on failure', () async {
+      apiClient.nextGetResult = const ApiNotConfigured();
+
+      expect(() => repo.getModels(), throwsA(isA<ChatException>()));
+    });
+  });
+
+  group('getBackends', () {
+    test('parses backends and defaultBackend', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode({
+          'backends': [_sampleBackend()],
+          'default_backend': 'groq',
+        }),
+      );
+
+      final options = await repo.getBackends();
+
+      expect(options.backends, hasLength(1));
+      expect(options.backends.first.id, 'groq');
+      expect(options.defaultBackend, 'groq');
+    });
+
+    test('handles null default_backend', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode({
+          'backends': [_sampleBackend()],
+          'default_backend': null,
+        }),
+      );
+
+      final options = await repo.getBackends();
+
+      expect(options.defaultBackend, isNull);
+    });
+
+    test('parses available flag', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode({
+          'backends': [_sampleBackend(available: false)],
+          'default_backend': null,
+        }),
+      );
+
+      final options = await repo.getBackends();
+
+      expect(options.backends.first.available, isFalse);
+    });
+
+    test('throws on failure', () async {
+      apiClient.nextGetResult = const ApiNotConfigured();
+
+      expect(() => repo.getBackends(), throwsA(isA<ChatException>()));
+    });
+  });
+
+  group('toggleEndorse', () {
+    test('returns true when endorsed', () async {
+      apiClient.nextPostResult = const ApiSuccess(
+        body: '{"user_endorsed": true}',
+      );
+
+      final result = await repo.toggleEndorse('rec-1');
+
+      expect(result, isTrue);
+      expect(apiClient.lastPostPath, '/records/rec-1/endorse');
+    });
+
+    test('returns false when unendorsed', () async {
+      apiClient.nextPostResult = const ApiSuccess(
+        body: '{"user_endorsed": false}',
+      );
+
+      final result = await repo.toggleEndorse('rec-1');
+
+      expect(result, isFalse);
+    });
+
+    test('throws on failure', () async {
+      apiClient.nextPostResult = const ApiPermanentFailure(
+        statusCode: 404,
+        message: 'Not found',
+      );
+
+      expect(
+        () => repo.toggleEndorse('rec-1'),
+        throwsA(isA<ChatException>()),
+      );
+    });
+  });
+
+  group('streamChat', () {
+    test('calls sseClient.post with correct path and required fields', () async {
+      final events = [
+        const SseEvent(event: 'result', data: '{"done": true}'),
+      ];
+      sseClient.nextStream = Stream.fromIterable(events);
+
+      final stream = repo.streamChat(
+        sessionId: 'sess-1',
+        content: 'Hello',
+        idempotencyKey: 'key-1',
+      );
+
+      await stream.drain<void>();
+
+      expect(sseClient.lastPath, '/chat/stream');
+      expect(sseClient.lastData!['session_id'], 'sess-1');
+      expect(sseClient.lastData!['content'], 'Hello');
+      expect(sseClient.lastData!['idempotency_key'], 'key-1');
+    });
+
+    test('includes model and backend when specified', () async {
+      sseClient.nextStream = const Stream.empty();
+
+      repo.streamChat(
+        sessionId: 'sess-1',
+        content: 'Hello',
+        idempotencyKey: 'key-1',
+        model: 'gpt-4',
+        backend: 'openai',
+      );
+
+      expect(sseClient.lastData!['model'], 'gpt-4');
+      expect(sseClient.lastData!['backend'], 'openai');
+    });
+
+    test('omits model and backend when null', () async {
+      sseClient.nextStream = const Stream.empty();
+
+      repo.streamChat(
+        sessionId: 'sess-1',
+        content: 'Hello',
+        idempotencyKey: 'key-1',
+      );
+
+      expect(sseClient.lastData!.containsKey('model'), isFalse);
+      expect(sseClient.lastData!.containsKey('backend'), isFalse);
+    });
+
+    test('returns events from sseClient stream', () async {
+      final events = [
+        const SseEvent(event: 'tool_use', data: '{"tool": "bash"}'),
+        const SseEvent(event: 'result', data: '{"reply": "done"}'),
+      ];
+      sseClient.nextStream = Stream.fromIterable(events);
+
+      final received = await repo
+          .streamChat(
+            sessionId: 'sess-1',
+            content: 'Hello',
+            idempotencyKey: 'key-1',
+          )
+          .toList();
+
+      expect(received, hasLength(2));
+      expect(received.first.event, 'tool_use');
+      expect(received.last.event, 'result');
+    });
+  });
+
+  group('cancelChat', () {
+    test('posts to correct path with session and idempotency key', () async {
+      apiClient.nextPostResult = const ApiSuccess(body: '{"cancelled": true}');
+
+      await repo.cancelChat(
+        sessionId: 'sess-1',
+        idempotencyKey: 'key-1',
+      );
+
+      expect(apiClient.lastPostPath, '/chat/cancel');
+      expect(apiClient.lastPostData, {
+        'session_id': 'sess-1',
+        'idempotency_key': 'key-1',
+      });
+    });
+
+    test('throws on failure', () async {
+      apiClient.nextPostResult = const ApiNotConfigured();
+
+      expect(
+        () => repo.cancelChat(sessionId: 'sess-1', idempotencyKey: 'key-1'),
+        throwsA(isA<ChatException>()),
+      );
+    });
+  });
+
+  group('ChatException', () {
+    test('toString returns message', () {
+      const e = ChatException('API not configured');
+      expect(e.toString(), 'API not configured');
+    });
+  });
+}

--- a/test/features/chat/domain/chat_result_test.dart
+++ b/test/features/chat/domain/chat_result_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/features/chat/domain/chat_repository.dart';
+
+void main() {
+  group('ChatResult.fromMap', () {
+    test('parses all fields present', () {
+      final map = {
+        'conversation_id': 'conv-1',
+        'user_event_id': 'evt-u-1',
+        'agent_event_id': 'evt-a-1',
+        'reply': 'Hello',
+        'backend': 'groq',
+        'knowledge_extraction': {'user_status': 'ok', 'agent_status': 'ok'},
+        'warnings': ['something'],
+      };
+
+      final result = ChatResult.fromMap(map);
+
+      expect(result.conversationId, 'conv-1');
+      expect(result.userEventId, 'evt-u-1');
+      expect(result.agentEventId, 'evt-a-1');
+      expect(result.reply, 'Hello');
+      expect(result.backend, 'groq');
+    });
+
+    test('handles absent agentEventId', () {
+      final map = {
+        'conversation_id': 'conv-1',
+        'user_event_id': 'evt-u-1',
+        'reply': 'Hello',
+      };
+
+      final result = ChatResult.fromMap(map);
+
+      expect(result.agentEventId, isNull);
+    });
+
+    test('handles absent backend', () {
+      final map = {
+        'conversation_id': 'conv-1',
+        'user_event_id': 'evt-u-1',
+        'reply': 'Hello',
+      };
+
+      final result = ChatResult.fromMap(map);
+
+      expect(result.backend, isNull);
+    });
+
+    test('ignores knowledge_extraction and warnings', () {
+      final map = {
+        'conversation_id': 'conv-1',
+        'user_event_id': 'evt-u-1',
+        'reply': 'Hello',
+        'knowledge_extraction': {'user_status': 'pending'},
+        'warnings': ['w1', 'w2'],
+      };
+
+      final result = ChatResult.fromMap(map);
+
+      expect(result.conversationId, 'conv-1');
+      expect(result.reply, 'Hello');
+    });
+
+    test('throws on missing required fields', () {
+      expect(
+        () => ChatResult.fromMap({'conversation_id': 'conv-1'}),
+        throwsA(isA<TypeError>()),
+      );
+    });
+  });
+}

--- a/test/features/chat/domain/record_display_text_test.dart
+++ b/test/features/chat/domain/record_display_text_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/features/chat/domain/chat_repository.dart';
+
+ConversationRecord _record({
+  String subjectRef = 'ref-1',
+  Map<String, dynamic> payload = const {},
+}) {
+  return ConversationRecord(
+    recordId: 'rec-1',
+    conversationId: 'conv-1',
+    recordType: RecordType.topic,
+    subjectRef: subjectRef,
+    payload: payload,
+    confidence: 0.9,
+    originRole: OriginRole.agent,
+    assertionMode: 'assert',
+    userEndorsed: false,
+    sourceEventRefs: [],
+  );
+}
+
+void main() {
+  group('recordDisplayText', () {
+    test('returns payload text when present and non-empty', () {
+      final record = _record(
+        subjectRef: 'fallback',
+        payload: {'text': 'The actual text'},
+      );
+
+      expect(recordDisplayText(record), 'The actual text');
+    });
+
+    test('falls back to subjectRef when payload has no text key', () {
+      final record = _record(subjectRef: 'my-subject', payload: {});
+
+      expect(recordDisplayText(record), 'my-subject');
+    });
+
+    test('falls back to subjectRef when payload text is null', () {
+      final record = _record(
+        subjectRef: 'my-subject',
+        payload: {'text': null},
+      );
+
+      expect(recordDisplayText(record), 'my-subject');
+    });
+
+    test('falls back to subjectRef when payload text is empty string', () {
+      final record = _record(
+        subjectRef: 'my-subject',
+        payload: {'text': ''},
+      );
+
+      expect(recordDisplayText(record), 'my-subject');
+    });
+  });
+}


### PR DESCRIPTION
Implements P024-T1: Chat domain + data layer.

## What

- `ChatRepository` abstract interface with 9 methods: `listConversations`, `getEvents`, `getRecords`, `streamChat`, `cancelChat`, `getConversation`, `getModels`, `getBackends`, `toggleEndorse`
- Domain types in `features/chat/domain/`: `ModelInfo`, `BackendInfo`, `BackendOptions`, `ChatResult.fromMap()` (ADR-DATA-003 compliant), `recordDisplayText()`
- Sealed state classes: `ChatListState` (loading/loaded/error) and `ThreadState` (loading/empty/loaded/streaming/error) using Dart 3 sealed classes
- `ApiChatRepository` in `features/chat/data/` backed by `ApiClient` + `SseClient`
- `ChatException` in data/ (not domain/) — matches `AgendaException` pattern per ADR-NET-001
- `sseClientProvider` added to `core/providers/api_client_provider.dart` (per ADR-NET-003 amendment)

## Tests

34 tests covering:
- All 9 repository methods with ApiSuccess/ApiPermanentFailure/ApiTransientFailure/ApiNotConfigured
- `ChatResult.fromMap` with all optional field combinations and missing required fields
- `recordDisplayText` payload text, null, empty string, and subjectRef fallback
- `getConversation` match and null return
- `getBackends` defaultBackend present/null

## After merge

Repository layer complete. No UI uses it yet — consistent state. T2 will add `ConversationsScreen` and stub `ThreadScreen`.

Closes #213
