### PR TITLE
docs(p027, p028): background sync + background TTS proposals

### DIFF
--- a/docs/decisions/ADR-NET-002-foreground-only-sync.md
+++ b/docs/decisions/ADR-NET-002-foreground-only-sync.md
@@ -1,7 +1,8 @@
-# ADR-NET-002: Foreground-only sync with no background processing
+# ADR-NET-002: Foreground-only sync with session-active carve-out
 
 Status: Accepted
 Proposed in: P005
+Amended in: P027
 
 ## Context
 
@@ -10,18 +11,73 @@ Pending transcripts need to reach the user's API. The sync worker could run:
 - **Foreground only** — simple periodic timer while the app is open. No platform-specific background APIs needed.
 - **Background processing** — `workmanager` or `background_fetch` package to sync when the app is closed. Requires platform configuration (iOS `BGTaskScheduler`, Android `WorkManager`), background mode entitlements, and battery-aware scheduling.
 
+P026 introduced hands-free sessions that continue running while the phone is
+locked (per ADR-PLATFORM-004). Transcripts captured during a locked session
+should reach the API without waiting for the user to unlock — but we still
+want to avoid general-purpose background sync.
+
 ## Decision
 
-Foreground-only sync via `Timer.periodic` (5-second poll interval). No `workmanager`, `background_fetch`, or any background processing package. The worker starts when the shell widget renders (`ref.watch(syncWorkerProvider)` in `AppShellScaffold`), pauses on connectivity loss, and stops when the provider is disposed.
+Sync runs when the app is foregrounded OR while a hands-free session is
+active. The predicate is checked inside `SyncWorker._drain()` at the start of
+each iteration; no new background processing package is added.
+
+- Foreground path: unchanged from P005 — `Timer.periodic` (5-second poll
+  interval), started when the shell widget renders
+  (`ref.watch(syncWorkerProvider)` in `AppShellScaffold`), paused on
+  connectivity loss, stopped when the provider is disposed.
+- Session-active path: `HandsFreeController` writes a core
+  `StateProvider<bool>` (`sessionActiveProvider`) at three lifecycle
+  transitions (`startSession`, `stopSession`, `_terminateWithError`).
+  `SyncWorker` reads the combined `shouldProcessQueue = foreground OR
+  sessionActive` predicate through its constructor callback.
+- Immediate drain on session start: `SyncWorker.kickDrain()` is a public,
+  idempotent method (short-circuits when `_draining` is true) triggered
+  from `ref.listen(sessionActiveProvider, ...)` in `sync_provider.dart` on
+  the idle→active edge. This is the canonical pattern for event-triggered
+  drains; future triggers (e.g. connectivity-up) reuse it.
 
 ## Rationale
 
-iOS severely restricts background execution (~30 seconds for background tasks, requires `BGTaskScheduler` registration and App Store review justification). The app already requires network for both STT (Groq) and sync — if the user is actively using the app, they're online and the worker syncs immediately. Pending items queue safely in SQLite and drain on next app open.
+The original 30-second iOS background limit no longer applies to the
+hands-free path: P026's foreground service (Android) and `playAndRecord`
+audio session (iOS `UIBackgroundModes: audio`, see ADR-AUDIO-009 and
+ADR-PLATFORM-006) keep the process alive for the full duration of a
+hands-free session. Sync riding on that keepalive has the same survivability
+as the capture itself — no `BGTaskScheduler` or `workmanager` dependency.
+
+The spirit of the original ADR (no surprise background data usage) is
+preserved because the carve-out is conditional on an explicit user action:
+the user tapped the Record tab and started a session. The session ends as
+soon as they switch tabs or force-close the app, which stops both capture
+and sync.
+
+`kickDrain()` is preferred over `await`-ing the next periodic tick because
+first-utterance end-to-end latency drops from ~5-10 seconds (up to one poll
+gap) to "capture + one HTTP round trip."
+
+Users who do not start a hands-free session see zero behavior change.
 
 ## Consequences
 
