### PR TITLE
feat(p028-t1): background TTS — Android mediaPlayback + lift P027 gate

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application
         android:label="voice_agent"

--- a/lib/core/background/flutter_foreground_task_service.dart
+++ b/lib/core/background/flutter_foreground_task_service.dart
@@ -51,7 +51,12 @@ class FlutterForegroundTaskService implements BackgroundService {
         serviceId: 1,
         notificationTitle: 'Voice Agent',
         notificationText: 'Starting...',
-        serviceTypes: [ForegroundServiceTypes.microphone],
+        serviceTypes: [
+          ForegroundServiceTypes.microphone,
+          // P028: required so flutter_tts.speak() can play through the
+          // speaker while the service is running on Android 14+.
+          ForegroundServiceTypes.mediaPlayback,
+        ],
       );
     }
 

--- a/lib/features/api_sync/sync_provider.dart
+++ b/lib/features/api_sync/sync_provider.dart
@@ -29,12 +29,11 @@ final syncWorkerProvider = Provider<SyncWorker>((ref) {
     getTtsEnabled: () => ref.read(appConfigProvider).ttsEnabled,
     audioFeedbackService: ref.watch(audioFeedbackServiceProvider),
     // P027 / ADR-NET-002: drain while foregrounded OR while a hands-free
-    // session is active.
+    // session is active. P028: TTS no longer needs a separate foreground
+    // gate — Android mediaPlayback FG service type + iOS playAndRecord
+    // cover background TTS.
     shouldProcessQueue: () =>
         ref.read(appForegroundedProvider) || ref.read(sessionActiveProvider),
-    // P027: TTS playback is foreground-gated until P028 adds Android
-    // FOREGROUND_SERVICE_MEDIA_PLAYBACK.
-    isAppForegrounded: () => ref.read(appForegroundedProvider),
     onAgentReply: (reply) {
       ref.read(latestAgentReplyProvider.notifier).state = reply;
     },

--- a/lib/features/api_sync/sync_worker.dart
+++ b/lib/features/api_sync/sync_worker.dart
@@ -20,7 +20,6 @@ class SyncWorker {
     required this.getTtsEnabled,
     required this.audioFeedbackService,
     required this.shouldProcessQueue,
-    required this.isAppForegrounded,
     this.onAgentReply,
   });
 
@@ -35,10 +34,6 @@ class SyncWorker {
   /// Returns true when the queue should be drained. After P027 this is
   /// `foreground OR hands-free session active`. See ADR-NET-002.
   final bool Function() shouldProcessQueue;
-
-  /// Returns true when the app is foregrounded. Used to gate TTS playback
-  /// in `_handleReply()` until P028 adds Android `FOREGROUND_SERVICE_MEDIA_PLAYBACK`.
-  final bool Function() isAppForegrounded;
 
   final void Function(String reply)? onAgentReply;
 
@@ -193,10 +188,11 @@ class SyncWorker {
       final message = json['message'] as String?;
       if (message == null || message.isEmpty) return;
       final language = json['language'] as String?;
-      // P027: TTS is temporarily foreground-gated. P028 lifts this after
-      // adding Android FOREGROUND_SERVICE_MEDIA_PLAYBACK. Reply text is
-      // always stored via onAgentReply so the user sees it on return.
-      if (getTtsEnabled() && isAppForegrounded()) {
+      // P028 lifted the P027 foreground gate — TTS plays in both foreground
+      // and background. iOS: covered by UIBackgroundModes:audio + playAndRecord.
+      // Android: covered by FOREGROUND_SERVICE_MEDIA_PLAYBACK + mediaPlayback
+      // service type on the active FG service.
+      if (getTtsEnabled()) {
         unawaited(ttsService.stop().then((_) => ttsService.speak(message, languageCode: language)));
       }
       onAgentReply?.call(message);

--- a/test/features/api_sync/sync_worker_test.dart
+++ b/test/features/api_sync/sync_worker_test.dart
@@ -228,7 +228,6 @@ void main() {
       getTtsEnabled: () => ttsEnabled,
       audioFeedbackService: _StubAudioFeedbackService(),
       shouldProcessQueue: () => true,
-      isAppForegrounded: () => true,
     );
   });
 
@@ -316,7 +315,6 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => true,
-        isAppForegrounded: () => true,
       );
 
       await storage.saveTranscript(transcript);
@@ -430,7 +428,6 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => true,
-        isAppForegrounded: () => true,
         onAgentReply: (reply) => receivedReply = reply,
       );
 
@@ -457,7 +454,6 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => true,
-        isAppForegrounded: () => true,
         onAgentReply: (reply) => receivedReply = reply,
       );
 
@@ -484,7 +480,6 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => true,
-        isAppForegrounded: () => true,
         onAgentReply: (reply) => receivedReply = reply,
       );
 
@@ -510,7 +505,6 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => true,
-        isAppForegrounded: () => true,
         onAgentReply: (reply) => receivedReply = reply,
       );
 
@@ -659,7 +653,6 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: predicate,
-        isAppForegrounded: predicate,
       );
     }
 
@@ -732,7 +725,6 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => canProcess,
-        isAppForegrounded: () => canProcess,
       );
 
       await storage.saveTranscript(transcript);
@@ -808,8 +800,8 @@ void main() {
     });
   });
 
-  group('TTS foreground gating (P027 temporary; P028 lifts)', () {
-    test('foreground=true → ttsService.speak() called', () async {
+  group('TTS (P028: always speaks regardless of foreground state)', () {
+    test('ttsEnabled=true → ttsService.speak() called', () async {
       await storage.saveTranscript(transcript);
       await storage.enqueue('tx-1');
       apiClient.nextResult = const ApiSuccess();
@@ -824,8 +816,9 @@ void main() {
       worker.stop();
     });
 
-    test('foreground=false → ttsService.speak() NOT called, reply stored',
+    test('ttsEnabled=false → ttsService.speak() NOT called, reply stored',
         () async {
+      ttsEnabled = false;
       String? capturedReply;
       worker = SyncWorker(
         storageService: storage,
@@ -836,8 +829,7 @@ void main() {
         ttsService: tts,
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
-        shouldProcessQueue: () => true, // backgrounded session active
-        isAppForegrounded: () => false, // backgrounded
+        shouldProcessQueue: () => true,
         onAgentReply: (reply) => capturedReply = reply,
       );
 


### PR DESCRIPTION
Closes #239. Adds Android FOREGROUND_SERVICE_MEDIA_PLAYBACK permission + mediaPlayback service type. Removes the P027 TTS foreground gate in SyncWorker. iOS is a no-op (already covered by P026 audio session). 723 tests passing. Manual smoke pending on iPhone 12 Pro.