### PR TITLE
fix(app): stop hands-free listening on tab switch

### DIFF
--- a/lib/app/app_shell_scaffold.dart
+++ b/lib/app/app_shell_scaffold.dart
@@ -23,6 +23,9 @@ class AppShellScaffold extends ConsumerStatefulWidget {
 
 class _AppShellScaffoldState extends ConsumerState<AppShellScaffold>
     with WidgetsBindingObserver {
+  // Matches Branch 2 in router.dart's StatefulShellRoute.
+  static const _recordTabIndex = 2;
+
   @override
   void initState() {
     super.initState();
@@ -68,13 +71,24 @@ class _AppShellScaffoldState extends ConsumerState<AppShellScaffold>
       bottomNavigationBar: NavigationBar(
         selectedIndex: widget.navigationShell.currentIndex,
         onDestinationSelected: (index) {
-          const recordTabIndex = 2;
           final currentIndex = widget.navigationShell.currentIndex;
-          if (currentIndex == recordTabIndex && index != recordTabIndex) {
+          if (currentIndex == _recordTabIndex && index != _recordTabIndex) {
+            final hfCtrl = ref.read(handsFreeControllerProvider.notifier);
             unawaited(
-              ref.read(handsFreeControllerProvider.notifier).stopSession(),
+              hfCtrl.stopSession().then((_) {
+                // If the user returned to the Record tab while the session was
+                // draining, startSession() called during the tab switch was
+                // blocked by the guard (state wasn't idle yet). Restart now.
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (mounted &&
+                      widget.navigationShell.currentIndex == _recordTabIndex) {
+                    unawaited(hfCtrl.startSession());
+                  }
+                });
+              }),
             );
-          } else if (index == recordTabIndex && currentIndex != recordTabIndex) {
+          } else if (index == _recordTabIndex &&
+              currentIndex != _recordTabIndex) {
             unawaited(
               ref.read(handsFreeControllerProvider.notifier).startSession(),
             );

--- a/lib/app/app_shell_scaffold.dart
+++ b/lib/app/app_shell_scaffold.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -66,9 +68,20 @@ class _AppShellScaffoldState extends ConsumerState<AppShellScaffold>
       bottomNavigationBar: NavigationBar(
         selectedIndex: widget.navigationShell.currentIndex,
         onDestinationSelected: (index) {
+          const recordTabIndex = 2;
+          final currentIndex = widget.navigationShell.currentIndex;
+          if (currentIndex == recordTabIndex && index != recordTabIndex) {
+            unawaited(
+              ref.read(handsFreeControllerProvider.notifier).stopSession(),
+            );
+          } else if (index == recordTabIndex && currentIndex != recordTabIndex) {
+            unawaited(
+              ref.read(handsFreeControllerProvider.notifier).startSession(),
+            );
+          }
           widget.navigationShell.goBranch(
             index,
-            initialLocation: index == widget.navigationShell.currentIndex,
+            initialLocation: index == currentIndex,
           );
         },
         destinations: const [

--- a/test/app/app_shell_scaffold_test.dart
+++ b/test/app/app_shell_scaffold_test.dart
@@ -1,0 +1,254 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/app/app.dart';
+import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
+import 'package:voice_agent/core/audio/audio_feedback_service.dart';
+import 'package:voice_agent/core/background/background_service_provider.dart';
+import 'package:voice_agent/core/config/app_config.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/config/app_config_service.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
+import 'package:voice_agent/core/models/agenda.dart';
+import 'package:voice_agent/core/models/routine.dart';
+import 'package:voice_agent/core/models/sync_queue_item.dart';
+import 'package:voice_agent/core/models/transcript.dart';
+import 'package:voice_agent/core/models/transcript_with_status.dart';
+import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/storage/storage_provider.dart';
+import 'package:voice_agent/features/api_sync/sync_provider.dart';
+import 'package:voice_agent/core/storage/storage_service.dart';
+import 'package:voice_agent/core/tts/tts_provider.dart';
+import 'package:voice_agent/core/tts/tts_service.dart';
+import 'package:voice_agent/features/activation/presentation/activation_provider.dart';
+import 'package:voice_agent/features/agenda/domain/agenda_repository.dart';
+import 'package:voice_agent/features/agenda/presentation/agenda_providers.dart';
+import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
+import 'package:voice_agent/features/recording/domain/hands_free_session_state.dart';
+import 'package:voice_agent/features/recording/presentation/hands_free_controller.dart';
+import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+
+import '../helpers/in_memory_bridge_store.dart';
+import '../helpers/stub_background_service.dart';
+
+// ── Stub dependencies ─────────────────────────────────────────────────────────
+
+class _StubStorage implements StorageService {
+  @override Future<String> getDeviceId() async => 'test';
+  @override Future<List<TranscriptWithStatus>> getTranscriptsWithStatus({int limit = 20, int offset = 0}) async => [];
+  @override Future<void> saveTranscript(Transcript t) async {}
+  @override Future<Transcript?> getTranscript(String id) async => null;
+  @override Future<List<Transcript>> getTranscripts({int limit = 50, int offset = 0}) async => [];
+  @override Future<void> deleteTranscript(String id) async {}
+  @override Future<void> enqueue(String transcriptId) async {}
+  @override Future<List<SyncQueueItem>> getPendingItems() async => [];
+  @override Future<void> markSending(String id) async {}
+  @override Future<void> markSent(String id) async {}
+  @override Future<void> markFailed(String id, String error, {int? overrideAttempts}) async {}
+  @override Future<void> markPendingForRetry(String id) async {}
+  @override Future<void> reactivateForResend(String transcriptId) async {}
+  @override Future<int> recoverStaleSending() async => 0;
+  @override Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
+}
+
+class _NoOpConnectivity extends ConnectivityService {
+  @override
+  Stream<ConnectivityStatus> get statusStream => const Stream.empty();
+}
+
+class _IdleHfEngine implements HandsFreeEngine {
+  final _ctrl = StreamController<HandsFreeEngineEvent>.broadcast();
+  @override Future<bool> hasPermission() async => true;
+  @override Stream<HandsFreeEngineEvent> start({required VadConfig config}) => _ctrl.stream;
+  @override Future<void> stop() async {}
+  @override Future<void> interruptCapture() async {}
+  @override void dispose() => _ctrl.close();
+}
+
+class _FixedConfigService extends AppConfigService {
+  _FixedConfigService(this._config);
+  final AppConfig _config;
+  @override
+  Future<AppConfig> load() async => _config;
+}
+
+class _StubTtsService implements TtsService {
+  @override ValueListenable<bool> get isSpeaking => ValueNotifier(false);
+  @override Future<void> speak(String text, {String? languageCode}) async {}
+  @override Future<void> stop() async {}
+  @override void dispose() {}
+}
+
+class _StubAudioFeedback implements AudioFeedbackService {
+  @override Future<void> startProcessingFeedback() async {}
+  @override Future<void> stopLoop() async {}
+  @override Future<void> playSuccess() async {}
+  @override Future<void> playError() async {}
+  @override Future<void> playWakeWordAcknowledgment() async {}
+  @override void dispose() {}
+}
+
+class _StubAgendaRepository implements AgendaRepository {
+  @override
+  Future<AgendaResponse> fetchAgenda(String date) async => AgendaResponse(
+        date: date, granularity: 'day', from: date, to: date, items: [], routineItems: []);
+  @override Future<CachedAgenda?> getCachedAgenda(String date) async => null;
+  @override Future<void> cacheAgenda(String date, AgendaResponse response) async {}
+  @override Future<void> markActionItemDone(String recordId) async {}
+  @override Future<void> updateOccurrenceStatus(
+    String routineId, String occurrenceId, OccurrenceStatus status) async {}
+}
+
+List<Override> get _baseOverrides => [
+  storageServiceProvider.overrideWithValue(_StubStorage()),
+  connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
+  handsFreeEngineProvider.overrideWithValue(_IdleHfEngine()),
+  appConfigServiceProvider.overrideWithValue(
+    _FixedConfigService(const AppConfig(groqApiKey: 'test-key')),
+  ),
+  ttsServiceProvider.overrideWithValue(_StubTtsService()),
+  audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedback()),
+  bridgeStoreProvider.overrideWithValue(InMemoryBridgeStore()),
+  backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+  agendaRepositoryProvider.overrideWithValue(_StubAgendaRepository()),
+];
+
+// ── Tracking HandsFreeController stubs ───────────────────────────────────────
+
+/// Tracks startSession/stopSession calls without doing real work.
+/// Mirrors the real controller's idle-guard so tests reflect actual behavior.
+class _TrackingHfController extends HandsFreeController {
+  _TrackingHfController(super.ref);
+
+  int startCalls = 0;
+  int stopCalls = 0;
+
+  @override
+  Future<void> startSession({bool triggeredByActivation = false}) async {
+    if (state is! HandsFreeIdle && state is! HandsFreeSessionError) return;
+    startCalls++;
+    state = HandsFreeListening([]);
+  }
+
+  @override
+  Future<void> stopSession() async {
+    if (state is HandsFreeIdle) return;
+    stopCalls++;
+    state = const HandsFreeIdle();
+  }
+}
+
+/// Variant with a controllable drain delay for race-condition tests.
+class _SlowStopHfController extends _TrackingHfController {
+  _SlowStopHfController(super.ref, this._drainCompleter);
+
+  final Completer<void> _drainCompleter;
+
+  @override
+  Future<void> stopSession() async {
+    if (state is HandsFreeIdle) return;
+    stopCalls++;
+    await _drainCompleter.future;
+    state = const HandsFreeIdle();
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  // Finder for the Record icon inside the NavigationBar (avoids ambiguity with
+  // the mic icon on the RecordingScreen itself).
+  final recordNavIcon = find.descendant(
+    of: find.byType(NavigationBar),
+    matching: find.byIcon(Icons.mic),
+  );
+
+  testWidgets('switching away from Record tab calls stopSession', (tester) async {
+    late _TrackingHfController controller;
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        ..._baseOverrides,
+        handsFreeControllerProvider.overrideWith((ref) {
+          controller = _TrackingHfController(ref);
+          return controller;
+        }),
+      ],
+      child: const App(),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(controller.startCalls, 1); // RecordingScreen.initState
+
+    await tester.tap(find.byIcon(Icons.calendar_today));
+    await tester.pumpAndSettle();
+
+    expect(controller.stopCalls, 1);
+  });
+
+  testWidgets('switching back to Record tab calls startSession', (tester) async {
+    late _TrackingHfController controller;
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        ..._baseOverrides,
+        handsFreeControllerProvider.overrideWith((ref) {
+          controller = _TrackingHfController(ref);
+          return controller;
+        }),
+      ],
+      child: const App(),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.calendar_today));
+    await tester.pumpAndSettle(); // stopSession called, state → idle
+
+    await tester.tap(recordNavIcon);
+    await tester.pumpAndSettle();
+
+    expect(controller.startCalls, 2); // 1 from initState + 1 from tab return
+  });
+
+  testWidgets('session recovers when user returns to Record during stopSession drain',
+      (tester) async {
+    final drainCompleter = Completer<void>();
+    late _SlowStopHfController controller;
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        ..._baseOverrides,
+        handsFreeControllerProvider.overrideWith((ref) {
+          controller = _SlowStopHfController(ref, drainCompleter);
+          return controller;
+        }),
+      ],
+      child: const App(),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(controller.startCalls, 1);
+
+    // Navigate away — stopSession starts but won't finish until drainCompleter fires.
+    await tester.tap(find.byIcon(Icons.calendar_today));
+    await tester.pumpAndSettle();
+
+    expect(controller.stopCalls, 1);
+    expect(controller.startCalls, 1); // unchanged
+
+    // Navigate back — startSession is called but the guard blocks it (not idle yet).
+    await tester.tap(recordNavIcon);
+    await tester.pumpAndSettle();
+
+    expect(controller.startCalls, 1); // still blocked
+
+    // Complete the drain — the .then() callback registers addPostFrameCallback.
+    drainCompleter.complete();
+    await tester.pumpAndSettle(); // frame fires → currentIndex == 2 → startSession
+
+    expect(controller.startCalls, 2); // recovery call
+  });
+}

--- a/test/core/tts/flutter_tts_service_test.dart
+++ b/test/core/tts/flutter_tts_service_test.dart
@@ -102,7 +102,7 @@ void main() {
 
   group('FlutterTtsService voice selection (iOS)', () {
     // Helper: build a service with isIOS=true so _bestVoice() is exercised.
-    FlutterTtsService _svc(_MockFlutterTts mock) =>
+    FlutterTtsService makeSvc(_MockFlutterTts mock) =>
         FlutterTtsService(tts: mock, isIOS: true);
 
     test('picks premium voice over enhanced and normal', () async {
@@ -112,7 +112,7 @@ void main() {
           {'name': 'com.apple.voice.enhanced.pl-PL.Ewa', 'locale': 'pl-PL'},
           {'name': 'com.apple.voice.premium.pl-PL.Zosia', 'locale': 'pl-PL'},
         ];
-      final svc = _svc(mock);
+      final svc = makeSvc(mock);
 
       await svc.speak('Cześć', languageCode: 'pl');
 
@@ -127,7 +127,7 @@ void main() {
           {'name': 'com.apple.voice.normal.pl-PL.Ewa', 'locale': 'pl-PL'},
           {'name': 'com.apple.voice.enhanced.pl-PL.Zosia', 'locale': 'pl-PL'},
         ];
-      final svc = _svc(mock);
+      final svc = makeSvc(mock);
 
       await svc.speak('Cześć', languageCode: 'pl');
 
@@ -139,7 +139,7 @@ void main() {
         ..voiceList = [
           {'name': 'com.apple.ttsbundle.pl-PL-Zosia', 'locale': 'pl-PL'},
         ];
-      final svc = _svc(mock);
+      final svc = makeSvc(mock);
 
       await svc.speak('Cześć', languageCode: 'pl');
 
@@ -152,7 +152,7 @@ void main() {
         ..voiceList = [
           {'name': 'com.apple.voice.premium.en-US.Zoe', 'locale': 'en-US'},
         ];
-      final svc = _svc(mock);
+      final svc = makeSvc(mock);
 
       await svc.speak('Cześć', languageCode: 'pl');
 
@@ -161,7 +161,7 @@ void main() {
 
     test('does not call setVoice when voice list is empty', () async {
       final mock = _MockFlutterTts()..voiceList = [];
-      final svc = _svc(mock);
+      final svc = makeSvc(mock);
 
       await svc.speak('Hello', languageCode: 'en');
 
@@ -175,7 +175,7 @@ void main() {
         ];
       // Wrap getVoices call tracking via voiceList side-effect isn't possible,
       // so we verify via a second speak() not throwing and setVoice being called twice.
-      final svc = _svc(mock);
+      final svc = makeSvc(mock);
 
       await svc.speak('First', languageCode: 'en');
       // Clear setVoiceCalls to distinguish second call.
@@ -194,7 +194,7 @@ void main() {
     test('falls back silently when getVoices throws', () async {
       final mock = _MockFlutterTts()
         ..getVoicesError = Exception('platform error');
-      final svc = _svc(mock);
+      final svc = makeSvc(mock);
 
       // Should not throw — speak() completes normally without setVoice.
       await expectLater(
@@ -210,7 +210,7 @@ void main() {
         ..voiceList = [
           {'name': 'com.apple.voice.premium.pl-PL.Zosia', 'locale': 'pl-PL'},
         ];
-      final svc = _svc(mock);
+      final svc = makeSvc(mock);
 
       // "pl_PL" (underscore) should still match "pl-PL" locale.
       await svc.speak('Cześć', languageCode: 'pl_PL');


### PR DESCRIPTION
Stop hands-free listening when user switches away from the Record tab, and resume it when they return.

- `AppShellScaffold.onDestinationSelected` calls `stopSession()` when leaving tab index 2 (Record)
- Calls `startSession()` when returning to tab index 2
- Both methods are idempotent (guarded), so the initial `startSession()` in `RecordingScreen.initState` is unaffected
- Also fixes a pre-existing lint warning in `flutter_tts_service_test.dart`