-- Transcripts only sync while the user has the app open — pending items wait until next session.
-- No iOS background mode entitlements needed — simpler App Store review.
-- No battery drain from background wake-ups.
-- Worker lifecycle is tied to the shell widget — if the shell unmounts (e.g., full-screen modal replacing navigator), the worker stops.
-- Adding background sync later requires `workmanager` integration and platform-specific configuration.
+- Transcripts sync live during active hands-free sessions — including while
+  backgrounded or locked.
+- No iOS background mode entitlements are added for this carve-out;
+  `UIBackgroundModes: audio` was already declared for hands-free capture.
+- Battery impact is additive to P026's (VAD + FG service): periodic network
+  activity while a session is active. Stopping the session (tab switch,
+  force-close, or error) restores foreground-only behavior.
+- TTS playback of replies during backgrounded drain is **temporarily
+  foreground-gated in P027** (the Dart `_handleReply()` path checks
+  `isAppForegrounded()` before calling `ttsService.speak()`). P028 lifts
+  this gate after adding Android `FOREGROUND_SERVICE_MEDIA_PLAYBACK`.
+  `latestAgentReplyProvider` is always populated regardless, so the user
+  sees the reply on return to foreground even when TTS is gated.
+- Worker lifecycle is still tied to the shell widget. If the shell unmounts
+  (full-screen modal replacing navigator), the worker stops — session-active
+  consumers should be aware of this limitation.
+- Future event-triggered drains (connectivity-up, schema migration, etc.)
+  should call `SyncWorker.kickDrain()` rather than inventing parallel
+  mechanisms.
+- Adding true background sync (sync without any active session) still
+  requires `workmanager` integration — not planned.

--- a/docs/decisions/ADR-PLATFORM-006-controller-owned-foreground-service-lifecycle.md
+++ b/docs/decisions/ADR-PLATFORM-006-controller-owned-foreground-service-lifecycle.md
@@ -2,6 +2,7 @@
 
 Status: Proposed
 Proposed in: P026
+Amended in: P027
 
 ## Context
 
@@ -74,3 +75,10 @@ capture, but not for audio-session category switching.
   that requires preconditions (audio session, background service, sensor).
   For controllers that only need to react to state transitions without
   preconditions, the listener pattern in ADR-ARCH-009 is still valid.
+- **P027 reuses this explicit-boundary pattern for non-platform consumers.**
+  `HandsFreeController` writes a core `StateProvider<bool>`
+  (`sessionActiveProvider`) at the same three call sites (`startSession`,
+  `stopSession`, `_terminateWithError`) so `SyncWorker` can gate on an
+  active session without depending on `features/recording`. Future
+  features that need a session-active signal should use the same provider
+  rather than reaching into `handsFreeControllerProvider`.

