### PR TITLE
feat(p027-t1): add sessionActiveProvider + HandsFreeController writes

### DIFF
--- a/lib/core/providers/session_active_provider.dart
+++ b/lib/core/providers/session_active_provider.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// True while a hands-free session is active (Listening / Capturing /
+/// Stopping / WithBacklog). Written by `HandsFreeController` at three
+/// lifecycle boundaries (`startSession`, `stopSession`,
+/// `_terminateWithError`); read by `SyncWorker` (P027) and any future
+/// consumer that needs to gate on an active session.
+///
+/// Mirrors the `appForegroundedProvider` pattern (core-layer
+/// `StateProvider<bool>` written by a feature) to avoid a cross-feature
+/// import from `features/api_sync` → `features/recording`. See ADR-NET-002
+/// (amended in P027) and ADR-PLATFORM-006 (amended in P027).
+final sessionActiveProvider = StateProvider<bool>((ref) => false);

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -7,6 +7,7 @@ import 'package:uuid/uuid.dart';
 import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
 import 'package:voice_agent/core/background/background_service_provider.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/providers/session_active_provider.dart';
 import 'package:voice_agent/core/config/vad_config.dart';
 import 'package:voice_agent/core/models/transcript.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
@@ -191,9 +192,14 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
       return;
     }
 
-    // All guards passed — start foreground service BEFORE engine so the iOS
-    // playAndRecord audio session is set before mic capture begins
-    // (ADR-AUDIO-009 + ADR-PLATFORM-006).
+    // All guards passed — mark the session active BEFORE starting the engine
+    // so SyncWorker (P027, ADR-NET-002) can drain in the background from the
+    // very first tick.
+    _ref.read(sessionActiveProvider.notifier).state = true;
+
+    // Start foreground service BEFORE engine so the iOS playAndRecord audio
+    // session is set before mic capture begins (ADR-AUDIO-009 +
+    // ADR-PLATFORM-006).
     final bg = _ref.read(backgroundServiceProvider);
     await bg.startService();
     unawaited(bg.updateNotification(
@@ -222,6 +228,10 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
 
   Future<void> stopSession() async {
     if (state is HandsFreeIdle) return;
+
+    // Flip the session-active flag early so SyncWorker stops draining in the
+    // background while we tear down (P027, ADR-NET-002).
+    _ref.read(sessionActiveProvider.notifier).state = false;
 
     // Stop foreground service before engine teardown; on iOS this reverts the
     // audio session category from playAndRecord back to ambient before the
@@ -442,6 +452,9 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     String message, {
     bool requiresSettings = false,
   }) {
+    // Flip the session-active flag so SyncWorker stops background draining
+    // immediately (P027, ADR-NET-002).
+    _ref.read(sessionActiveProvider.notifier).state = false;
     unawaited(_ref.read(backgroundServiceProvider).stopService());
     unawaited(_engineSub?.cancel());
     _engineSub = null;

--- a/test/core/providers/session_active_provider_test.dart
+++ b/test/core/providers/session_active_provider_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/providers/session_active_provider.dart';
+
+void main() {
+  group('sessionActiveProvider', () {
+    test('default is false', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(sessionActiveProvider), isFalse);
+    });
+
+    test('can be written to true and read back', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(sessionActiveProvider.notifier).state = true;
+      expect(container.read(sessionActiveProvider), isTrue);
+    });
+
+    test('can flip false → true → false', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(sessionActiveProvider.notifier).state = true;
+      expect(container.read(sessionActiveProvider), isTrue);
+
+      container.read(sessionActiveProvider.notifier).state = false;
+      expect(container.read(sessionActiveProvider), isFalse);
+    });
+  });
+}

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -13,6 +13,7 @@ import 'package:voice_agent/core/models/sync_queue_item.dart';
 import 'package:voice_agent/core/models/transcript.dart';
 import 'package:voice_agent/core/models/transcript_result.dart';
 import 'package:voice_agent/core/models/transcript_with_status.dart';
+import 'package:voice_agent/core/providers/session_active_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
 import 'package:voice_agent/core/config/vad_config.dart';
@@ -611,6 +612,81 @@ void main() {
 
       expect(bg.calls, contains('stopService'));
       expect(stateOf(c), isA<HandsFreeSessionError>());
+    });
+  });
+
+  // ── sessionActiveProvider writes (P027) ───────────────────────────────────
+
+  group('sessionActiveProvider lifecycle', () {
+    test('startSession success → sessionActive = true', () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine);
+
+      expect(c.read(sessionActiveProvider), isFalse);
+
+      await ctrl(c).startSession();
+
+      expect(c.read(sessionActiveProvider), isTrue);
+    });
+
+    test('stopSession → sessionActive = false', () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine);
+      await ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      await ctrl(c).stopSession();
+
+      expect(c.read(sessionActiveProvider), isFalse);
+    });
+
+    test('_terminateWithError via engine error → sessionActive = false',
+        () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine);
+      await ctrl(c).startSession();
+      await Future.delayed(Duration.zero);
+
+      engine.emit(const EngineError('VAD crashed'));
+      await Future.delayed(Duration.zero);
+
+      expect(c.read(sessionActiveProvider), isFalse);
+    });
+
+    test('permission denied guard → sessionActive stays false', () async {
+      final engine = FakeHandsFreeEngine()..permissionGranted = false;
+      final c = makeContainer(engine: engine);
+
+      await ctrl(c).startSession();
+
+      expect(c.read(sessionActiveProvider), isFalse);
+    });
+
+    test('missing Groq key guard → sessionActive stays false', () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine, groqApiKey: null);
+
+      await ctrl(c).startSession();
+
+      expect(c.read(sessionActiveProvider), isFalse);
+    });
+
+    test('already-idle stopSession → no write (provider stays whatever it was)',
+        () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine);
+
+      // Simulate an inconsistent state: provider is true but controller is
+      // idle (shouldn't happen in practice, but verifies the early-return
+      // guard doesn't clobber the flag).
+      c.read(sessionActiveProvider.notifier).state = true;
+
+      await ctrl(c).stopSession();
+
+      // Because state was already HandsFreeIdle, stopSession returns before
+      // writing the provider.
+      expect(c.read(sessionActiveProvider), isTrue);
     });
   });
 


### PR DESCRIPTION
Closes #237. Introduces the core-layer StateProvider<bool> that SyncWorker will gate on in P027-T2. HandsFreeController writes it at startSession/stopSession/_terminateWithError. All 717 tests passing.