### PR TITLE
test(chat): add ConversationsScreen '+' button navigation test

### DIFF
--- a/test/features/chat/presentation/conversations_screen_test.dart
+++ b/test/features/chat/presentation/conversations_screen_test.dart
@@ -157,6 +157,15 @@ void main() {
       );
     });
 
+    testWidgets('add icon navigates to /chat/new', (tester) async {
+      await _pumpScreen(tester);
+
+      await tester.tap(find.byKey(const Key('conversations-new-icon')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Thread new'), findsOneWidget);
+    });
+
     testWidgets('shows empty state when no conversations', (tester) async {
       await _pumpScreen(tester);
 


### PR DESCRIPTION
Adds the missing test that taps the '+' icon and asserts navigation to `/chat/new`. Required by proposal spec (T2 test list). Found in post-implementation review.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)