--- a/docs/proposals/027-background-sync.md
+++ b/docs/proposals/027-background-sync.md
@@ -1,0 +1,298 @@
+# Proposal 027 — Background Sync While Hands-Free Session Active
+
+## Status: Draft
+
+## Prerequisites
+
+- P026 (Remove Wake Word, Rewire FG Service) — FG service start/stop is tied
+  to hands-free session lifecycle; VAD + STT + local enqueue work in the
+  background. Sync is still gated to foreground.
+
+## Scope
+- Risk: Medium — amends ADR-NET-002 (foreground-only sync); changes the
+  predicate used by `SyncWorker._drain()`
+- Layers: `features/api_sync`, `core/providers`
+- Expected PRs: 2
+
+## Problem Statement
+
+After P026 a hands-free session continues running while the phone is locked:
+Silero VAD captures speech, Groq STT transcribes it, and the transcript is
+saved to the local `sync_queue`. But `SyncWorker._drain()` early-returns when
+`isAppForegrounded()` returns false (`sync_worker.dart:100`, per ADR-NET-002).
+Transcripts pile up locally and only flush to personal-agent when the user
+unlocks the phone.
+
+Observed (iOS 26.3, iPhone 12 Pro, after P026 + AudioSessionBridge fix):
+
+> Locking the phone during an active hands-free session. Speak a sentence.
+> Unlock. Only after unlock do I see the transcript arriving at
+> personal-agent, and the reply reads back in-app.
+
+Desired: transcripts flow to personal-agent within the normal ~5-second sync
+cadence regardless of app visibility, as long as the user has started a
+hands-free session.
+
+## Are We Solving the Right Problem?
+
+**Root cause:** ADR-NET-002 ("foreground-only sync") was written for the
+original use case — manual tap-to-record, app always foregrounded during
+recording. P026 made hands-free sessions continue in the background. The
+sync gate should follow the session, not the app's visibility state.
+
+**Alternatives dismissed:**
+- *Keep sync gated, add a "flush on unlock" animation.* Masks the gap rather
+  than fixing it; defeats the "phone in pocket" flow.
+- *Gate behind a new user-facing toggle.* The setting's semantics collapse
+  into "do you want your hands-free session to work end-to-end?" — busywork
+  with no real user choice.
+- *Event-driven sync (on enqueue).* Larger refactor. The 5 s cadence is
+  acceptable for V1; event-driven is a separate future improvement.
+
+**Smallest change:** Replace the `isAppForegrounded()` gate in `_drain()`
+with a predicate that also considers whether a hands-free session is active,
+and amend ADR-NET-002 with the carve-out.
+
+## Goals
+
+- Transcripts captured during a hands-free session reach personal-agent
+  within one sync cycle (~5 s) regardless of app visibility.
+- Sync behavior when no session is active is unchanged from ADR-NET-002
+  semantics — manual recording, agenda, and general app usage are not
+  affected.
+
+## Non-Goals
+
+- TTS playback in background. Scope of P028.
+- Android `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permission. Scope of P028.
+- General-purpose background sync (e.g. sync without any active session).
+- Cellular vs. Wi-Fi controls, data-saver toggle.
+- Event-driven sync / lower latency than the current 5 s timer.
+- Changes to retry, backoff, or failure semantics.
+
+## User-Visible Changes
+
+After P027 (but before P028), with a hands-free session active and the phone
+locked:
+
+- The user speaks → a transcript arrives at personal-agent within ~5 s →
+  the agent reply appears in `latestAgentReplyProvider` and is visible when
+  the user unlocks the app.
+- TTS playback of the reply still requires foreground (P028 lifts that
+  restriction for Android; iOS already supports it via `UIBackgroundModes:
+  audio` but without sync there was nothing to play).
+
+No new settings, no new UI.
+
+## Solution Design
+
+### Scope the sync gate to hands-free lifecycle
+
+Today `SyncWorker._drain()` short-circuits on `!isAppForegrounded()`. Change
+the predicate to:
+
+```
+shouldProcessQueue() =>
+    isAppForegrounded() || isHandsFreeSessionActive()
+```
+
+"Hands-free session active" means `HandsFreeController.state` is any of the
+mic-holding variants (`HandsFreeListening`, `HandsFreeCapturing`,
+`HandsFreeStopping`, `HandsFreeWithBacklog`). `HandsFreeIdle` and
+`HandsFreeSessionError` both mean inactive — matching the FG service
+predicate already established in P026's ADR-PLATFORM-006.
+
+Expose the predicate via a new core-layer `StateProvider<bool>` —
+`sessionActiveProvider` — written by `HandsFreeController` on state
+transitions and read by `SyncWorker` through its constructor callback.
+Placing it in `core/providers/` avoids the CLAUDE.md dependency-rule
+violation a derived provider would trigger (core must not import from
+features). This mirrors the existing `appForegroundedProvider` pattern.
+
+`SyncWorker` takes a `shouldProcessQueue` callback that reads both
+`appForegroundedProvider` and `sessionActiveProvider`.
+
+### Kick on session-active transition
+
+Without a kick, worst-case latency for the first utterance in a session is
+~5 s of capture + up to ~5 s until the next sync tick = up to ~10 s. Add a
+public `SyncWorker.kickDrain()` method (immediate drain, returns early if a
+drain is already in progress) and wire a `ref.listen(sessionActiveProvider,
+...)` inside `sync_provider.dart` that calls `kickDrain()` on the
+idle→active transition. First-utterance end-to-end latency becomes
+"capture + one HTTP round trip." Subsequent utterances within the same
+session rely on the existing 5 s timer.
+
+Keeping the listener inside `sync_provider.dart` preserves one-directional
+coupling — `features/recording` does not depend on `features/api_sync`.
+
+### Guard TTS to foreground until P028 ships
+
+`_handleReply()` at `sync_worker.dart:167` calls
+`unawaited(ttsService.speak(...))`. Post-P027, `_drain()` also runs while
+backgrounded, so `_handleReply()` runs backgrounded too. Until P028 adds
+`FOREGROUND_SERVICE_MEDIA_PLAYBACK` on Android, backgrounded TTS may fail
+silently or throw on Android 14+. Add an explicit foreground gate on the
+TTS branch inside `_handleReply()` (without gating storage writes or
+`latestAgentReplyProvider`):
+
+```
+if (isAppForegrounded()) {
+    unawaited(ttsService.speak(message, languageCode: language));
+}
+// else: reply is stored; user hears nothing until foreground, sees it on return
+```
+
+P028 removes this gate. Document the sequencing in both proposals.
+
+### ADR-NET-002 amendment
+
+Current: "Sync runs only while the app is in the foreground."
+After P027: "Sync runs while the app is in the foreground OR while a
+hands-free session is active." The ADR's motivation (no surprise background
+data usage) is preserved — the user explicitly started the session.
+
+## Affected Mutation Points
+
+**Needs change:**
+- `lib/core/providers/session_active_provider.dart` (NEW) — a
+  `StateProvider<bool>` defaulting to `false`, written by
+  `HandsFreeController` on lifecycle transitions. Mirrors the
+  `appForegroundedProvider` pattern to keep `core/providers/` free of
+  `features/` imports.
+- `lib/features/recording/presentation/hands_free_controller.dart`:
+  - `startSession()` (after guards pass, before `bg.startService()`): set
+    `_ref.read(sessionActiveProvider.notifier).state = true`.
+  - `stopSession()` (start of method): set `sessionActiveProvider` to
+    `false` before the idle guard returns.
+  - `_terminateWithError()`: set `sessionActiveProvider` to `false` before
+    the service stop.
+- `lib/features/api_sync/sync_worker.dart:22,33` — swap the
+  `isAppForegrounded` constructor param/field for `shouldProcessQueue`.
+- `lib/features/api_sync/sync_worker.dart:100` — replace
+  `if (!isAppForegrounded()) return;` with `if (!shouldProcessQueue()) return;`.
+- `lib/features/api_sync/sync_worker.dart` — add public `Future<void>
+  kickDrain()` that calls `_drain()` if no drain is in progress (idempotent
+  with existing `_draining` flag).
+- `lib/features/api_sync/sync_worker.dart:167` — foreground-gate the TTS
+  call inside `_handleReply()` until P028 ships. Storage writes and
+  `latestAgentReplyProvider` updates remain unconditional.
+- `lib/features/api_sync/sync_provider.dart:30` — wire the
+  `shouldProcessQueue` callback to read both `appForegroundedProvider` and
+  `sessionActiveProvider`. Also add a `ref.listen(sessionActiveProvider,
+  ...)` that calls `syncWorker.kickDrain()` on idle→active edge.
+- `docs/decisions/ADR-NET-002-*.md` — amend Decision section with the
+  "or while a hands-free session is active" carve-out. Note that TTS
+  playback during backgrounded drain is explicitly gated until P028.
+
+**No change needed:**
+- `handsFreeControllerProvider` itself — the StateProvider pattern means
+  `HandsFreeController` writes to the separate `sessionActiveProvider`
+  directly; no derived provider.
+- Connectivity / retry / backoff logic in `SyncWorker`.
+- `flutter_foreground_task_service.dart` — FG service lifecycle is unchanged.
+
+## Tasks
+
+| # | Task | Layer | Notes |
+|---|------|-------|-------|
+| T1 | Add `lib/core/providers/session_active_provider.dart` as a `StateProvider<bool>` defaulting to `false`. Wire `HandsFreeController.startSession()/stopSession()/_terminateWithError()` to write it. Extend `hands_free_controller_test.dart` with transition tests verifying the provider value at each edge. | core/providers, features/recording, test | ~60 LOC |
+| T2 | Swap `SyncWorker.isAppForegrounded` callback for `shouldProcessQueue`. Add `SyncWorker.kickDrain()` public method (idempotent via existing `_draining` flag). Foreground-gate the TTS call in `_handleReply()`. In `sync_provider.dart`, wire `shouldProcessQueue` to read both flags, and `ref.listen(sessionActiveProvider, ...)` to call `kickDrain()` on idle→active edge. Rename the existing `foreground gating` test group to cover the 2D matrix `(foregrounded, sessionActive) → shouldProcess` (4 cases). Amend **ADR-NET-002** — Decision + Rationale + Consequences per ADR Impact section below. Amend **ADR-PLATFORM-006** — one-line Consequences cross-reference. | features/api_sync, test, docs | Single PR. |
+
+## Test Impact / Verification
+
+**Existing tests affected:**
+- `sync_worker_test.dart` — any test asserting "sync skipped when
+  backgrounded" needs a two-dimensional matrix now:
+  `(foregrounded, sessionActive) → shouldProcess`. Existing foreground cases
+  stay; add two background cases.
+
+**New tests:**
+- Provider test for `sessionActiveProvider` covering the 6
+  `HandsFreeSessionState` variants.
+- `sync_worker_test.dart`:
+  - `(background, sessionActive)` → processes queue
+  - `(background, sessionIdle)` → skips queue
+  - `(foreground, sessionIdle)` → processes queue (regression)
+
+**Manual verification:**
+- iOS, release build, iPhone 12 Pro: start hands-free session, lock screen,
+  speak, observe personal-agent logs receiving the transcript within 10 s.
+  Unlock — no "burst" flush, because it already happened.
+- iOS, same setup: enable airplane mode mid-session, speak (transcript
+  enqueues but fails to sync). Disable airplane mode with screen still
+  locked. Verify transcript reaches personal-agent within the next tick or
+  kick. (Acceptable if connectivity-stream delays push this to ~5 s.)
+- Android (when device available): same flow on Android 14+ device. Verify
+  no `ForegroundServiceTypeException` in logcat. (TTS remains foreground-only
+  in P027; P028 adds Android mediaPlayback.)
+
+**Commands:** `flutter analyze && flutter test`.
+
+## Acceptance Criteria
+
+1. With a hands-free session active and the phone locked, a spoken utterance
+   is transcribed locally and the transcript reaches personal-agent within
+   10 s (first utterance after session start, thanks to `kickDrain()`).
+2. Subsequent utterances within the same session reach personal-agent within
+   one 5 s sync cycle.
+3. With NO session active and the app backgrounded, sync remains gated —
+   existing ADR-NET-002 behavior for all non-hands-free code paths.
+4. TTS playback during a backgrounded drain is skipped (gated to foreground
+   until P028). Reply text is still stored in `latestAgentReplyProvider`
+   and visible on return to foreground.
+5. Re-entering a hands-free session after a previous one ended does not
+   reprocess previously-synced items (regression check).
+6. `flutter analyze` and `flutter test` both pass.
+7. ADR-NET-002 status field reflects the amendment ("Amended in P027").
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Cellular data usage while backgrounded during long hands-free sessions | Acceptable — user opted into the session. Existing 5 s cadence rate-limits. |
+| **Privacy expectation gap** — user locks phone during sensitive dictation, assumes data transmission stops, but the session keeps syncing | Document in release notes: "while a hands-free session is active, transcripts are sent to your personal-agent API regardless of screen state. Stop the session (switch tab off Record, or force-close) to pause transmission." |
+| Battery drain | Already present post-P026 for VAD; P027 adds periodic network calls on top. Tab-switch and manual stop end the session and restore battery behavior. |
+| Android OEM-specific FG service killers (Xiaomi, OPPO) may kill the service despite correct types | Out of scope — Android ecosystem problem that existed pre-P027. Documented. |
+| `sessionActiveProvider` writes fire too often and generate spurious drain attempts | `kickDrain()` is idempotent (short-circuits when `_draining == true`). State writes happen at 3 fixed controller methods; the listen fires only on `true ← false` edge. |
+| **Connectivity stream may not deliver events reliably when the app is backgrounded** (iOS drops Wi-Fi, OS delays delivery) | Existing pause/resume coordination in `SyncWorker` is unchanged. Document as known limitation: if connectivity is lost while backgrounded and recovers before the next 5 s tick, `kickDrain()` is not called on recovery. The next tick catches it. If this becomes a real issue, a follow-up can wire connectivity changes to `kickDrain()` via `sync_provider.dart`. |
+| Session transitions through `HandsFreeStopping` before `HandsFreeIdle` — predicate still true during stopping | Correct behavior — drain the queue during the ~500ms stopping window. Document. |
+| In-flight `kickDrain()` when session goes active→idle mid-drain | Drain continues to completion. Individual HTTP requests already have independent state; the `_draining` flag resets naturally when the current iteration finishes. If `shouldProcessQueue()` returns false on the next iteration inside `_drain()`, the loop exits. No partial state corruption. |
+
+## Known Compromises and Follow-Up Direction
+
+- **Sync cadence is still 5 s.** A user speaking immediately at session
+  start may see the reply up to ~5 s after the ideal moment. Event-driven
+  sync (on enqueue) is a natural follow-up but not required for V1.
+- **Only hands-free sessions get background sync.** Any other long-running
+  user-initiated background activity that needs sync would need its own
+  carve-out — OK, there is no such other case today.
+
+## ADR Impact
+
+**Amends ADR-NET-002 (foreground-only sync).** Three sections need edits, not
+just the Decision line:
+
+1. **Decision** — widen the predicate to "foreground OR session active,"
+   name `SyncWorker.kickDrain()` as the canonical event-triggered drain
+   entry point for future triggers.
+2. **Rationale** — the current ADR cites "iOS severely restricts background
+   execution (~30 seconds, requires BGTaskScheduler)". Rewrite: P026
+   eliminated that restriction for hands-free sessions by tying the
+   foreground service + `playAndRecord` audio session (ADR-AUDIO-009,
+   ADR-PLATFORM-006) to session lifecycle. Sync riding on that keepalive
+   has the same survivability as capture itself.
+3. **Consequences** — add that sync runs during background hands-free
+   sessions, that TTS is temporarily foreground-gated until P028, and that
+   `latestAgentReplyProvider` is always populated so the user sees the
+   reply on return to foreground regardless of whether TTS plays.
+
+**Amends ADR-PLATFORM-006 (controller-owned FG service lifecycle).** One-
+line cross-reference in Consequences: "P027 reuses this explicit-boundary
+pattern for `sessionActiveProvider` writes at the same three call sites
+(`startSession`, `stopSession`, `_terminateWithError`)." No Decision change.
+
+**No new ADR.** `kickDrain()` is named inside ADR-NET-002 as the canonical
+pattern for future event-triggered drains; if a second trigger lands
+(connectivity-up being the most likely), it reuses the method without a
+new ADR.

--- a/docs/proposals/028-background-tts.md
+++ b/docs/proposals/028-background-tts.md
@@ -1,0 +1,225 @@
+# Proposal 028 — Background TTS Playback for Hands-Free Sessions
+
+## Status: Draft
+
+## Prerequisites
+
+- P026 (Remove Wake Word, Rewire FG Service) — FG service start/stop tied
+  to hands-free session lifecycle.
+- P027 (Background Sync While Hands-Free Session Active) — transcripts
+  reach personal-agent in the background. Without P027 there is nothing
+  to TTS back while backgrounded.
+
+## Scope
+- Risk: Medium — changes Android foreground service semantics (permission +
+  service type). iOS requires no platform change (already covered by
+  `UIBackgroundModes: audio` + `.playAndRecord`).
+- Layers: platform/android (manifest + FG service type), `core/background`
+- Expected PRs: 1
+
+## Problem Statement
+
+After P026 + P027, transcripts arrive at personal-agent and the agent replies
+even while the phone is locked. But the reply is not read aloud until the user
+unlocks the app. On iOS 17+ this works by accident/design (the active
+`.playAndRecord` audio session + `UIBackgroundModes: audio` let
+`AVSpeechSynthesizer` play in the background). **On Android 14+, TTS
+playback from a foreground service requires the service to declare the
+`mediaPlayback` service type and hold the `FOREGROUND_SERVICE_MEDIA_PLAYBACK`
+permission.** Today the manifest declares only
+`FOREGROUND_SERVICE_MICROPHONE`, so TTS triggered via
+`FlutterTtsService.speak()` while backgrounded is silently throttled or
+killed by the system.
+
+Observed (iOS, after P027): reply is spoken live, as expected.
+Observed on Android 14+ (expected, per research): reply would not be audible
+in the background — the user would only hear it on returning to the app.
+
+## Are We Solving the Right Problem?
+
+**Root cause:** Android 14+ hardened the foreground service model: each FG
+service must declare which special work it is doing. Our FG service declares
+only `microphone`. When TTS playback is triggered, Android considers this
+"media playback" and enforces the matching service type. Without the right
+declaration, the audio is suppressed.
+
+**Alternatives dismissed:**
+- *Don't do TTS in background, show a silent notification instead.* Rejected.
+  Defeats the hands-free flow — the user has a phone in a pocket and can't
+  look at a notification.
+- *Move TTS playback to a separate, short-lived FG service started only when
+  a reply arrives.* Rejected as complexity for no gain. We already have a
+  long-lived FG service tied to the session; adding a second short-lived one
+  creates coordination headaches.
+- *Use Android `MediaSession`/`MediaStyle` notifications for TTS.* Overkill
+  for single-utterance TTS; the foreground service with `mediaPlayback` type
+  is the idiomatic solution.
+
+**Smallest change:** Add the `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permission
+and register both `microphone` and `mediaPlayback` service types when
+starting the FG service.
+
+## Goals
+
+- TTS playback reads the agent reply aloud while the phone is locked, on
+  both iOS and Android, while a hands-free session is active.
+- No regression in foreground TTS.
+
+## Non-Goals
+
+- Sync changes. Scope of P027.
+- iOS-specific work. Already covered by `UIBackgroundModes: audio` +
+  `.playAndRecord` from P026's audio session.
+- TTS voice/language selection changes (existing `flutter_tts` config
+  stays).
+- TTS audio routing under phone calls / Bluetooth intricacies — platform
+  defaults apply.
+- Android MediaSession integration (play/pause controls, lock-screen art).
+
+## User-Visible Changes
+
+After P027 + P028, with a hands-free session active and the phone locked:
+
+- User speaks → transcript syncs (P027) → agent replies → **TTS reads the
+  reply aloud through the speaker**, audible while the phone is locked, on
+  both iOS and Android.
+- No new UI. The persistent Android notification ("Voice Agent — Recording
+  session active") stays; only the underlying FG service type changes.
+
+## Solution Design
+
+### Android: declare `mediaPlayback` permission and service type
+
+Three changes, two Android-side and one cross-platform:
+
+1. **Manifest** (`android/app/src/main/AndroidManifest.xml`): add
+   `<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>`.
+2. **FG service registration**
+   (`lib/core/background/flutter_foreground_task_service.dart:49-55`):
+   change `serviceTypes: [ForegroundServiceTypes.microphone]` to
+   `serviceTypes: [ForegroundServiceTypes.microphone,
+   ForegroundServiceTypes.mediaPlayback]`.
+3. **Lift the P027 TTS foreground gate**
+   (`lib/features/api_sync/sync_worker.dart`, `_handleReply()`): P027 added
+   `if (isAppForegrounded()) unawaited(ttsService.speak(...));` as a
+   temporary guard until Android's FG service type issue was fixed. P028
+   removes the `isAppForegrounded()` check and calls TTS unconditionally
+   when `getTtsEnabled()` is true. Without this removal, the manifest +
+   service-type change has no observable effect.
+
+Android supports multi-type FG services in the manifest since API 29,
+but the strict typed-service enforcement (with `FOREGROUND_SERVICE_*`
+per-type permissions) begins at **Android 14 / API 34**. On API 24-33 the
+manifest permission is a harmless no-op; on API 34+ it is required for
+media playback while a typed FG service is active. Both types remain
+active for the full duration of a hands-free session — no dynamic switching.
+
+### iOS — no platform changes required
+
+`UIBackgroundModes: audio` is already declared (P019 → preserved in P026).
+The `AudioSessionBridge` already sets `.playAndRecord` with
+`[.defaultToSpeaker, .allowBluetooth, .mixWithOthers]` at session start.
+`flutter_tts` plays via `AVSpeechSynthesizer`, which routes through the
+active audio session. Manual smoke in P028 confirms this works.
+
+### `FlutterTtsService` stays unchanged
+
+The service's `speak()` method does not touch audio session state. With
+P026's `AudioSessionBridge` holding `.playAndRecord` on iOS and P028's
+`mediaPlayback` service type on Android, TTS playback reaches the speaker
+in both foreground and background.
+
+### TTS-VAD interaction remains intact
+
+`HandsFreeController.suspendForTts()` / `resumeAfterTts()` pauses VAD while
+TTS plays to avoid mic feedback. This is triggered by `ttsPlayingProvider`
+and fires regardless of whether the Record tab is visible — the listener
+lives on `RecordingScreen` which is kept alive by the IndexedStack while
+the tab exists.
+
+## Affected Mutation Points
+
+**Needs change:**
+- `android/app/src/main/AndroidManifest.xml` — add
+  `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permission.
+- `lib/core/background/flutter_foreground_task_service.dart:49-55` — add
+  `ForegroundServiceTypes.mediaPlayback` to `serviceTypes`.
+- `lib/features/api_sync/sync_worker.dart` — remove the P027
+  `if (isAppForegrounded())` guard around `unawaited(ttsService.speak(...))`
+  in `_handleReply()`. TTS is again invoked whenever `getTtsEnabled()` is
+  true, regardless of foreground state.
+
+**No change needed:**
+- iOS native (bridge, Info.plist, entitlements).
+- `FlutterTtsService` or its provider.
+- VAD suspend/resume on TTS (`HandsFreeController.suspendForTts`) —
+  triggered from `ttsPlayingProvider`, works regardless of app visibility.
+
+## Tasks
+
+| # | Task | Layer | Notes |
+|---|------|-------|-------|
+| T1 | Add `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permission to `AndroidManifest.xml`. Update `FlutterForegroundTaskService.startService()` to declare both `microphone` and `mediaPlayback` service types. Remove the P027 `isAppForegrounded()` TTS foreground-gate in `sync_worker.dart` `_handleReply()`. Extend `flutter_foreground_task_service_test.dart` (if present) with an assertion that `startService` passes both service types. Update `sync_worker_test.dart` to remove the "TTS skipped when backgrounded" case added in P027. Manual smoke on iPhone 12 Pro + Android 14+ device: speak during locked session, verify TTS is audible. | platform/android, core/background, features/api_sync, test | Single small PR |
+
+## Test Impact / Verification
+
+**Existing tests affected:** none (`flutter_foreground_task_service_test.dart`
+tests the service interface, not the Android-specific service types passed
+to the platform).
+
+**New tests:** none required — the change is a declaration. Verify in manual
+smoke.
+
+**Manual verification (required before marking Implemented):**
+- iOS iPhone 12 Pro, release build: lock screen during active session,
+  speak, verify TTS is audible through speaker while locked.
+- Android 14+ device, release build: same flow. Verify no
+  `ForegroundServiceStartNotAllowedException`,
+  `SecurityException: Starting FGS with type mediaPlayback`, or
+  `InvalidForegroundServiceTypeException` in logcat. Verify TTS audible
+  while locked.
+- Android pre-14 device (if available): same flow. No permission error
+  expected (permission is a no-op there); TTS should also be audible.
+- Both platforms: session-idle state after tab switch → no FG service → no
+  regression.
+
+**Commands:** `flutter analyze && flutter test`.
+
+## Acceptance Criteria
+
+1. With a hands-free session active on iOS, phone locked, personal-agent
+   reply triggers TTS that is audible through the speaker without unlocking.
+2. With a hands-free session active on Android 14+, same behavior — TTS
+   audible while locked, no logcat errors about service type violations.
+3. `flutter analyze` and `flutter test` both pass.
+4. `AndroidManifest.xml` contains `FOREGROUND_SERVICE_MEDIA_PLAYBACK`
+   permission.
+5. `FlutterForegroundTaskService.startService()` registers both `microphone`
+   and `mediaPlayback` service types.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `flutter_foreground_task` SDK version may not support `ForegroundServiceTypes.mediaPlayback` | Verified: pubspec locks `flutter_foreground_task: ^9.2.2` which supports multi-type services. Re-verify during T1 implementation. |
+| TTS audio routing under phone calls | iOS ducks or suspends our audio — desired behavior. Android follows OS audio focus. No explicit handling needed; default behavior is correct. |
+| Android OEM-specific FG service killers | Out of scope — existed pre-P028. The `mediaPlayback` type does not change OEM kill behavior. |
+| `flutter_tts` on Android may internally require its own audio focus request that fails under our FG service | If smoke reveals this, add `audioSession`/`awaitSynthCompletion` config to `FlutterTtsService`. Not expected based on research. |
+
+## Known Compromises and Follow-Up Direction
+
+- **No lock-screen media controls.** We don't surface the TTS as a
+  `MediaSession`, so the user can't pause/skip from the lock screen.
+  Acceptable — replies are short and per-utterance. A future proposal could
+  add `MediaSession` if the UX needs it.
+- **Battery impact** of continuous `mediaPlayback`-typed FG service is
+  negligibly different from `microphone`-only. Both keep the process alive
+  the same way.
+
+## ADR Impact
+
+No ADR changes. The change is a platform manifest + service type adjustment
+to support behavior already sanctioned by P019/P026 (background audio for
+active sessions). If there's an ADR that explicitly names
+`FOREGROUND_SERVICE_MICROPHONE` as the single FG service type, amend it to
+name both. Otherwise no documentation change.


### PR DESCRIPTION
Two proposals + ADR amendments:

**P027** - Background sync while hands-free session active. Amends ADR-NET-002 (foreground-only → foreground OR sessionActive). Adds `SyncWorker.kickDrain()`. TTS temporarily foreground-gated.

**P028** - Background TTS. Android-only: adds FOREGROUND_SERVICE_MEDIA_PLAYBACK + mediaPlayback service type. Removes P027 TTS gate. iOS is a no-op.

**ADR amendments**
- ADR-NET-002: Decision + Rationale + Consequences rewritten
- ADR-PLATFORM-006: one-line cross-reference to P027 reuse

Reviews done: primary proposal review (2 rounds) + architectural review. All P0/P1/P2 resolved before presenting for approval.

Implementation follows in 3 task PRs after this merges.