### PR TITLE
fix(chat): align selectModel/Backend with proposal — no-op in ThreadError

### DIFF
--- a/lib/features/chat/presentation/thread_notifier.dart
+++ b/lib/features/chat/presentation/thread_notifier.dart
@@ -316,8 +316,10 @@ class ThreadNotifier extends StateNotifier<ThreadState> {
           pendingUserMessage: current.pendingUserMessage,
           toolProgress: current.toolProgress,
         );
-      case ThreadLoading() || ThreadError():
+      case ThreadLoading():
         _pendingModel = model;
+      case ThreadError():
+        break;
     }
   }
 
@@ -354,8 +356,10 @@ class ThreadNotifier extends StateNotifier<ThreadState> {
           pendingUserMessage: current.pendingUserMessage,
           toolProgress: current.toolProgress,
         );
-      case ThreadLoading() || ThreadError():
+      case ThreadLoading():
         _pendingBackend = backend;
+      case ThreadError():
+        break;
     }
   }
 

--- a/test/features/chat/presentation/thread_notifier_test.dart
+++ b/test/features/chat/presentation/thread_notifier_test.dart
@@ -563,5 +563,34 @@ void main() {
       final empty = notifier.state as ThreadEmpty;
       expect(empty.selectedBackend, 'backend-b');
     });
+
+    test('selectModel updates streaming state', () async {
+      final repo = _StubRepository()..conversationResult = _conv();
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      await notifier.send('hello');
+      expect(notifier.state, isA<ThreadStreaming>());
+
+      notifier.selectModel('model-streaming');
+
+      final streaming = notifier.state as ThreadStreaming;
+      expect(streaming.selectedModel, 'model-streaming');
+    });
+
+    test('selectModel during error state is a no-op', () async {
+      final repo = _StubRepository()..conversationResult = null;
+      final notifier =
+          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+
+      expect(notifier.state, isA<ThreadError>());
+      notifier.selectModel('model-ignored');
+
+      expect(notifier.state, isA<ThreadError>());
+    });
   });
 }


### PR DESCRIPTION
Fixes two issues found in post-implementation review:

- **P1 fix**: `selectModel()`/`selectBackend()` now no-op in `ThreadError` state per proposal spec (only `ThreadLoading` stores pending). Previously both stored pending in error state, which is undocumented behavior.
- **P2 fix**: Add `selectModel` in streaming state test and `selectModel` in error state no-op test (101 total).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)