### PR TITLE
feat(p026-t4): remove wake-word AppConfig fields + add removal migration

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -15,11 +15,6 @@ class AppConfig {
     this.vadConfig = const VadConfig.defaults(),
     this.ttsEnabled = true,
     this.audioFeedbackEnabled = true,
-    this.backgroundListeningEnabled = false,
-    this.wakeWordEnabled = false,
-    this.picovoiceAccessKey,
-    this.wakeWordKeyword = 'jarvis',
-    this.wakeWordSensitivity = 0.5,
   });
 
   final String? apiUrl;
@@ -31,11 +26,6 @@ class AppConfig {
   final VadConfig vadConfig;
   final bool ttsEnabled;
   final bool audioFeedbackEnabled;
-  final bool backgroundListeningEnabled;
-  final bool wakeWordEnabled;
-  final String? picovoiceAccessKey;
-  final String wakeWordKeyword;
-  final double wakeWordSensitivity;
 
   AppConfig copyWith({
     Object? apiUrl = _sentinel,
@@ -47,11 +37,6 @@ class AppConfig {
     VadConfig? vadConfig,
     bool? ttsEnabled,
     bool? audioFeedbackEnabled,
-    bool? backgroundListeningEnabled,
-    bool? wakeWordEnabled,
-    Object? picovoiceAccessKey = _sentinel,
-    String? wakeWordKeyword,
-    double? wakeWordSensitivity,
   }) {
     return AppConfig(
       apiUrl: apiUrl == _sentinel ? this.apiUrl : apiUrl as String?,
@@ -64,14 +49,6 @@ class AppConfig {
       vadConfig: vadConfig ?? this.vadConfig,
       ttsEnabled: ttsEnabled ?? this.ttsEnabled,
       audioFeedbackEnabled: audioFeedbackEnabled ?? this.audioFeedbackEnabled,
-      backgroundListeningEnabled:
-          backgroundListeningEnabled ?? this.backgroundListeningEnabled,
-      wakeWordEnabled: wakeWordEnabled ?? this.wakeWordEnabled,
-      picovoiceAccessKey: picovoiceAccessKey == _sentinel
-          ? this.picovoiceAccessKey
-          : picovoiceAccessKey as String?,
-      wakeWordKeyword: wakeWordKeyword ?? this.wakeWordKeyword,
-      wakeWordSensitivity: wakeWordSensitivity ?? this.wakeWordSensitivity,
     );
   }
 }

--- a/lib/core/config/app_config_provider.dart
+++ b/lib/core/config/app_config_provider.dart
@@ -78,29 +78,4 @@ class AppConfigNotifier extends StateNotifier<AppConfig> {
     await _service.saveAudioFeedbackEnabled(value);
     state = state.copyWith(audioFeedbackEnabled: value);
   }
-
-  Future<void> updateBackgroundListeningEnabled(bool value) async {
-    await _service.saveBackgroundListeningEnabled(value);
-    state = state.copyWith(backgroundListeningEnabled: value);
-  }
-
-  Future<void> updateWakeWordEnabled(bool value) async {
-    await _service.saveWakeWordEnabled(value);
-    state = state.copyWith(wakeWordEnabled: value);
-  }
-
-  Future<void> updatePicovoiceAccessKey(String key) async {
-    await _service.savePicovoiceAccessKey(key);
-    state = state.copyWith(picovoiceAccessKey: key);
-  }
-
-  Future<void> updateWakeWordKeyword(String keyword) async {
-    await _service.saveWakeWordKeyword(keyword);
-    state = state.copyWith(wakeWordKeyword: keyword);
-  }
-
-  Future<void> updateWakeWordSensitivity(double value) async {
-    await _service.saveWakeWordSensitivity(value);
-    state = state.copyWith(wakeWordSensitivity: value);
-  }
 }

--- a/lib/core/config/app_config_service.dart
+++ b/lib/core/config/app_config_service.dart
@@ -26,17 +26,32 @@ class AppConfigService {
   static const _ttsEnabledKey = 'tts_enabled';
   static const _audioFeedbackEnabledKey = 'audio_feedback_enabled';
 
-  static const _backgroundListeningEnabledKey = 'background_listening_enabled';
-  static const _wakeWordEnabledKey = 'wake_word_enabled';
-  static const _picovoiceAccessKeyKey = 'picovoice_access_key';
-  static const _wakeWordKeywordKey = 'wake_word_keyword';
-  static const _wakeWordSensitivityKey = 'wake_word_sensitivity';
-
   static const _vadPositiveThresholdKey = 'vad_positive_threshold';
   static const _vadNegativeThresholdKey = 'vad_negative_threshold';
   static const _vadHangoverMsKey = 'vad_hangover_ms';
   static const _vadMinSpeechMsKey = 'vad_min_speech_ms';
   static const _vadPreRollMsKey = 'vad_pre_roll_ms';
+
+  // ── P026 removal migration ──────────────────────────────────────────────
+  // Keys retired by P026 (wake word feature + Porcupine). Cleaned up on first
+  // launch of the new version, gated by [_wakeWordRemovalMigrationDoneKey].
+  // See ADR-DATA-009.
+  static const _wakeWordRemovalMigrationDoneKey =
+      'wake_word_removal_migration_done';
+  static const _retiredPrefsKeys = <String>[
+    'background_listening_enabled',
+    'wake_word_enabled',
+    'wake_word_keyword',
+    'wake_word_sensitivity',
+    // Legacy IPC keys from the deleted PlatformChannelBridge.
+    'activation_state',
+    'activation_toggle_requested',
+    'activation_stop_requested',
+    'foreground_service_running',
+  ];
+  static const _retiredSecureStorageKeys = <String>[
+    'picovoice_access_key',
+  ];
 
   Future<SharedPreferences> get _preferences async {
     _prefs ??= await SharedPreferences.getInstance();
@@ -45,6 +60,11 @@ class AppConfigService {
 
   Future<AppConfig> load() async {
     final prefs = await _preferences;
+
+    // Run the P026 removal migration before constructing the config so that
+    // consumers never observe the deleted fields in transient states.
+    await _runRemovalMigration(prefs);
+
     String? token;
     try {
       token = await _secureStorage.read(key: _apiTokenKey);
@@ -54,13 +74,6 @@ class AppConfigService {
     String? groqApiKey;
     try {
       groqApiKey = await _secureStorage.read(key: _groqApiKeyKey);
-    } catch (_) {
-      // Secure storage may fail on some devices — treat as absent
-    }
-    String? picovoiceAccessKey;
-    try {
-      picovoiceAccessKey =
-          await _secureStorage.read(key: _picovoiceAccessKeyKey);
     } catch (_) {
       // Secure storage may fail on some devices — treat as absent
     }
@@ -88,14 +101,22 @@ class AppConfigService {
       vadConfig: vadConfig,
       ttsEnabled: prefs.getBool(_ttsEnabledKey) ?? true,
       audioFeedbackEnabled: prefs.getBool(_audioFeedbackEnabledKey) ?? true,
-      backgroundListeningEnabled:
-          prefs.getBool(_backgroundListeningEnabledKey) ?? false,
-      wakeWordEnabled: prefs.getBool(_wakeWordEnabledKey) ?? false,
-      picovoiceAccessKey: picovoiceAccessKey,
-      wakeWordKeyword: prefs.getString(_wakeWordKeywordKey) ?? 'jarvis',
-      wakeWordSensitivity:
-          prefs.getDouble(_wakeWordSensitivityKey) ?? 0.5,
     );
+  }
+
+  Future<void> _runRemovalMigration(SharedPreferences prefs) async {
+    if (prefs.getBool(_wakeWordRemovalMigrationDoneKey) == true) return;
+    for (final key in _retiredPrefsKeys) {
+      await prefs.remove(key);
+    }
+    for (final key in _retiredSecureStorageKeys) {
+      try {
+        await _secureStorage.delete(key: key);
+      } catch (_) {
+        // Best-effort — log-only; do not block migration on Keychain failure.
+      }
+    }
+    await prefs.setBool(_wakeWordRemovalMigrationDoneKey, true);
   }
 
   Future<void> saveVadConfig(VadConfig config) async {
@@ -145,29 +166,5 @@ class AppConfigService {
   Future<void> saveAudioFeedbackEnabled(bool value) async {
     final prefs = await _preferences;
     await prefs.setBool(_audioFeedbackEnabledKey, value);
-  }
-
-  Future<void> saveBackgroundListeningEnabled(bool value) async {
-    final prefs = await _preferences;
-    await prefs.setBool(_backgroundListeningEnabledKey, value);
-  }
-
-  Future<void> saveWakeWordEnabled(bool value) async {
-    final prefs = await _preferences;
-    await prefs.setBool(_wakeWordEnabledKey, value);
-  }
-
-  Future<void> savePicovoiceAccessKey(String key) async {
-    await _secureStorage.write(key: _picovoiceAccessKeyKey, value: key);
-  }
-
-  Future<void> saveWakeWordKeyword(String keyword) async {
-    final prefs = await _preferences;
-    await prefs.setString(_wakeWordKeywordKey, keyword);
-  }
-
-  Future<void> saveWakeWordSensitivity(double value) async {
-    final prefs = await _preferences;
-    await prefs.setDouble(_wakeWordSensitivityKey, value);
   }
 }

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,10 +1,8 @@
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:voice_agent/core/config/app_config.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/network/api_client.dart';
@@ -22,7 +20,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   late final TextEditingController _urlController;
   late final TextEditingController _tokenController;
   late final TextEditingController _groqKeyController;
-  late final TextEditingController _picovoiceKeyController;
   String? _urlError;
   _TestStatus _testStatus = _TestStatus.idle;
   ProviderSubscription<AppConfig>? _configSubscription;
@@ -34,8 +31,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     _urlController = TextEditingController(text: config.apiUrl ?? '');
     _tokenController = TextEditingController(text: config.apiToken ?? '');
     _groqKeyController = TextEditingController(text: config.groqApiKey ?? '');
-    _picovoiceKeyController =
-        TextEditingController(text: config.picovoiceAccessKey ?? '');
     // listenManual is the correct API for initState — keeps controllers in sync
     // when appConfigProvider emits the loaded value after async secure-storage read.
     _configSubscription = ref.listenManual(appConfigProvider, (_, next) {
@@ -48,9 +43,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       if (_groqKeyController.text.isEmpty) {
         _groqKeyController.text = next.groqApiKey ?? '';
       }
-      if (_picovoiceKeyController.text.isEmpty) {
-        _picovoiceKeyController.text = next.picovoiceAccessKey ?? '';
-      }
     });
   }
 
@@ -60,7 +52,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     _urlController.dispose();
     _tokenController.dispose();
     _groqKeyController.dispose();
-    _picovoiceKeyController.dispose();
     super.dispose();
   }
 
@@ -91,50 +82,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   void _onGroqKeyFocusLost() {
     final key = _groqKeyController.text;
     ref.read(appConfigProvider.notifier).updateGroqApiKey(key);
-  }
-
-  void _onPicovoiceKeyFocusLost() {
-    final key = _picovoiceKeyController.text;
-    ref.read(appConfigProvider.notifier).updatePicovoiceAccessKey(key);
-  }
-
-  Future<void> _onWakeWordChanged(bool value) async {
-    if (value) {
-      // Verify microphone permission before enabling wake word.
-      final status = await Permission.microphone.request();
-      if (status.isDenied || status.isPermanentlyDenied) {
-        if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: const Text('Microphone permission required for wake word'),
-            action: status.isPermanentlyDenied
-                ? SnackBarAction(
-                    label: 'Settings',
-                    onPressed: openAppSettings,
-                  )
-                : null,
-          ),
-        );
-        return;
-      }
-    }
-    ref.read(appConfigProvider.notifier).updateWakeWordEnabled(value);
-  }
-
-  Future<void> _onBackgroundListeningChanged(bool value) async {
-    if (value && Platform.isAndroid) {
-      final status = await Permission.notification.request();
-      if (status.isDenied || status.isPermanentlyDenied) {
-        if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-              content: Text('Notification permission required for '
-                  'background listening')),
-        );
-        return;
-      }
-    }
-    ref.read(appConfigProvider.notifier).updateBackgroundListeningEnabled(value);
   }
 
   Future<void> _testConnection() async {
@@ -325,107 +272,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             subtitle: const Text('Speech detection tuning'),
             trailing: const Icon(Icons.chevron_right),
             onTap: () => context.push('/settings/advanced'),
-          ),
-          _buildSectionHeader('Background Activation'),
-          SwitchListTile(
-            key: const Key('background-listening-tile'),
-            title: const Text('Background listening'),
-            subtitle: const Text('Keep listening when app is in background'),
-            value: config.backgroundListeningEnabled,
-            onChanged: _onBackgroundListeningChanged,
-          ),
-          SwitchListTile(
-            key: const Key('wake-word-tile'),
-            title: const Text('Wake word detection'),
-            subtitle: const Text('Activate recording with a spoken keyword'),
-            value: config.wakeWordEnabled,
-            onChanged: config.backgroundListeningEnabled
-                ? _onWakeWordChanged
-                : null,
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Focus(
-              onFocusChange: (hasFocus) {
-                if (!hasFocus) _onPicovoiceKeyFocusLost();
-              },
-              child: TextField(
-                key: const Key('picovoice-key-field'),
-                controller: _picovoiceKeyController,
-                decoration: const InputDecoration(
-                  labelText: 'Picovoice Access Key',
-                  hintText: 'Paste your Picovoice Console access key',
-                  border: OutlineInputBorder(),
-                ),
-                obscureText: true,
-              ),
-            ),
-          ),
-          ListTile(
-            title: const Text('Wake word keyword'),
-            trailing: DropdownButton<String>(
-              key: const Key('wake-word-keyword-dropdown'),
-              value: config.wakeWordKeyword,
-              onChanged: config.backgroundListeningEnabled &&
-                      config.wakeWordEnabled
-                  ? (v) {
-                      if (v != null) {
-                        ref
-                            .read(appConfigProvider.notifier)
-                            .updateWakeWordKeyword(v);
-                      }
-                    }
-                  : null,
-              items: const [
-                DropdownMenuItem(value: 'jarvis', child: Text('Jarvis')),
-                DropdownMenuItem(value: 'computer', child: Text('Computer')),
-                DropdownMenuItem(value: 'alexa', child: Text('Alexa')),
-                DropdownMenuItem(value: 'americano', child: Text('Americano')),
-                DropdownMenuItem(value: 'blueberry', child: Text('Blueberry')),
-                DropdownMenuItem(value: 'bumblebee', child: Text('Bumblebee')),
-                DropdownMenuItem(
-                    value: 'grapefruit', child: Text('Grapefruit')),
-                DropdownMenuItem(
-                    value: 'grasshopper', child: Text('Grasshopper')),
-                DropdownMenuItem(value: 'picovoice', child: Text('Picovoice')),
-                DropdownMenuItem(value: 'porcupine', child: Text('Porcupine')),
-                DropdownMenuItem(
-                    value: 'terminator', child: Text('Terminator')),
-              ],
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Row(
-              children: [
-                const Text('Sensitivity'),
-                Expanded(
-                  child: Slider(
-                    key: const Key('wake-word-sensitivity-slider'),
-                    value: config.wakeWordSensitivity,
-                    min: 0.0,
-                    max: 1.0,
-                    divisions: 10,
-                    label: config.wakeWordSensitivity.toStringAsFixed(1),
-                    onChanged: config.backgroundListeningEnabled &&
-                            config.wakeWordEnabled
-                        ? (v) {
-                            ref
-                                .read(appConfigProvider.notifier)
-                                .updateWakeWordSensitivity(v);
-                          }
-                        : null,
-                  ),
-                ),
-                SizedBox(
-                  width: 32,
-                  child: Text(
-                    config.wakeWordSensitivity.toStringAsFixed(1),
-                    textAlign: TextAlign.center,
-                  ),
-                ),
-              ],
-            ),
           ),
           _buildSectionHeader('About'),
           ListTile(

--- a/test/core/config/app_config_service_test.dart
+++ b/test/core/config/app_config_service_test.dart
@@ -1,49 +1,10 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:voice_agent/core/config/app_config.dart';
 import 'package:voice_agent/core/config/app_config_service.dart';
 import 'package:voice_agent/core/config/vad_config.dart';
 
 void main() {
-  group('AppConfig.copyWith', () {
-    test('picovoiceAccessKey sentinel allows setting to null', () {
-      const config = AppConfig(picovoiceAccessKey: 'key');
-      final updated = config.copyWith(picovoiceAccessKey: null);
-      expect(updated.picovoiceAccessKey, isNull);
-    });
-
-    test('picovoiceAccessKey omitted preserves value', () {
-      const config = AppConfig(picovoiceAccessKey: 'key');
-      final updated = config.copyWith(backgroundListeningEnabled: true);
-      expect(updated.picovoiceAccessKey, 'key');
-    });
-
-    test('new fields have correct defaults', () {
-      const config = AppConfig();
-      expect(config.backgroundListeningEnabled, isFalse);
-      expect(config.wakeWordEnabled, isFalse);
-      expect(config.picovoiceAccessKey, isNull);
-      expect(config.wakeWordKeyword, 'jarvis');
-      expect(config.wakeWordSensitivity, 0.5);
-    });
-
-    test('copyWith updates new fields', () {
-      const config = AppConfig();
-      final updated = config.copyWith(
-        backgroundListeningEnabled: true,
-        wakeWordEnabled: true,
-        picovoiceAccessKey: 'pv_key',
-        wakeWordKeyword: 'computer',
-        wakeWordSensitivity: 0.8,
-      );
-      expect(updated.backgroundListeningEnabled, isTrue);
-      expect(updated.wakeWordEnabled, isTrue);
-      expect(updated.picovoiceAccessKey, 'pv_key');
-      expect(updated.wakeWordKeyword, 'computer');
-      expect(updated.wakeWordSensitivity, 0.8);
-    });
-  });
 
   group('AppConfigService', () {
     setUp(() {
@@ -162,110 +123,96 @@ void main() {
       expect(config.audioFeedbackEnabled, isFalse);
     });
 
-    group('background activation config', () {
-      test('load returns defaults for new fields when storage is empty',
+    group('P026 removal migration', () {
+      test('fresh install → migration runs, flag set, no errors', () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        await service.load();
+
+        expect(prefs.getBool('wake_word_removal_migration_done'), isTrue);
+      });
+
+      test('full state → all retired keys removed', () async {
+        SharedPreferences.setMockInitialValues({
+          'background_listening_enabled': true,
+          'wake_word_enabled': true,
+          'wake_word_keyword': 'alexa',
+          'wake_word_sensitivity': 0.8,
+          'activation_state': 'listening',
+          'activation_toggle_requested': true,
+          'activation_stop_requested': false,
+          'foreground_service_running': true,
+        });
+        FlutterSecureStorage.setMockInitialValues(
+            {'picovoice_access_key': 'pv_test'});
+        final prefs = await SharedPreferences.getInstance();
+        final service = AppConfigService(prefs: prefs);
+
+        await service.load();
+
+        expect(prefs.containsKey('background_listening_enabled'), isFalse);
+        expect(prefs.containsKey('wake_word_enabled'), isFalse);
+        expect(prefs.containsKey('wake_word_keyword'), isFalse);
+        expect(prefs.containsKey('wake_word_sensitivity'), isFalse);
+        expect(prefs.containsKey('activation_state'), isFalse);
+        expect(prefs.containsKey('activation_toggle_requested'), isFalse);
+        expect(prefs.containsKey('activation_stop_requested'), isFalse);
+        expect(prefs.containsKey('foreground_service_running'), isFalse);
+        expect(prefs.getBool('wake_word_removal_migration_done'), isTrue);
+      });
+
+      test('already migrated (flag = true) → retired keys NOT re-touched',
           () async {
-        SharedPreferences.setMockInitialValues({});
+        // Simulate a fresh install that's somehow already past the migration
+        // AND has a leftover key (shouldn't happen in practice, but verifies
+        // the gate is honored).
+        SharedPreferences.setMockInitialValues({
+          'wake_word_removal_migration_done': true,
+          'background_listening_enabled': true,
+        });
         final prefs = await SharedPreferences.getInstance();
         final service = AppConfigService(prefs: prefs);
 
-        final config = await service.load();
+        await service.load();
 
-        expect(config.backgroundListeningEnabled, isFalse);
-        expect(config.wakeWordEnabled, isFalse);
-        expect(config.picovoiceAccessKey, isNull);
-        expect(config.wakeWordKeyword, 'jarvis');
-        expect(config.wakeWordSensitivity, 0.5);
+        // Flag was set — migration should have been skipped, leaving the
+        // leftover value untouched.
+        expect(prefs.getBool('background_listening_enabled'), isTrue);
       });
 
-      test('saveBackgroundListeningEnabled then load round-trips', () async {
-        SharedPreferences.setMockInitialValues({});
+      test('idempotent across two load() calls', () async {
+        SharedPreferences.setMockInitialValues({
+          'background_listening_enabled': true,
+        });
         final prefs = await SharedPreferences.getInstance();
         final service = AppConfigService(prefs: prefs);
 
-        await service.saveBackgroundListeningEnabled(true);
-        final config = await service.load();
+        await service.load();
+        await service.load();
 
-        expect(config.backgroundListeningEnabled, isTrue);
+        expect(prefs.getBool('wake_word_removal_migration_done'), isTrue);
+        expect(prefs.containsKey('background_listening_enabled'), isFalse);
       });
 
-      test('saveWakeWordEnabled then load round-trips', () async {
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-        final service = AppConfigService(prefs: prefs);
-
-        await service.saveWakeWordEnabled(true);
-        final config = await service.load();
-
-        expect(config.wakeWordEnabled, isTrue);
-      });
-
-      test('savePicovoiceAccessKey then load round-trips', () async {
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-        final service = AppConfigService(prefs: prefs);
-
-        await service.savePicovoiceAccessKey('pv_test_key_12345');
-        final config = await service.load();
-
-        expect(config.picovoiceAccessKey, 'pv_test_key_12345');
-      });
-
-      test('saveWakeWordKeyword then load round-trips', () async {
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-        final service = AppConfigService(prefs: prefs);
-
-        await service.saveWakeWordKeyword('computer');
-        final config = await service.load();
-
-        expect(config.wakeWordKeyword, 'computer');
-      });
-
-      test('saveWakeWordSensitivity then load round-trips', () async {
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-        final service = AppConfigService(prefs: prefs);
-
-        await service.saveWakeWordSensitivity(0.8);
-        final config = await service.load();
-
-        expect(config.wakeWordSensitivity, 0.8);
-      });
-
-      test('picovoiceAccessKey survives SecureStorage failure gracefully',
+      test(
+          'load does NOT expose removed fields — config only has migrated-only keys',
           () async {
-        SharedPreferences.setMockInitialValues({});
+        SharedPreferences.setMockInitialValues({
+          'background_listening_enabled': true,
+          'wake_word_keyword': 'alexa',
+        });
         final prefs = await SharedPreferences.getInstance();
-        // Use a fresh service — FlutterSecureStorage mock has no key stored,
-        // so read returns null (simulating empty/failed storage)
         final service = AppConfigService(prefs: prefs);
 
         final config = await service.load();
 
-        expect(config.picovoiceAccessKey, isNull);
-      });
-
-      test('all background activation fields preserved alongside other config',
-          () async {
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-        final service = AppConfigService(prefs: prefs);
-
-        await service.saveApiUrl('https://test.com');
-        await service.saveBackgroundListeningEnabled(true);
-        await service.saveWakeWordEnabled(true);
-        await service.savePicovoiceAccessKey('pv_key');
-        await service.saveWakeWordKeyword('alexa');
-        await service.saveWakeWordSensitivity(0.7);
-        final config = await service.load();
-
-        expect(config.apiUrl, 'https://test.com');
-        expect(config.backgroundListeningEnabled, isTrue);
-        expect(config.wakeWordEnabled, isTrue);
-        expect(config.picovoiceAccessKey, 'pv_key');
-        expect(config.wakeWordKeyword, 'alexa');
-        expect(config.wakeWordSensitivity, 0.7);
+        // AppConfig no longer has those fields at compile time; this test
+        // asserts that the surviving config has the standard (unrelated)
+        // fields intact after migration.
+        expect(config.apiUrl, isNull);
+        expect(config.vadConfig, const VadConfig.defaults());
       });
     });
 

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -257,7 +257,7 @@ void main() {
       expect(savedValue, isFalse);
     });
 
-    testWidgets('Background Activation section is visible', (tester) async {
+    testWidgets('Background Activation section is removed (P026)', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
           overrides: _baseOverrides(),
@@ -270,138 +270,12 @@ void main() {
       await tester.drag(find.byType(ListView).first, const Offset(0, -600));
       await tester.pumpAndSettle();
 
-      expect(find.text('Background Activation'), findsOneWidget);
-      expect(find.byKey(const Key('background-listening-tile')), findsOneWidget);
-    });
-
-    testWidgets('Background listening defaults to off', (tester) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: _baseOverrides(),
-          child: const App(),
-        ),
-      );
-      await tester.pumpAndSettle();
-      await _navigateToSettings(tester);
-
-      await tester.drag(find.byType(ListView).first, const Offset(0, -600));
-      await tester.pumpAndSettle();
-
-      final tile = tester.widget<SwitchListTile>(
-          find.byKey(const Key('background-listening-tile')));
-      expect(tile.value, isFalse);
-    });
-
-    testWidgets('Wake word tile is disabled when background listening is off',
-        (tester) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: _baseOverrides(),
-          child: const App(),
-        ),
-      );
-      await tester.pumpAndSettle();
-      await _navigateToSettings(tester);
-
-      await tester.drag(find.byType(ListView).first, const Offset(0, -600));
-      await tester.pumpAndSettle();
-
-      final tile = tester.widget<SwitchListTile>(
-          find.byKey(const Key('wake-word-tile')));
-      expect(tile.onChanged, isNull);
-    });
-
-    testWidgets('Wake word tile is enabled when background listening is on',
-        (tester) async {
-      final seededService = _SeededConfigService(
-        const AppConfig(backgroundListeningEnabled: true),
-      );
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            ..._baseOverrides(),
-            appConfigServiceProvider.overrideWithValue(seededService),
-          ],
-          child: const App(),
-        ),
-      );
-      await tester.pumpAndSettle();
-      await _navigateToSettings(tester);
-
-      await tester.drag(find.byType(ListView).first, const Offset(0, -600));
-      await tester.pumpAndSettle();
-
-      final tile = tester.widget<SwitchListTile>(
-          find.byKey(const Key('wake-word-tile')));
-      expect(tile.onChanged, isNotNull);
-    });
-
-    testWidgets('Sensitivity slider is visible when wake word enabled',
-        (tester) async {
-      final seededService = _SeededConfigService(
-        const AppConfig(
-          backgroundListeningEnabled: true,
-          wakeWordEnabled: true,
-        ),
-      );
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            ..._baseOverrides(),
-            appConfigServiceProvider.overrideWithValue(seededService),
-          ],
-          child: const App(),
-        ),
-      );
-      await tester.pumpAndSettle();
-      await _navigateToSettings(tester);
-
-      await tester.drag(find.byType(ListView).first, const Offset(0, -900));
-      await tester.pumpAndSettle();
-
-      final slider = find.byKey(const Key('wake-word-sensitivity-slider'));
-      expect(slider, findsOneWidget);
-      final sliderWidget = tester.widget<Slider>(slider);
-      expect(sliderWidget.value, 0.5);
-      expect(sliderWidget.onChanged, isNotNull);
-    });
-
-    testWidgets('Picovoice access key field is visible and persists on blur',
-        (tester) async {
-      String? savedKey;
-      final trackingService = _TrackingWakeWordConfigService(
-        onSavePicovoiceAccessKey: (k) => savedKey = k,
-      );
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            ..._baseOverrides(),
-            appConfigServiceProvider.overrideWithValue(trackingService),
-          ],
-          child: const App(),
-        ),
-      );
-      await tester.pumpAndSettle();
-      await _navigateToSettings(tester);
-
-      await tester.drag(find.byType(ListView).first, const Offset(0, -700));
-      await tester.pumpAndSettle();
-
-      final field = find.byKey(const Key('picovoice-key-field'));
-      expect(field, findsOneWidget);
-
-      await tester.tap(field);
-      await tester.pump();
-      await tester.enterText(field, 'test-access-key');
-
-      // Programmatically unfocus to trigger the Focus.onFocusChange callback
-      FocusManager.instance.primaryFocus?.unfocus();
-      await tester.pump();
-
-      expect(savedKey, 'test-access-key');
+      expect(find.text('Background Activation'), findsNothing);
+      expect(find.byKey(const Key('background-listening-tile')), findsNothing);
+      expect(find.byKey(const Key('wake-word-tile')), findsNothing);
+      expect(find.byKey(const Key('picovoice-key-field')), findsNothing);
+      expect(find.byKey(const Key('wake-word-sensitivity-slider')), findsNothing);
+      expect(find.byKey(const Key('wake-word-keyword-dropdown')), findsNothing);
     });
 
     testWidgets('Groq API Key field saves on focus lost', (tester) async {
@@ -481,17 +355,3 @@ class _TrackingAudioFeedbackConfigService extends AppConfigService {
       onSaveAudioFeedbackEnabled(value);
 }
 
-class _TrackingWakeWordConfigService extends AppConfigService {
-  _TrackingWakeWordConfigService({
-    this.onSavePicovoiceAccessKey,
-  });
-
-  final void Function(String)? onSavePicovoiceAccessKey;
-
-  @override
-  Future<AppConfig> load() async => const AppConfig();
-
-  @override
-  Future<void> savePicovoiceAccessKey(String key) async =>
-      onSavePicovoiceAccessKey?.call(key);
-}


### PR DESCRIPTION
Closes #226. Removes 5 wake-word settings from AppConfig, the Background Activation UI section, and adds an idempotent one-shot removal migration per ADR-DATA-009. 708 tests passing.