### PR TITLE
feat(chat): T3 full ThreadScreen + ThreadNotifier SSE flow

### DIFF
--- a/lib/features/chat/presentation/chat_providers.dart
+++ b/lib/features/chat/presentation/chat_providers.dart
@@ -18,8 +18,10 @@ final conversationsNotifierProvider =
   return ConversationsNotifier(ref.watch(chatRepositoryProvider));
 });
 
-// Stub provider — replaced by T3 with full ThreadNotifier implementation.
 final threadNotifierProvider =
     StateNotifierProvider.family<ThreadNotifier, ThreadState, String>(
-  (ref, conversationId) => ThreadNotifier(),
+  (ref, conversationId) => ThreadNotifier(
+    conversationId: conversationId,
+    repository: ref.watch(chatRepositoryProvider),
+  ),
 );

--- a/lib/features/chat/presentation/thread_notifier.dart
+++ b/lib/features/chat/presentation/thread_notifier.dart
@@ -1,7 +1,425 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+import 'package:voice_agent/core/models/conversation.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/core/network/sse_client.dart';
+import 'package:voice_agent/features/chat/domain/chat_repository.dart';
 import 'package:voice_agent/features/chat/domain/chat_state.dart';
 
-// Stub replaced by T3 with full SSE implementation.
 class ThreadNotifier extends StateNotifier<ThreadState> {
-  ThreadNotifier() : super(const ThreadLoading());
+  ThreadNotifier({
+    required String conversationId,
+    required ChatRepository repository,
+  })  : _conversationId = conversationId,
+        _repository = repository,
+        super(const ThreadLoading()) {
+    load();
+  }
+
+  final String _conversationId;
+  final ChatRepository _repository;
+
+  StreamSubscription<SseEvent>? _subscription;
+  String? _currentIdempotencyKey;
+  String? _activeSessionId;
+  String? _currentConversationId;
+  ThreadState? _preSendState;
+  String? _pendingModel;
+  String? _pendingBackend;
+
+  Future<void> load() async {
+    state = const ThreadLoading();
+    try {
+      if (_conversationId == 'new') {
+        await _loadNew();
+      } else {
+        await _loadExisting();
+      }
+    } catch (e) {
+      state = ThreadError(e.toString(), null);
+    }
+  }
+
+  Future<void> _loadNew() async {
+    final sessionId = const Uuid().v4();
+    final results = await Future.wait([
+      _repository.getModels(),
+      _repository.getBackends(),
+    ]);
+    final models = results[0] as List<ModelInfo>;
+    final backendOptions = results[1] as BackendOptions;
+    state = ThreadEmpty(
+      sessionId: sessionId,
+      models: models,
+      backends: backendOptions.backends,
+      selectedModel: _pendingModel,
+      selectedBackend: _pendingBackend ?? backendOptions.defaultBackend,
+    );
+    _pendingModel = null;
+    _pendingBackend = null;
+  }
+
+  Future<void> _loadExisting() async {
+    final results = await Future.wait([
+      _repository.getConversation(_conversationId),
+      _repository.getEvents(_conversationId),
+      _repository.getRecords(_conversationId),
+      _repository.getModels(),
+      _repository.getBackends(),
+    ]);
+    final conversation = results[0] as Conversation?;
+    if (conversation == null) {
+      state = const ThreadError('Conversation not found', null);
+      return;
+    }
+    final events = results[1] as List<ConversationEvent>;
+    final records = results[2] as List<ConversationRecord>;
+    final models = results[3] as List<ModelInfo>;
+    final backendOptions = results[4] as BackendOptions;
+    state = ThreadLoaded(
+      conversation: conversation,
+      events: events,
+      records: records,
+      models: models,
+      backends: backendOptions.backends,
+      selectedModel: _pendingModel,
+      selectedBackend: _pendingBackend ?? backendOptions.defaultBackend,
+    );
+    _pendingModel = null;
+    _pendingBackend = null;
+  }
+
+  Future<void> send(String content) async {
+    if (state is ThreadStreaming) return;
+
+    final currentState = state;
+
+    switch (currentState) {
+      case ThreadLoaded(
+          conversation: final conv,
+          events: final events,
+          records: final records,
+          models: final models,
+          backends: final backends,
+          selectedModel: final selectedModel,
+          selectedBackend: final selectedBackend,
+        ):
+        if (conv.status == ConversationStatus.closed) return;
+        _preSendState = currentState;
+        final idempotencyKey = const Uuid().v4();
+        _currentIdempotencyKey = idempotencyKey;
+        _activeSessionId = conv.sessionId;
+        state = ThreadStreaming(
+          conversation: conv,
+          events: events,
+          records: records,
+          models: models,
+          backends: backends,
+          selectedModel: selectedModel,
+          selectedBackend: selectedBackend,
+          pendingUserMessage: content,
+        );
+        _subscribe(
+          sessionId: conv.sessionId,
+          content: content,
+          idempotencyKey: idempotencyKey,
+          model: selectedModel,
+          backend: selectedBackend,
+        );
+
+      case ThreadEmpty(
+          sessionId: final sid,
+          models: final models,
+          backends: final backends,
+          selectedModel: final selectedModel,
+          selectedBackend: final selectedBackend,
+        ):
+        _preSendState = currentState;
+        final idempotencyKey = const Uuid().v4();
+        _currentIdempotencyKey = idempotencyKey;
+        _activeSessionId = sid;
+        state = ThreadStreaming(
+          conversation: null,
+          events: const [],
+          records: const [],
+          models: models,
+          backends: backends,
+          selectedModel: selectedModel,
+          selectedBackend: selectedBackend,
+          pendingUserMessage: content,
+        );
+        _subscribe(
+          sessionId: sid,
+          content: content,
+          idempotencyKey: idempotencyKey,
+          model: selectedModel,
+          backend: selectedBackend,
+        );
+
+      default:
+        return;
+    }
+  }
+
+  void _subscribe({
+    required String sessionId,
+    required String content,
+    required String idempotencyKey,
+    String? model,
+    String? backend,
+  }) {
+    _subscription = _repository
+        .streamChat(
+          sessionId: sessionId,
+          content: content,
+          idempotencyKey: idempotencyKey,
+          model: model,
+          backend: backend,
+        )
+        .listen(
+          _onSseEvent,
+          onError: _onStreamError,
+          cancelOnError: true,
+        );
+  }
+
+  void _onSseEvent(SseEvent event) {
+    final currentStreaming = state;
+    if (currentStreaming is! ThreadStreaming) return;
+
+    switch (event.event) {
+      case 'tool_use':
+        final json = jsonDecode(event.data) as Map<String, dynamic>;
+        final tool = json['tool'] as String? ?? '';
+        state = ThreadStreaming(
+          conversation: currentStreaming.conversation,
+          events: currentStreaming.events,
+          records: currentStreaming.records,
+          models: currentStreaming.models,
+          backends: currentStreaming.backends,
+          selectedModel: currentStreaming.selectedModel,
+          selectedBackend: currentStreaming.selectedBackend,
+          pendingUserMessage: currentStreaming.pendingUserMessage,
+          toolProgress: 'Using $tool\u2026',
+        );
+
+      case 'result':
+        final json = jsonDecode(event.data) as Map<String, dynamic>;
+        final result = ChatResult.fromMap(json);
+        _currentConversationId = result.conversationId;
+        _fetchAfterResult(currentStreaming);
+
+      case 'error':
+        final json = jsonDecode(event.data) as Map<String, dynamic>;
+        final message = json['error'] as String? ?? 'Stream error';
+        state = ThreadError(message, _preSendState);
+        _preSendState = null;
+    }
+  }
+
+  void _onStreamError(Object error) {
+    state = ThreadError(_streamErrorMessage(error), _preSendState);
+    _preSendState = null;
+  }
+
+  Future<void> _fetchAfterResult(ThreadStreaming streamingState) async {
+    final convId = _currentConversationId!;
+    try {
+      final results = await Future.wait([
+        _repository.getEvents(convId),
+        _repository.getRecords(convId),
+        _repository.getConversation(convId),
+      ]);
+      final events = results[0] as List<ConversationEvent>;
+      final records = results[1] as List<ConversationRecord>;
+      final conversation = results[2] as Conversation?;
+      state = ThreadLoaded(
+        conversation: conversation ??
+            streamingState.conversation ??
+            Conversation(
+              conversationId: convId,
+              sessionId: _activeSessionId ?? '',
+              status: ConversationStatus.open,
+              createdAt: DateTime.now(),
+              eventCount: events.length,
+            ),
+        events: events,
+        records: records,
+        models: streamingState.models,
+        backends: streamingState.backends,
+        selectedModel: streamingState.selectedModel,
+        selectedBackend: streamingState.selectedBackend,
+      );
+      _preSendState = null;
+      _currentConversationId = null;
+    } catch (e) {
+      state = ThreadError('Failed to load messages', streamingState);
+    }
+  }
+
+  String _streamErrorMessage(Object error) {
+    return switch (error) {
+      ApiNotConfigured() => 'API not configured',
+      ApiPermanentFailure(message: final m) => m,
+      ApiTransientFailure(reason: final r) => r,
+      _ => error.toString(),
+    };
+  }
+
+  void cancelStream() {
+    if (state is! ThreadStreaming || _activeSessionId == null) return;
+    _subscription?.cancel();
+    _subscription = null;
+    final sessionId = _activeSessionId!;
+    final idempotencyKey = _currentIdempotencyKey!;
+    state = _preSendState ?? const ThreadLoading();
+    _preSendState = null;
+    _repository
+        .cancelChat(sessionId: sessionId, idempotencyKey: idempotencyKey)
+        .catchError((_) {});
+  }
+
+  void selectModel(String? model) {
+    final current = state;
+    switch (current) {
+      case ThreadLoaded():
+        state = ThreadLoaded(
+          conversation: current.conversation,
+          events: current.events,
+          records: current.records,
+          models: current.models,
+          backends: current.backends,
+          selectedModel: model,
+          selectedBackend: current.selectedBackend,
+        );
+      case ThreadEmpty():
+        state = ThreadEmpty(
+          sessionId: current.sessionId,
+          models: current.models,
+          backends: current.backends,
+          selectedModel: model,
+          selectedBackend: current.selectedBackend,
+        );
+      case ThreadStreaming():
+        state = ThreadStreaming(
+          conversation: current.conversation,
+          events: current.events,
+          records: current.records,
+          models: current.models,
+          backends: current.backends,
+          selectedModel: model,
+          selectedBackend: current.selectedBackend,
+          pendingUserMessage: current.pendingUserMessage,
+          toolProgress: current.toolProgress,
+        );
+      case ThreadLoading() || ThreadError():
+        _pendingModel = model;
+    }
+  }
+
+  void selectBackend(String? backend) {
+    final current = state;
+    switch (current) {
+      case ThreadLoaded():
+        state = ThreadLoaded(
+          conversation: current.conversation,
+          events: current.events,
+          records: current.records,
+          models: current.models,
+          backends: current.backends,
+          selectedModel: current.selectedModel,
+          selectedBackend: backend,
+        );
+      case ThreadEmpty():
+        state = ThreadEmpty(
+          sessionId: current.sessionId,
+          models: current.models,
+          backends: current.backends,
+          selectedModel: current.selectedModel,
+          selectedBackend: backend,
+        );
+      case ThreadStreaming():
+        state = ThreadStreaming(
+          conversation: current.conversation,
+          events: current.events,
+          records: current.records,
+          models: current.models,
+          backends: current.backends,
+          selectedModel: current.selectedModel,
+          selectedBackend: backend,
+          pendingUserMessage: current.pendingUserMessage,
+          toolProgress: current.toolProgress,
+        );
+      case ThreadLoading() || ThreadError():
+        _pendingBackend = backend;
+    }
+  }
+
+  Future<void> toggleEndorse(String recordId) async {
+    final current = state;
+    final List<ConversationRecord> records;
+    switch (current) {
+      case ThreadLoaded(records: final r):
+        records = r;
+      case ThreadStreaming(records: final r):
+        records = r;
+      default:
+        return;
+    }
+
+    final endorsed = await _repository.toggleEndorse(recordId);
+    final updated = records.map((r) {
+      if (r.recordId != recordId) return r;
+      return ConversationRecord(
+        recordId: r.recordId,
+        conversationId: r.conversationId,
+        recordType: r.recordType,
+        subjectRef: r.subjectRef,
+        payload: r.payload,
+        confidence: r.confidence,
+        originRole: r.originRole,
+        assertionMode: r.assertionMode,
+        userEndorsed: endorsed,
+        sourceEventRefs: r.sourceEventRefs,
+      );
+    }).toList();
+
+    final refreshed = state;
+    switch (refreshed) {
+      case ThreadLoaded():
+        state = ThreadLoaded(
+          conversation: refreshed.conversation,
+          events: refreshed.events,
+          records: updated,
+          models: refreshed.models,
+          backends: refreshed.backends,
+          selectedModel: refreshed.selectedModel,
+          selectedBackend: refreshed.selectedBackend,
+        );
+      case ThreadStreaming():
+        state = ThreadStreaming(
+          conversation: refreshed.conversation,
+          events: refreshed.events,
+          records: updated,
+          models: refreshed.models,
+          backends: refreshed.backends,
+          selectedModel: refreshed.selectedModel,
+          selectedBackend: refreshed.selectedBackend,
+          pendingUserMessage: refreshed.pendingUserMessage,
+          toolProgress: refreshed.toolProgress,
+        );
+      default:
+        break;
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
 }

--- a/lib/features/chat/presentation/thread_screen.dart
+++ b/lib/features/chat/presentation/thread_screen.dart
@@ -1,16 +1,555 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:voice_agent/core/models/conversation.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/features/chat/domain/chat_repository.dart';
+import 'package:voice_agent/features/chat/domain/chat_state.dart';
+import 'package:voice_agent/features/chat/presentation/chat_providers.dart';
 
-// Stub replaced by T3 with full thread screen implementation.
-class ThreadScreen extends StatelessWidget {
+class ThreadScreen extends ConsumerStatefulWidget {
   const ThreadScreen({super.key, required this.conversationId});
 
   final String conversationId;
 
   @override
+  ConsumerState<ThreadScreen> createState() => _ThreadScreenState();
+}
+
+class _ThreadScreenState extends ConsumerState<ThreadScreen> {
+  final _textController = TextEditingController();
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final state = ref.watch(threadNotifierProvider(widget.conversationId));
+    final notifier =
+        ref.read(threadNotifierProvider(widget.conversationId).notifier);
+
+    final String title;
+    final List<ConversationEvent> events;
+    final List<ConversationRecord> records;
+    final List<ModelInfo> models;
+    final List<BackendInfo> backends;
+    final String? selectedModel;
+    final String? selectedBackend;
+    final bool isStreaming;
+    final String? pendingMessage;
+    final String? toolProgress;
+    final bool isClosed;
+
+    switch (state) {
+      case ThreadLoading():
+        return Scaffold(
+          appBar: AppBar(title: const Text('Loading\u2026')),
+          body: const Center(child: CircularProgressIndicator()),
+        );
+
+      case ThreadError(message: final msg, previousState: final prev):
+        return Scaffold(
+          appBar: AppBar(title: const Text('Error')),
+          body: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(msg),
+                const SizedBox(height: 16),
+                if (prev != null)
+                  ElevatedButton(
+                    key: const Key('thread-retry-button'),
+                    onPressed: notifier.load,
+                    child: const Text('Retry'),
+                  ),
+              ],
+            ),
+          ),
+        );
+
+      case ThreadEmpty(
+          models: final m,
+          backends: final b,
+          selectedModel: final sm,
+          selectedBackend: final sb,
+        ):
+        title = 'New Chat';
+        events = const [];
+        records = const [];
+        models = m;
+        backends = b;
+        selectedModel = sm;
+        selectedBackend = sb;
+        isStreaming = false;
+        pendingMessage = null;
+        toolProgress = null;
+        isClosed = false;
+
+      case ThreadLoaded(
+          conversation: final conv,
+          events: final e,
+          records: final r,
+          models: final m,
+          backends: final b,
+          selectedModel: final sm,
+          selectedBackend: final sb,
+        ):
+        title = conv.firstMessagePreview ?? 'New Chat';
+        events = e;
+        records = r;
+        models = m;
+        backends = b;
+        selectedModel = sm;
+        selectedBackend = sb;
+        isStreaming = false;
+        pendingMessage = null;
+        toolProgress = null;
+        isClosed = conv.status == ConversationStatus.closed;
+
+      case ThreadStreaming(
+          conversation: final conv,
+          events: final e,
+          records: final r,
+          models: final m,
+          backends: final b,
+          selectedModel: final sm,
+          selectedBackend: final sb,
+          pendingUserMessage: final pm,
+          toolProgress: final tp,
+        ):
+        title = conv?.firstMessagePreview ?? 'New Chat';
+        events = e;
+        records = r;
+        models = m;
+        backends = b;
+        selectedModel = sm;
+        selectedBackend = sb;
+        isStreaming = true;
+        pendingMessage = pm;
+        toolProgress = tp;
+        isClosed = false;
+    }
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Thread')),
-      body: const Center(child: CircularProgressIndicator()),
+      appBar: AppBar(
+        title: Text(title),
+        actions: [
+          _ModelBackendPicker(
+            models: models,
+            backends: backends,
+            selectedModel: selectedModel,
+            selectedBackend: selectedBackend,
+            onSelectModel: notifier.selectModel,
+            onSelectBackend: notifier.selectBackend,
+          ),
+          IconButton(
+            key: const Key('thread-settings-icon'),
+            icon: const Icon(Icons.settings),
+            onPressed: () => context.push('/settings'),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView(
+              key: const Key('thread-message-list'),
+              reverse: true,
+              children: [
+                if (isStreaming) _TypingIndicator(toolProgress: toolProgress),
+                if (pendingMessage != null)
+                  _MessageBubble(
+                    key: const Key('thread-pending-message'),
+                    content: pendingMessage,
+                    role: EventRole.user,
+                    pending: true,
+                  ),
+                ...(() {
+                  final reversed = events.reversed.toList();
+                  final widgets = <Widget>[];
+                  for (var i = 0; i < reversed.length; i++) {
+                    final event = reversed[i];
+                    widgets.add(_MessageBubble(
+                      key: Key('thread-event-${event.eventId}'),
+                      content: event.content,
+                      role: event.role,
+                    ));
+                    final isLastAgent = event.role == EventRole.agent &&
+                        reversed
+                            .sublist(0, i)
+                            .every((e) => e.role != EventRole.agent);
+                    if (isLastAgent && records.isNotEmpty) {
+                      widgets.add(_RecordBadges(
+                        records: records,
+                        onToggleEndorse: notifier.toggleEndorse,
+                      ));
+                    }
+                  }
+                  return widgets;
+                })(),
+              ],
+            ),
+          ),
+          if (isClosed)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: Text(
+                'Conversation closed',
+                key: const Key('thread-closed-label'),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+              ),
+            ),
+          _InputBar(
+            controller: _textController,
+            canSend: !isStreaming && !isClosed,
+            isStreaming: isStreaming,
+            onSend: (text) {
+              notifier.send(text);
+              _textController.clear();
+            },
+            onCancel: notifier.cancelStream,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MessageBubble extends StatelessWidget {
+  const _MessageBubble({
+    super.key,
+    required this.content,
+    required this.role,
+    this.pending = false,
+  });
+
+  final String content;
+  final EventRole role;
+  final bool pending;
+
+  @override
+  Widget build(BuildContext context) {
+    final isUser = role == EventRole.user;
+    return Align(
+      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.75,
+        ),
+        decoration: BoxDecoration(
+          color: isUser
+              ? Theme.of(context).colorScheme.primary.withAlpha(pending ? 128 : 255)
+              : Theme.of(context).colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          content,
+          key: Key('bubble-$role'),
+          style: TextStyle(
+            color: isUser ? Theme.of(context).colorScheme.onPrimary : null,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TypingIndicator extends StatelessWidget {
+  const _TypingIndicator({this.toolProgress});
+
+  final String? toolProgress;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        key: const Key('thread-typing-indicator'),
+        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          toolProgress ?? 'Thinking\u2026',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ),
+    );
+  }
+}
+
+class _RecordBadges extends StatelessWidget {
+  const _RecordBadges({
+    required this.records,
+    required this.onToggleEndorse,
+  });
+
+  final List<ConversationRecord> records;
+  final void Function(String recordId) onToggleEndorse;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: Wrap(
+        key: const Key('thread-record-badges'),
+        spacing: 6,
+        runSpacing: 4,
+        children: records
+            .map(
+              (r) => _RecordBadge(
+                record: r,
+                onToggleEndorse: () => onToggleEndorse(r.recordId),
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}
+
+class _RecordBadge extends StatelessWidget {
+  const _RecordBadge({
+    required this.record,
+    required this.onToggleEndorse,
+  });
+
+  final ConversationRecord record;
+  final VoidCallback onToggleEndorse;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = recordDisplayText(record);
+    return GestureDetector(
+      key: Key('badge-${record.recordId}'),
+      onTap: onToggleEndorse,
+      child: Chip(
+        avatar: Icon(
+          record.userEndorsed ? Icons.star : Icons.star_border,
+          size: 16,
+          key: Key('badge-star-${record.recordId}'),
+        ),
+        label: Text(text, style: const TextStyle(fontSize: 12)),
+      ),
+    );
+  }
+}
+
+class _ModelBackendPicker extends StatelessWidget {
+  const _ModelBackendPicker({
+    required this.models,
+    required this.backends,
+    required this.selectedModel,
+    required this.selectedBackend,
+    required this.onSelectModel,
+    required this.onSelectBackend,
+  });
+
+  final List<ModelInfo> models;
+  final List<BackendInfo> backends;
+  final String? selectedModel;
+  final String? selectedBackend;
+  final void Function(String?) onSelectModel;
+  final void Function(String?) onSelectBackend;
+
+  @override
+  Widget build(BuildContext context) {
+    if (backends.isEmpty) return const SizedBox.shrink();
+    final currentBackend = backends.firstWhere(
+      (b) => b.id == selectedBackend,
+      orElse: () => backends.first,
+    );
+    return TextButton(
+      key: const Key('thread-model-picker'),
+      onPressed: () => _showPicker(context),
+      child: Text(currentBackend.name),
+    );
+  }
+
+  void _showPicker(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (ctx) => _ModelPickerSheet(
+        models: models,
+        backends: backends,
+        selectedModel: selectedModel,
+        selectedBackend: selectedBackend,
+        onSelectModel: onSelectModel,
+        onSelectBackend: onSelectBackend,
+      ),
+    );
+  }
+}
+
+class _ModelPickerSheet extends StatefulWidget {
+  const _ModelPickerSheet({
+    required this.models,
+    required this.backends,
+    required this.selectedModel,
+    required this.selectedBackend,
+    required this.onSelectModel,
+    required this.onSelectBackend,
+  });
+
+  final List<ModelInfo> models;
+  final List<BackendInfo> backends;
+  final String? selectedModel;
+  final String? selectedBackend;
+  final void Function(String?) onSelectModel;
+  final void Function(String?) onSelectBackend;
+
+  @override
+  State<_ModelPickerSheet> createState() => _ModelPickerSheetState();
+}
+
+class _ModelPickerSheetState extends State<_ModelPickerSheet> {
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Text(
+                'Backend',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+            ),
+            RadioGroup<String>(
+              groupValue: widget.selectedBackend,
+              onChanged: (v) {
+                if (v == null) return;
+                final backend =
+                    widget.backends.firstWhere((b) => b.id == v);
+                if (!backend.available) return;
+                widget.onSelectBackend(v);
+                Navigator.of(context).pop();
+              },
+              child: Column(
+                children: widget.backends
+                    .map(
+                      (b) => ListTile(
+                        key: Key('backend-option-${b.id}'),
+                        enabled: b.available,
+                        title: Text(b.name),
+                        subtitle:
+                            b.available ? null : const Text('Unavailable'),
+                        leading: Radio<String>(value: b.id),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+            if (widget.models.isNotEmpty) ...[
+              const Divider(),
+              Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Text(
+                  'Model',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: DropdownButton<String>(
+                  key: const Key('model-dropdown'),
+                  isExpanded: true,
+                  value: widget.selectedModel,
+                  hint: const Text('Default model'),
+                  items: widget.models
+                      .map(
+                        (m) => DropdownMenuItem(
+                          value: m.id,
+                          child: Text(m.name),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (v) {
+                    widget.onSelectModel(v);
+                    Navigator.of(context).pop();
+                  },
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InputBar extends StatelessWidget {
+  const _InputBar({
+    required this.controller,
+    required this.canSend,
+    required this.isStreaming,
+    required this.onSend,
+    required this.onCancel,
+  });
+
+  final TextEditingController controller;
+  final bool canSend;
+  final bool isStreaming;
+  final void Function(String text) onSend;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                key: const Key('thread-input-field'),
+                controller: controller,
+                enabled: canSend,
+                maxLines: null,
+                decoration: const InputDecoration(
+                  hintText: 'Message\u2026',
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+                onSubmitted: canSend ? (t) => onSend(t.trim()) : null,
+              ),
+            ),
+            const SizedBox(width: 8),
+            if (isStreaming)
+              IconButton(
+                key: const Key('thread-cancel-button'),
+                icon: const Icon(Icons.stop_circle_outlined),
+                onPressed: onCancel,
+              )
+            else
+              IconButton(
+                key: const Key('thread-send-button'),
+                icon: const Icon(Icons.send),
+                onPressed: canSend
+                    ? () {
+                        final text = controller.text.trim();
+                        if (text.isEmpty) return;
+                        onSend(text);
+                      }
+                    : null,
+              ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/test/features/chat/presentation/thread_notifier_test.dart
+++ b/test/features/chat/presentation/thread_notifier_test.dart
@@ -1,0 +1,567 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/conversation.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/core/network/sse_client.dart';
+import 'package:voice_agent/features/chat/domain/chat_repository.dart';
+import 'package:voice_agent/features/chat/domain/chat_state.dart';
+import 'package:voice_agent/features/chat/presentation/thread_notifier.dart';
+
+// ---------------------------------------------------------------------------
+// Stub helpers
+// ---------------------------------------------------------------------------
+
+class _StubRepository implements ChatRepository {
+  Conversation? conversationResult;
+  List<ConversationEvent> eventsResult = [];
+  List<ConversationRecord> recordsResult = [];
+  List<ModelInfo> modelsResult = [];
+  BackendOptions backendsResult = const BackendOptions(backends: []);
+  bool toggleResult = true;
+
+  bool throwOnLoad = false;
+  bool throwOnFetchAfterResult = false;
+
+  StreamController<SseEvent>? streamController;
+
+  String? lastCancelSessionId;
+  String? lastCancelIdempotencyKey;
+  String? lastToggleRecordId;
+
+  int getConversationCallCount = 0;
+
+  @override
+  Future<List<Conversation>> listConversations() async => [];
+
+  @override
+  Future<Conversation?> getConversation(String conversationId) async {
+    getConversationCallCount++;
+    if (throwOnLoad) throw Exception('load failed');
+    return conversationResult;
+  }
+
+  @override
+  Future<List<ConversationEvent>> getEvents(String conversationId) async {
+    if (throwOnFetchAfterResult) throw Exception('fetch failed');
+    return eventsResult;
+  }
+
+  @override
+  Future<List<ConversationRecord>> getRecords(String conversationId) async {
+    if (throwOnFetchAfterResult) throw Exception('fetch failed');
+    return recordsResult;
+  }
+
+  @override
+  Future<List<ModelInfo>> getModels({String? backend}) async => modelsResult;
+
+  @override
+  Future<BackendOptions> getBackends() async => backendsResult;
+
+  @override
+  Stream<SseEvent> streamChat({
+    required String sessionId,
+    required String content,
+    required String idempotencyKey,
+    String? model,
+    String? backend,
+  }) {
+    streamController = StreamController<SseEvent>();
+    return streamController!.stream;
+  }
+
+  @override
+  Future<void> cancelChat({
+    required String sessionId,
+    required String idempotencyKey,
+  }) async {
+    lastCancelSessionId = sessionId;
+    lastCancelIdempotencyKey = idempotencyKey;
+  }
+
+  @override
+  Future<bool> toggleEndorse(String recordId) async {
+    lastToggleRecordId = recordId;
+    return toggleResult;
+  }
+}
+
+Conversation _conv({
+  String id = 'conv-1',
+  String sessionId = 'sess-1',
+  ConversationStatus status = ConversationStatus.open,
+  String? preview,
+}) {
+  return Conversation(
+    conversationId: id,
+    sessionId: sessionId,
+    status: status,
+    createdAt: DateTime(2026, 1, 1),
+    eventCount: 0,
+    firstMessagePreview: preview,
+  );
+}
+
+ConversationEvent _event({String id = 'evt-1', EventRole role = EventRole.user}) {
+  return ConversationEvent(
+    eventId: id,
+    conversationId: 'conv-1',
+    sequence: 1,
+    role: role,
+    content: 'content-$id',
+    receivedAt: DateTime(2026, 1, 1),
+  );
+}
+
+ConversationRecord _record({String id = 'rec-1', bool endorsed = false}) {
+  return ConversationRecord(
+    recordId: id,
+    conversationId: 'conv-1',
+    recordType: RecordType.decision,
+    subjectRef: 'subj-$id',
+    payload: const {},
+    confidence: 0.9,
+    originRole: OriginRole.agent,
+    assertionMode: 'assert',
+    userEndorsed: endorsed,
+    sourceEventRefs: const [],
+  );
+}
+
+SseEvent _toolUseEvent(String tool) {
+  return SseEvent(
+    event: 'tool_use',
+    data: '{"type":"tool_use","tool":"$tool","input":"{}"}',
+  );
+}
+
+SseEvent _resultEvent({
+  String conversationId = 'conv-1',
+  String reply = 'Agent reply',
+}) {
+  return SseEvent(
+    event: 'result',
+    data:
+        '{"conversation_id":"$conversationId","user_event_id":"ue-1","reply":"$reply"}',
+  );
+}
+
+SseEvent _errorEvent(String message) {
+  return SseEvent(event: 'error', data: '{"error":"$message"}');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('ThreadNotifier — new conversation', () {
+    test('transitions to empty state with generated sessionId', () async {
+      final repo = _StubRepository();
+      final notifier =
+          ThreadNotifier(conversationId: 'new', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      expect(notifier.state, isA<ThreadEmpty>());
+      final empty = notifier.state as ThreadEmpty;
+      expect(empty.sessionId, isNotEmpty);
+    });
+
+    test('selectedBackend set from defaultBackend', () async {
+      final repo = _StubRepository()
+        ..backendsResult = const BackendOptions(
+          backends: [BackendInfo(id: 'b1', name: 'B1', available: true)],
+          defaultBackend: 'b1',
+        );
+      final notifier =
+          ThreadNotifier(conversationId: 'new', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      final empty = notifier.state as ThreadEmpty;
+      expect(empty.selectedBackend, 'b1');
+    });
+  });
+
+  group('ThreadNotifier — existing conversation', () {
+    test('transitions to loaded state', () async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [_event()]
+        ..recordsResult = [_record()];
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      expect(notifier.state, isA<ThreadLoaded>());
+      final loaded = notifier.state as ThreadLoaded;
+      expect(loaded.conversation.conversationId, 'conv-1');
+      expect(loaded.events, hasLength(1));
+      expect(loaded.records, hasLength(1));
+    });
+
+    test('emits error when getConversation returns null', () async {
+      final repo = _StubRepository()..conversationResult = null;
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      expect(notifier.state, isA<ThreadError>());
+      final error = notifier.state as ThreadError;
+      expect(error.message, 'Conversation not found');
+    });
+
+    test('emits error on load failure', () async {
+      final repo = _StubRepository()..throwOnLoad = true;
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      expect(notifier.state, isA<ThreadError>());
+    });
+
+    test('selectedBackend initialized from defaultBackend', () async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..backendsResult = const BackendOptions(
+          backends: [BackendInfo(id: 'b2', name: 'B2', available: true)],
+          defaultBackend: 'b2',
+        );
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      final loaded = notifier.state as ThreadLoaded;
+      expect(loaded.selectedBackend, 'b2');
+    });
+  });
+
+  group('ThreadNotifier — send', () {
+    test('is no-op when state is streaming', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.send('first');
+      expect(notifier.state, isA<ThreadStreaming>());
+
+      await notifier.send('second');
+      expect(notifier.state, isA<ThreadStreaming>());
+    });
+
+    test('is no-op when conversation is closed', () async {
+      final repo = _StubRepository()
+        ..conversationResult =
+            _conv(status: ConversationStatus.closed);
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.send('hello');
+      expect(notifier.state, isA<ThreadLoaded>());
+    });
+
+    test('transitions loaded → streaming with pendingUserMessage', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.send('hello');
+
+      expect(notifier.state, isA<ThreadStreaming>());
+      final streaming = notifier.state as ThreadStreaming;
+      expect(streaming.pendingUserMessage, 'hello');
+    });
+
+    test('transitions empty → streaming for new conversation', () async {
+      final repo = _StubRepository();
+      final notifier =
+          ThreadNotifier(conversationId: 'new', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.send('first message');
+
+      expect(notifier.state, isA<ThreadStreaming>());
+      final streaming = notifier.state as ThreadStreaming;
+      expect(streaming.pendingUserMessage, 'first message');
+      expect(streaming.conversation, isNull);
+    });
+
+    test('tool_use event updates toolProgress', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.send('hello');
+      repo.streamController!.add(_toolUseEvent('Bash'));
+      await Future.microtask(() {});
+
+      expect(notifier.state, isA<ThreadStreaming>());
+      final streaming = notifier.state as ThreadStreaming;
+      expect(streaming.toolProgress, contains('Bash'));
+    });
+
+    test('result event transitions to loaded with refreshed data', () async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [_event(), _event(id: 'evt-2')];
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.send('hello');
+      repo.streamController!.add(_resultEvent());
+      await repo.streamController!.close();
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      expect(notifier.state, isA<ThreadLoaded>());
+      final loaded = notifier.state as ThreadLoaded;
+      expect(loaded.events, hasLength(2));
+    });
+
+    test('SSE error event emits error with preSendState', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      final preSend = notifier.state;
+      await notifier.send('hello');
+      repo.streamController!.add(_errorEvent('backend error'));
+      await Future.microtask(() {});
+
+      expect(notifier.state, isA<ThreadError>());
+      final error = notifier.state as ThreadError;
+      expect(error.message, 'backend error');
+      expect(error.previousState, preSend);
+    });
+
+    test('stream Dart error maps ApiNotConfigured', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.send('hello');
+      repo.streamController!.addError(const ApiNotConfigured());
+      await Future.microtask(() {});
+
+      expect(notifier.state, isA<ThreadError>());
+      final error = notifier.state as ThreadError;
+      expect(error.message, 'API not configured');
+    });
+
+    test('stream Dart error maps ApiPermanentFailure', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.send('hello');
+      repo.streamController!.addError(
+        const ApiPermanentFailure(statusCode: 500, message: 'Server error'),
+      );
+      await Future.microtask(() {});
+
+      expect(notifier.state, isA<ThreadError>());
+      expect((notifier.state as ThreadError).message, 'Server error');
+    });
+
+    test('stream Dart error maps ApiTransientFailure', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.send('hello');
+      repo.streamController!.addError(
+        const ApiTransientFailure(reason: 'timeout'),
+      );
+      await Future.microtask(() {});
+
+      expect(notifier.state, isA<ThreadError>());
+      expect((notifier.state as ThreadError).message, 'timeout');
+    });
+
+    test('post-result fetch failure emits error with streaming state', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.send('hello');
+      repo.throwOnFetchAfterResult = true;
+      repo.streamController!.add(_resultEvent());
+      await repo.streamController!.close();
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      expect(notifier.state, isA<ThreadError>());
+      final error = notifier.state as ThreadError;
+      expect(error.message, 'Failed to load messages');
+      expect(error.previousState, isA<ThreadStreaming>());
+      final prev = error.previousState as ThreadStreaming;
+      expect(prev.pendingUserMessage, 'hello');
+    });
+  });
+
+  group('ThreadNotifier — cancelStream', () {
+    test('is no-op when not streaming', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      notifier.cancelStream();
+      expect(notifier.state, isA<ThreadLoaded>());
+    });
+
+    test('reverts to preSendState and calls cancelChat', () async {
+      final repo = _StubRepository()..conversationResult = _conv(sessionId: 'sess-abc');
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      final preSend = notifier.state;
+      await notifier.send('hello');
+      expect(notifier.state, isA<ThreadStreaming>());
+
+      notifier.cancelStream();
+      await Future.microtask(() {});
+
+      expect(notifier.state, preSend);
+      expect(repo.lastCancelSessionId, 'sess-abc');
+    });
+  });
+
+  group('ThreadNotifier — toggleEndorse', () {
+    test('flips userEndorsed on matching record in loaded state', () async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..recordsResult = [_record(id: 'rec-1', endorsed: false)]
+        ..toggleResult = true;
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.toggleEndorse('rec-1');
+
+      final loaded = notifier.state as ThreadLoaded;
+      expect(loaded.records.first.userEndorsed, isTrue);
+    });
+
+    test('calls repository.toggleEndorse with correct id', () async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..recordsResult = [_record(id: 'rec-42')];
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.toggleEndorse('rec-42');
+
+      expect(repo.lastToggleRecordId, 'rec-42');
+    });
+  });
+
+  group('ThreadNotifier — selectModel / selectBackend', () {
+    test('selectModel updates loaded state', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      notifier.selectModel('model-x');
+
+      final loaded = notifier.state as ThreadLoaded;
+      expect(loaded.selectedModel, 'model-x');
+    });
+
+    test('selectModel updates empty state', () async {
+      final repo = _StubRepository();
+      final notifier =
+          ThreadNotifier(conversationId: 'new', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      notifier.selectModel('model-y');
+
+      final empty = notifier.state as ThreadEmpty;
+      expect(empty.selectedModel, 'model-y');
+    });
+
+    test('selectModel during loading stores as pending', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      // Immediately after creation, state is ThreadLoading
+      expect(notifier.state, isA<ThreadLoading>());
+
+      notifier.selectModel('model-z');
+
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      final loaded = notifier.state as ThreadLoaded;
+      expect(loaded.selectedModel, 'model-z');
+    });
+
+    test('selectBackend updates loaded state', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      notifier.selectBackend('backend-a');
+
+      final loaded = notifier.state as ThreadLoaded;
+      expect(loaded.selectedBackend, 'backend-a');
+    });
+
+    test('selectBackend during loading stores as pending applied on empty',
+        () async {
+      final repo = _StubRepository();
+      final notifier =
+          ThreadNotifier(conversationId: 'new', repository: repo);
+      expect(notifier.state, isA<ThreadLoading>());
+
+      notifier.selectBackend('backend-b');
+
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      final empty = notifier.state as ThreadEmpty;
+      expect(empty.selectedBackend, 'backend-b');
+    });
+  });
+}

--- a/test/features/chat/presentation/thread_screen_test.dart
+++ b/test/features/chat/presentation/thread_screen_test.dart
@@ -1,0 +1,347 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:voice_agent/core/models/conversation.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/network/sse_client.dart';
+import 'package:voice_agent/features/chat/domain/chat_repository.dart';
+import 'package:voice_agent/features/chat/presentation/chat_providers.dart';
+import 'package:voice_agent/features/chat/presentation/thread_screen.dart';
+
+// ---------------------------------------------------------------------------
+// Stub repository
+// ---------------------------------------------------------------------------
+
+class _StubRepository implements ChatRepository {
+  Conversation? conversationResult;
+  List<ConversationEvent> eventsResult = [];
+  List<ConversationRecord> recordsResult = [];
+  BackendOptions backendsResult = const BackendOptions(backends: [
+    BackendInfo(id: 'b1', name: 'Claude', available: true),
+  ]);
+  bool toggleResult = true;
+
+  StreamController<SseEvent>? streamController;
+
+  @override
+  Future<List<Conversation>> listConversations() async => [];
+
+  @override
+  Future<Conversation?> getConversation(String conversationId) async =>
+      conversationResult;
+
+  @override
+  Future<List<ConversationEvent>> getEvents(String conversationId) async =>
+      eventsResult;
+
+  @override
+  Future<List<ConversationRecord>> getRecords(String conversationId) async =>
+      recordsResult;
+
+  @override
+  Future<List<ModelInfo>> getModels({String? backend}) async => [];
+
+  @override
+  Future<BackendOptions> getBackends() async => backendsResult;
+
+  @override
+  Stream<SseEvent> streamChat({
+    required String sessionId,
+    required String content,
+    required String idempotencyKey,
+    String? model,
+    String? backend,
+  }) {
+    streamController = StreamController<SseEvent>();
+    return streamController!.stream;
+  }
+
+  @override
+  Future<void> cancelChat({
+    required String sessionId,
+    required String idempotencyKey,
+  }) async {}
+
+  @override
+  Future<bool> toggleEndorse(String recordId) async => toggleResult;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Conversation _conv({
+  String id = 'conv-1',
+  String sessionId = 'sess-1',
+  ConversationStatus status = ConversationStatus.open,
+  String? preview,
+}) {
+  return Conversation(
+    conversationId: id,
+    sessionId: sessionId,
+    status: status,
+    createdAt: DateTime(2026, 1, 1),
+    eventCount: 0,
+    firstMessagePreview: preview,
+  );
+}
+
+ConversationEvent _event({String id = 'evt-1', EventRole role = EventRole.user, String content = 'Hello'}) {
+  return ConversationEvent(
+    eventId: id,
+    conversationId: 'conv-1',
+    sequence: 1,
+    role: role,
+    content: content,
+    receivedAt: DateTime(2026, 1, 1),
+  );
+}
+
+ConversationRecord _record({String id = 'rec-1', bool endorsed = false, String subjectRef = 'A decision'}) {
+  return ConversationRecord(
+    recordId: id,
+    conversationId: 'conv-1',
+    recordType: RecordType.decision,
+    subjectRef: subjectRef,
+    payload: const {},
+    confidence: 0.9,
+    originRole: OriginRole.agent,
+    assertionMode: 'assert',
+    userEndorsed: endorsed,
+    sourceEventRefs: const [],
+  );
+}
+
+Future<void> _pumpScreen(
+  WidgetTester tester, {
+  required _StubRepository repository,
+  String conversationId = 'conv-1',
+}) async {
+  final router = GoRouter(
+    initialLocation: '/chat/$conversationId',
+    routes: [
+      GoRoute(
+        path: '/chat/:id',
+        builder: (_, state) =>
+            ThreadScreen(conversationId: state.pathParameters['id']!),
+      ),
+      GoRoute(
+        path: '/settings',
+        builder: (_, _) => const Scaffold(body: Text('Settings')),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        chatRepositoryProvider.overrideWithValue(repository),
+      ],
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('ThreadScreen', () {
+    testWidgets('shows loading indicator before data resolves', (tester) async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final router = GoRouter(
+        initialLocation: '/chat/conv-1',
+        routes: [
+          GoRoute(
+            path: '/chat/:id',
+            builder: (_, state) =>
+                ThreadScreen(conversationId: state.pathParameters['id']!),
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [chatRepositoryProvider.overrideWithValue(repo)],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      // First pump — still in loading state
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('renders user message bubble', (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [_event(role: EventRole.user, content: 'User says hi')];
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.text('User says hi'), findsOneWidget);
+    });
+
+    testWidgets('renders agent message bubble', (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [_event(id: 'a1', role: EventRole.agent, content: 'Agent replies')];
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.text('Agent replies'), findsOneWidget);
+    });
+
+    testWidgets('shows record badges after last agent bubble', (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [_event(id: 'a1', role: EventRole.agent, content: 'Reply')]
+        ..recordsResult = [_record(subjectRef: 'Decision badge')];
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.byKey(const Key('thread-record-badges')), findsOneWidget);
+      expect(find.text('Decision badge'), findsOneWidget);
+    });
+
+    testWidgets('record badge shows empty star when not endorsed', (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [_event(id: 'a1', role: EventRole.agent)]
+        ..recordsResult = [_record(id: 'rec-1', endorsed: false)];
+      await _pumpScreen(tester, repository: repo);
+
+      final starIcon = find.byKey(const Key('badge-star-rec-1'));
+      expect(starIcon, findsOneWidget);
+      final icon = tester.widget<Icon>(starIcon);
+      expect(icon.icon, Icons.star_border);
+    });
+
+    testWidgets('record badge shows filled star when endorsed', (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [_event(id: 'a1', role: EventRole.agent)]
+        ..recordsResult = [_record(id: 'rec-2', endorsed: true)];
+      await _pumpScreen(tester, repository: repo);
+
+      final icon = tester.widget<Icon>(find.byKey(const Key('badge-star-rec-2')));
+      expect(icon.icon, Icons.star);
+    });
+
+    testWidgets('tapping record badge calls toggleEndorse', (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [_event(id: 'a1', role: EventRole.agent)]
+        ..recordsResult = [_record(id: 'rec-tap')];
+      await _pumpScreen(tester, repository: repo);
+
+      await tester.tap(find.byKey(const Key('badge-rec-tap')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('badge-star-rec-tap')), findsOneWidget);
+    });
+
+    testWidgets('send button is enabled when loaded and open', (tester) async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      await _pumpScreen(tester, repository: repo);
+
+      final sendButton = tester.widget<IconButton>(
+        find.byKey(const Key('thread-send-button')),
+      );
+      expect(sendButton.onPressed, isNotNull);
+    });
+
+    testWidgets('send button is disabled for closed conversation', (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv(status: ConversationStatus.closed);
+      await _pumpScreen(tester, repository: repo);
+
+      final sendButton = tester.widget<IconButton>(
+        find.byKey(const Key('thread-send-button')),
+      );
+      expect(sendButton.onPressed, isNull);
+    });
+
+    testWidgets('closed conversation shows closed label', (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv(status: ConversationStatus.closed);
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.byKey(const Key('thread-closed-label')), findsOneWidget);
+    });
+
+    testWidgets('tapping send button calls notifier.send', (tester) async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      await _pumpScreen(tester, repository: repo);
+
+      await tester.enterText(find.byKey(const Key('thread-input-field')), 'test message');
+      await tester.tap(find.byKey(const Key('thread-send-button')));
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.byKey(const Key('thread-cancel-button')), findsOneWidget);
+    });
+
+    testWidgets('input field is cleared after send', (tester) async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      await _pumpScreen(tester, repository: repo);
+
+      await tester.enterText(find.byKey(const Key('thread-input-field')), 'hello');
+      await tester.tap(find.byKey(const Key('thread-send-button')));
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byKey(const Key('thread-input-field')));
+      expect(field.controller?.text, isEmpty);
+    });
+
+    testWidgets('shows pending user message during streaming', (tester) async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      await _pumpScreen(tester, repository: repo);
+
+      await tester.enterText(find.byKey(const Key('thread-input-field')), 'pending msg');
+      await tester.tap(find.byKey(const Key('thread-send-button')));
+      await tester.pump();
+
+      expect(find.byKey(const Key('thread-pending-message')), findsOneWidget);
+      expect(find.text('pending msg'), findsOneWidget);
+    });
+
+    testWidgets('shows typing indicator during streaming', (tester) async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      await _pumpScreen(tester, repository: repo);
+
+      await tester.enterText(find.byKey(const Key('thread-input-field')), 'hello');
+      await tester.tap(find.byKey(const Key('thread-send-button')));
+      await tester.pump();
+
+      expect(find.byKey(const Key('thread-typing-indicator')), findsOneWidget);
+    });
+
+    testWidgets('settings icon navigates to settings', (tester) async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      await _pumpScreen(tester, repository: repo);
+
+      await tester.tap(find.byKey(const Key('thread-settings-icon')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Settings'), findsOneWidget);
+    });
+
+    testWidgets('model picker button opens bottom sheet', (tester) async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      await _pumpScreen(tester, repository: repo);
+
+      await tester.tap(find.byKey(const Key('thread-model-picker')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Backend'), findsOneWidget);
+      expect(find.byKey(const Key('backend-option-b1')), findsOneWidget);
+    });
+
+    testWidgets('new conversation shows New Chat title', (tester) async {
+      final repo = _StubRepository();
+      await _pumpScreen(tester, repository: repo, conversationId: 'new');
+
+      expect(find.text('New Chat'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Full `ThreadNotifier` SSE flow: `send()`, `cancelStream()`, `selectModel()`, `selectBackend()`, `toggleEndorse()`
- New-conversation mode (`conversationId == 'new'`): generates UUID sessionId, fetches models+backends, emits `ThreadEmpty`
- Existing-conversation mode: fetches conversation/events/records/models/backends in parallel
- `_streamErrorMessage()` private helper maps `ApiResult` subtypes to human-readable strings
- Full `ThreadScreen`: message bubbles (user=right/blue, agent=left/grey), pending user bubble during streaming, typing indicator with tool name, record badges with star endorsement, `RadioGroup`-based backend picker bottom sheet, model dropdown, input bar with cancel button (streaming) or send button
- Replaces stub `threadNotifierProvider` with real `StateNotifierProvider.family`

## Test plan

- [ ] `flutter test test/features/chat/` — 99 tests pass
- [ ] `flutter analyze` — 0 new issues
- [ ] New conversation: tap `+`, type message, verify streaming indicator + pending bubble, verify reply appears
- [ ] Existing conversation: tap conversation from list, verify events render, verify endorsement toggle
- [ ] Backend picker: tap picker button, verify backend options, select one, verify state updates

Closes #215

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
