### PR TITLE
fix(ios): register AudioSessionBridge via engine plugin registry

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -12,8 +12,10 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
-    if let controller = window?.rootViewController as? FlutterViewController {
-      AudioSessionBridge.shared.configure(with: controller.binaryMessenger)
+    // In UIScene-based apps window?.rootViewController is nil here, so go via
+    // the plugin registry to get a reliable binary messenger.
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "AudioSessionBridge") {
+      AudioSessionBridge.shared.configure(with: registrar.messenger())
     }
   }
 }

--- a/lib/core/background/flutter_foreground_task_service.dart
+++ b/lib/core/background/flutter_foreground_task_service.dart
@@ -61,6 +61,10 @@ class FlutterForegroundTaskService implements BackgroundService {
       } on PlatformException {
         // Audio session switch failed — continue anyway, background may
         // not persist but foreground still works
+      } on MissingPluginException {
+        // AudioSessionBridge not registered (e.g. iOS plugin wiring changed).
+        // Proceed so foreground VAD still works; background recording may not
+        // survive screen lock until the bridge is re-registered.
       }
     }
 
@@ -80,6 +84,8 @@ class FlutterForegroundTaskService implements BackgroundService {
         await _audioSessionChannel.invokeMethod('setAmbient');
       } on PlatformException {
         // Audio session revert failed — non-critical
+      } on MissingPluginException {
+        // Bridge not registered — nothing to revert.
       }
     }
 


### PR DESCRIPTION
Fixes the 'no VAD listening after P026' regression on iOS 17+ SceneDelegate-based apps. The old wiring relied on `window?.rootViewController` which is nil in `didInitializeImplicitFlutterEngine`; MissingPluginException then propagated out of `startService` (uncaught) and silently killed the hands-free session.

Verified on iPhone 12 Pro, iOS 26.3 — VAD now starts listening on Record tab entry.