### PR TITLE
docs: proposal seeds for backlog items (031, 032, 033)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,11 +168,25 @@ shell restructure, permission model, or personal-agent API contract changes.
 
 ### Proposal and ADR Commit
 
-For Tier 2/3 work, commit approved proposal and ADR changes before implementation:
+When a proposal exists, it must be merged to `main` before any implementation
+begins. For Tier 2/3 work, ADR changes follow the same flow:
 
 - The proposal document (`docs/proposals/`)
 - All new ADR files (`docs/decisions/`)
 - All updates to existing ADR files (`docs/decisions/`)
+
+Workflow:
+
+1. Create a branch (e.g. `<NNN>/proposal`).
+2. Commit the proposal + ADR changes on that branch.
+3. Push and open a PR.
+4. Merge to `main` after approval.
+5. Only then create a new branch from `main` for implementation
+   (`feat/<short-description>` or similar — see Branch Naming).
+
+The proposal is the contract: it must be on `main` before implementation
+references it. Implementation PRs reference a stable, merged proposal — not one
+in flight on a feature branch.
 
 ### Implementation
 

--- a/docs/proposals/029-honor-session-control-signals.md
+++ b/docs/proposals/029-honor-session-control-signals.md
@@ -1,0 +1,884 @@
+# Proposal 029 — Honor Session-Control Signals from Backend Metadata
+
+## Status: Draft (seed)
+
+## Origin
+
+Conversation 2026-04-22. After a farewell or an explicit "start a new
+session" ask, the backend agent will know the conversation is over but there
+is currently no channel to tell voice-agent to release the mic or swap to a
+new session. voice-agent must learn to honour two new signals the backend
+will emit.
+
+## Prerequisites
+
+- 015-tts-response-playback and 024-chat-screen — the existing chat reply
+  consumption path
+- 025-shared-api-layer — the shared response model that will carry the new
+  metadata fields
+- 014-recording-mode-overhaul — recording lifecycle the signals will control
+
+All three are implemented.
+
+**Cross-project pair:** personal-agent proposal P049
+(`session-control-signals.md`) defines the server contract. Both must ship
+together.
+
+## Scope
+
+- Risk: Medium — signals alter microphone and session lifecycle from a
+  remote source; silent mishandling confuses the user
+- Layers: core/network (response parsing), core/session_control (new
+  dispatcher + bus; see architecture caveat below), features/api_sync
+  (wires sync worker into the bus), features/recording (session + recorder
+  handlers)
+- Expected PRs: 1
+
+## Problem Statement
+
+Today the voice-agent is the sole authority on session and recorder state.
+The backend can detect end-of-conversation and new-session intents, but has
+no way to act on them. Consequences:
+
+- After a farewell, the recorder keeps listening; ambient noise becomes
+  input for the same conversation.
+- Voice-only requests like "zacznij nową sesję" cannot be fulfilled — the
+  user must tap the mobile UI.
+- No hook exists for future proactive agent behaviour (e.g. agent-initiated
+  conversation close after extended idle).
+
+## Are We Solving the Right Problem?
+
+**Root cause:** The voice-agent process is the sole authority over both
+`conversation_id` and the microphone/VAD session lifecycle. The backend
+sends a text reply that the client plays through TTS; nothing else travels
+back. There is no declarative channel for the backend to advise the client
+to release the mic or open a fresh conversation. The `ApiClient.post()`
+response body contains only `message` and `language`
+(`lib/features/api_sync/sync_worker.dart:184-201`); `SyncWorker._handleReply()`
+ignores anything else. P025 extends the shared domain models but does not
+yet carry session-control metadata.
+
+**Alternatives dismissed:**
+
+- *Client-side heuristic for farewell detection.* Rejected. Requires the
+  client to re-run NLP (or string matching) on either user input or agent
+  reply. That logic already lives on the backend as a deterministic
+  post-processor inside `chat.Service.Chat` (P049 §Classifier
+  Responsibility — `DefaultSessionControlEmitter`, a server-side rule-based
+  emitter; **not** a ChatAgent prompt-level classifier, the LLM is not
+  involved). Duplicating a server-side classifier on a mobile device wastes
+  CPU, battery, and introduces a second place for farewell rules to drift.
+- *User-only control (keep status quo; require the user to stop recording
+  or tap "new session").* Rejected. Breaks the hands-free contract set by
+  P019/P026/P028 — the user's phone is in their pocket. Forcing a tap to
+  close the session defeats the reason voice mode exists.
+- *Separate websocket/long-poll channel for out-of-band control messages.*
+  Rejected. Adds a second network channel, a second auth surface, a second
+  reconnect policy, and a race where a control message can arrive before
+  the reply it is bound to. The natural carrier is the already-round-tripping
+  reply — one request, one response, signals attached to the same frame.
+
+**Smallest change:** extend the existing chat reply response body with two
+optional boolean fields (`reset_session`, `stop_recording`), parse them in
+the response-mapping layer, dispatch them after TTS completes to the
+`HandsFreeController` and to a new session-id coordinator. No new transport,
+no new auth surface, no new backend endpoint.
+
+## Goals
+
+- Parse the `session_control` object (with boolean `reset_session` and
+  `stop_recording` keys) from the chat reply response body. In v1 the
+  primary carrier is `POST /api/v1/voice/transcript` (the path
+  `SyncWorker` uses today); the same `session_control` envelope is also
+  emitted by `/api/v1/chat` blocking and `/api/v1/chat/stream` SSE
+  `event:result` frames per P049, so the shared parser works for the
+  `features/chat` `ThreadNotifier` forward-compat path too.
+- When `stop_recording` is true: tear down the hands-free session after TTS
+  finishes; leave the app in an idle state that requires a user gesture
+  to re-arm.
+- When `reset_session` is true: close the current conversation, generate a
+  fresh `conversation_id` on next send, keep the hands-free session alive
+  (no mic restart).
+- When both are true: apply `reset_session` first, then `stop_recording`
+  against the new (empty) session.
+- When neither is present (or both false): behave exactly as today.
+- Confirm the applied signal to the user with a toast and a short haptic so
+  the state change is observable without looking at the screen.
+
+## Non-goals
+
+- No backend protocol change beyond the two optional booleans defined by
+  P049 — no semantic version bump, no new envelope, no new endpoint.
+- No telemetry ping back to personal-agent confirming the signal was
+  honoured (deferred; v1 writes only local debug logs).
+- No user-visible toggle to ignore signals ("never auto-stop"). If users
+  report friction after ship, add it in a follow-up — the setting
+  framework already exists (P015 `ttsEnabled`).
+- No changes to VAD, STT, Groq, or the transcript sync queue behaviour.
+- No scheduling of signals ("stop recording in 30 seconds"). Signals apply
+  once, immediately after the current TTS utterance finishes or a bounded
+  timeout fires.
+- No queueing or replay of signals across app restarts — signals are
+  consumed in-memory and discarded.
+
+## User-Visible Changes
+
+A user holding a hands-free conversation with the backend will observe:
+
+- After saying "goodbye" (or any farewell the backend classifies as
+  end-of-conversation), the agent replies with a spoken farewell, then the
+  hands-free green mic indicator disappears and a short toast
+  "Session ended" plus a single haptic tap confirms the mic has been
+  released. To resume, the user must tap the mic button — identical to the
+  post-error recovery path already established by P014.
+- After saying "start a new session" (or any intent the backend classifies
+  as new-conversation), the agent replies with a confirmation ("Starting a
+  new conversation."), the toast reads "New conversation", the haptic fires,
+  the green mic indicator stays on, and the next utterance is tagged with a
+  fresh `conversation_id` invisibly to the user.
+- After the rare double-signal (both booleans true), the user hears the
+  farewell, sees "New conversation" then "Session ended" in rapid
+  succession (or a single consolidated toast — see Solution Design), the
+  mic releases, and the next session opens a fresh conversation.
+
+No new screens, no new settings, no new icons. The only new UI surface is
+two short transient toasts and two short haptic taps.
+
+## Solution Design
+
+### Architecture caveat (dependency rule)
+
+`voice-agent/CLAUDE.md` is explicit: **features cannot import other
+features**. The signals originate in `features/api_sync` (`SyncWorker`)
+and, later, `features/chat` (`ThreadNotifier`, P024). They must act on
+`features/recording` (`HandsFreeController`). A direct import from one
+feature to another is a blocker.
+
+We resolve this by placing the dispatcher and the signal bus in `core/`.
+`features/api_sync` and `features/chat` *produce* signals into a core bus;
+`features/recording` *subscribes* to the same bus via a Riverpod provider.
+Neither importer references the other. This follows the same pattern P015
+used for `TtsService` — a shared concern promoted to `core/` so multiple
+features can consume it without cross-feature imports.
+
+### Directory layout (new + changed)
+
+```
+lib/core/
+  session_control/
+    session_control_signal.dart       — new: Dart model + fromMap
+    session_control_dispatcher.dart   — new: ordering + TTS-wait + toast/haptic
+    session_control_provider.dart     — new: Riverpod providers (dispatcher + bus)
+
+lib/core/network/
+  api_client.dart                     — unchanged (body is already forwarded)
+
+lib/features/api_sync/
+  sync_worker.dart                    — _handleReply parses session_control and
+                                         forwards to SessionControlDispatcher
+
+lib/features/recording/
+  presentation/
+    hands_free_controller.dart        — new handlers exposed (see below)
+```
+
+The `core/session_control/` directory is new and mirrors the structure of
+`core/tts/` introduced by P015. The dispatcher lives in `core/`, not in
+`features/api_sync/`, because P024's `ThreadNotifier` also needs to produce
+these signals once the /chat/stream path carries them. Placing the
+dispatcher in `features/api_sync/` would force `features/chat/` to import
+from another feature.
+
+### Response model extension
+
+The signals arrive in the JSON body of the transcript-sync response (v1
+primary carrier: `POST /api/v1/voice/transcript`) and, via the shared
+parser, in the SSE `result` event carried by P024 (forward-compat). The
+extension lives in `core/session_control/session_control_signal.dart`:
+
+- `SessionControlSignal` — immutable value object with two non-nullable
+  fields: `resetSession: bool`, `stopRecording: bool`; convenience
+  `isNoop` getter (true when both booleans are false).
+- `SessionControlSignal.fromBody(Map<String, dynamic> body)` — reads the
+  `session_control` key. Returns `null` only when the key is **absent**
+  or the value is **not a `Map`**. Returns a non-null
+  `SessionControlSignal` whenever the envelope is present as a map — even
+  if both booleans resolve to false. This distinguishes "field absent"
+  (null, backend emitted nothing) from "field present but no-op"
+  (non-null signal with `isNoop == true`, backend emitted an empty
+  envelope) for audit/debug traceability. Parses strictly `value == true`
+  (no truthy-ness tricks; missing keys → false); unknown keys are ignored
+  (forward-compat: a future third boolean keeps this call non-null even
+  when the current two are false).
+
+**Why `core/session_control/` and not `core/models/`?** The signal type is
+inseparable from the dispatcher — a value object that exists solely to
+drive `SessionControlDispatcher`. `core/models/` is reserved for
+persistence-layer DTOs (`Transcript`, `SyncQueueItem`, `Conversation`,
+etc.) that match a wire schema and round-trip through SQLite. Grouping the
+signal type with its dispatcher mirrors the layout of `core/tts/`
+(`TtsService` + `FlutterTtsService` + `tts_provider`).
+
+The field naming uses camelCase in Dart and maps to snake_case on the
+wire, consistent with every other DTO (`RecordType`, `ConversationEvent`,
+etc.). The wire field names (`session_control`, `reset_session`,
+`stop_recording`) are exactly those defined by P049.
+
+### Dispatcher
+
+The dispatcher lives in
+`lib/core/session_control/session_control_dispatcher.dart`.
+
+**Contract (signatures only, bodies are implementation):**
+
+- `SessionControlDispatcher` constructor takes: `TtsService`,
+  `HandsFreeControlPort`, `SessionIdCoordinator`, `Toaster`,
+  `HapticService`, and an optional `ttsTimeout: Duration` (default 3s,
+  matches P049 §5 "3 seconds, whichever comes first").
+- `Future<void> dispatch(SessionControlSignal signal)` — single entry
+  point. When `signal.isNoop` is true, the dispatcher returns early
+  without waiting for TTS and without firing toast/haptic (no-op
+  envelope is recorded only via `debugPrint` at the entry seam for
+  audit).
+- Concurrent `dispatch` calls are serialised through an internal
+  `Future` chain: a second `dispatch` invocation while a first is in
+  flight queues and runs only after the first settles (including its
+  `_waitForTtsToFinish` stage). This prevents duplicate toast/haptic
+  when the backend emits back-to-back replies each carrying a signal
+  within a single TTS window. Worst case: the second signal observes a
+  ~3s delay while the first's TTS wait plays out.
+
+**Ordering guarantee (canonical — matches P049 §5 byte-for-byte):** when
+both signals are true, the client applies them as:
+
+1. Wait for the current TTS utterance to finish, or 3 seconds, whichever
+   comes first.
+2. Apply `reset_session` — the voice-agent drops its current
+   `conversation_id` **locally** and generates a fresh one on its next
+   outbound request. No new request field; no client-advertised
+   `conversation_id`; the backend does not echo a successor id.
+3. Apply `stop_recording` — stop the mic against the (now empty) session.
+
+Both signals in one reply always land in the correct order. Sequencing is
+enforced inside `dispatch` via `await` between steps; no parallelism.
+
+**Apply-after-TTS guarantee:** the dispatcher observes
+`TtsService.isSpeaking` (already exposed as `ValueListenable<bool>` at
+`core/tts/tts_service.dart:9`) and proceeds either when it flips to
+`false` or when the 3s ceiling fires — whichever comes first. The
+timeout is a safety ceiling: if TTS is stuck, the signal still applies,
+which is the safe default (releasing the mic is better than holding it
+forever).
+
+**Signal bus (core → feature):** Producers call
+`SessionControlDispatcher.dispatch(signal)` directly — the provider
+exposes a single dispatcher instance, so there is no explicit
+Stream-based bus. Riverpod resolution supplies the recording-feature
+handlers via thin `core/`-owned ports (`HandsFreeControlPort`,
+`SessionIdCoordinator`). See below.
+
+**Toast and haptic:** A lightweight `Toaster` abstraction wraps
+`SnackBar` via a `GlobalKey<ScaffoldMessengerState>` owned by
+`app/app.dart`. A parallel `HapticService` wraps `HapticFeedback.lightImpact`
+from `services.dart`. Both live in `core/session_control/` because the
+dispatcher is the only caller; promoting either to a wider `core/ui`
+location is a follow-up. If both signals are true, the dispatcher emits
+two toasts (250 ms apart via the natural sequencing of the `await`s); if
+this reads as noisy in manual smoke, collapse to a single "Session ended,
+new conversation ready" string in a follow-up — not worth the extra
+conditional branching in v1.
+
+### Recorder + session-handler contracts per signal
+
+`HandsFreeController` already exposes:
+
+- `startSession()` (`hands_free_controller.dart:167`) — opens mic + FG service
+- `stopSession()` (`hands_free_controller.dart:229`) — closes mic + FG service,
+  drains in-flight jobs
+- `suspendForTts()` / `resumeAfterTts()` — already used by P028 TTS path
+- `isSuspendedForManualRecording` getter — guard for lifecycle edges
+
+For `stop_recording` we reuse `stopSession()` unchanged. It already flips
+`sessionActiveProvider` to false, stops the foreground service, cancels the
+engine, and drains in-flight jobs — exactly the "release the mic" contract.
+The post-stop state is `HandsFreeIdle`, identical to the state after a
+`HandsFreeSessionError` retry. The mic button on `RecordingScreen` is
+already wired to re-arm from this state on tap (P014 gesture table).
+
+For `reset_session` we need a minimal client-local coordinator. Per the
+canonical contract (P049 §5): reset is entirely client-local — no
+request-side wire change, no client-advertised `conversation_id`, no
+header. The voice-agent drops its local `conversation_id` and generates a
+fresh one on its next outbound request; the backend's existing
+device-id-based conversation stitching handles the new conversation on
+the server side.
+
+**`SessionIdCoordinator` contract** (lives in
+`core/session_control/session_id_coordinator.dart`):
+
+- Holds a private `String?` current conversation id; initial value null
+  (meaning "fresh — backend will create one").
+- `Future<void> resetSession()` — clears the id. Purely client-local:
+  subsequent diagnostic logs tag the new turn as a new conversation.
+  This has no wire effect — no outbound request ever carries the id —
+  so clearing is a signal-of-intent, observable only in logs and
+  telemetry.
+- `String? get currentConversationId` — reads the id for
+  diagnostics/logs.
+- `void adoptConversationId(String id)` — called by `SyncWorker` after a
+  successful reply that returns `conversation_id`, so subsequent sends
+  keep the same local tag.
+
+`SyncWorker` adopts the returned `conversation_id` from each reply and
+uses it purely for client-side correlation (logs, telemetry). **The
+request body shape is unchanged** — no `conversation_id` field is added
+to outbound requests. Reset is observable to the backend only indirectly:
+after reset, the voice-agent's `SyncWorker` allows the backend's existing
+10-minute-inactivity session rollover heuristic to run on the next send,
+or emits a backend-initiated reset on its own follow-up cue.
+
+**No new method on `HandsFreeController` is required for `reset_session`.**
+The hands-free session is conversation-agnostic from the mic's perspective;
+the mic stays open, the VAD stays running, only the local tag changes.
+
+**For `stop_recording`, a port interface is introduced:**
+`HandsFreeControlPort` — a minimal interface placed in `core/` so the
+dispatcher depends on core only, preserving the CLAUDE.md dependency
+rule.
+
+- Port: `lib/core/session_control/hands_free_control_port.dart`
+  (`HandsFreeControlPort`) declares: `Future<void> stopSession()`,
+  `bool get isSuspendedForManualRecording`. (`isSessionActive` is not
+  required by the dispatcher in v1 and is omitted to keep the port
+  minimal; if a future caller needs it, add it via a port extension.)
+- Adapter: `features/recording/presentation/hands_free_controller.dart`
+  declares `implements HandsFreeControlPort`. `HandsFreeController`
+  already exposes `stopSession` and `isSuspendedForManualRecording`
+  (verified at `hands_free_controller.dart:65` and the existing
+  `stopSession` around line 229), so no method-body changes are needed
+  on the controller.
+- Provider: `core/session_control/session_control_provider.dart` declares
+  `handsFreeControlPortProvider`; `app/app.dart` overrides it to delegate
+  to `handsFreeControllerProvider.notifier`.
+
+This is the ports-and-adapters shape CLAUDE.md's architecture implies:
+`core/` owns the port; `features/` owns the adapter; the app wires them.
+No cross-feature import occurs. The GlobalKey backing `Toaster` is owned
+by `_AppState` and exposed through the `toasterProvider` override, not a
+module-level singleton — the Riverpod provider is the DI seam.
+
+### Toast/haptic UX
+
+Toasts use the existing `ScaffoldMessenger` via a global key owned by
+`app/app.dart`. Strings:
+
+- `reset_session` applied → "New conversation"
+- `stop_recording` applied → "Session ended"
+- both → two toasts in sequence (see above)
+
+Each toast has duration `Duration(seconds: 2)` and the default
+`SnackBarBehavior.floating`. Haptic is
+`HapticFeedback.lightImpact()` (Android) / UIImpactFeedbackGenerator light
+(iOS) — the Flutter `HapticFeedback` API already handles both.
+
+Rationale: a screenless user needs a non-visual confirmation; the haptic
+is the primary channel. The toast is redundant for hands-free use but
+useful for a user who happens to be looking at the screen, and costs
+nothing.
+
+### Failure modes
+
+**Signal arrives mid-recording.** Example: VAD is actively capturing a new
+segment (`HandsFreeCapturing`) when the previous segment's reply carrying
+`stop_recording=true` arrives. The dispatcher `await`s TTS completion; by
+the time TTS finishes, the mid-recording segment has either finished
+(engine returned to `HandsFreeListening`) or is still capturing. In either
+case `stopSession()` is safe: it interrupts the engine, drains in-flight
+jobs (with the same 10-second bounded drain already in
+`hands_free_controller.dart:_drainInFlightJobs`), and emits `HandsFreeIdle`.
+The in-flight segment's transcript is preserved if it reaches `Persisting`
+before the drain deadline; otherwise its WAV file is cleaned up.
+
+**Signal conflicts with user action.** Example: user taps the mic button
+during TTS to force manual recording (P014 interrupt path). The dispatcher
+is still `await`ing TTS. When the user taps:
+
+1. `RecordingScreen._onTap` calls
+   `ttsService.stop()` — TTS flips to `isSpeaking=false` — dispatcher's
+   listener resolves the completer and the dispatcher proceeds to
+   `stopSession()`.
+2. But before the dispatcher acquires `HandsFreeControlPort`, the user's
+   `suspendForManualRecording()` has already fired.
+3. The dispatcher's `stopSession()` runs anyway. The controller handles
+   this: it no-ops on `HandsFreeIdle`, and from
+   `HandsFreeSuspendedForManualRecording` it tears down the manual
+   recording path cleanly via `RecordingController.cancelRecording` (the
+   existing background-pause path) plus controller-level teardown.
+
+Solution: the dispatcher reads
+`HandsFreeControlPort.isSuspendedForManualRecording` before calling
+`stopSession()`. Canonical authority statement (mirrored byte-for-byte
+in personal-agent P049): **Backend emits signals advisory; client may
+honor with delay or fail-safely. On `stop_recording`, the client always
+honors (no opt-out in V1). On `reset_session`, the client honors after
+TTS completion.** Concretely, the suspended-for-manual-recording branch
+is a *delayed* honor on `stop_recording` — the client still honors the
+signal, but only after the user-initiated manual segment completes; the
+dispatcher does not call `stopSession()` mid-manual-recording because
+the already-active `HandsFreeController` teardown from the manual path
+will handle the mic release on its own. Toast and haptic are suppressed
+in that branch so the user sees no conflicting feedback.
+
+For `reset_session` the conflict is simpler: resetting the
+`currentConversationId` has no user-visible effect until the next send,
+and any in-flight user-initiated send has already captured the previous
+id — no race.
+
+**TTS fails or never starts.** Example: TTS is disabled in settings
+(`getTtsEnabled() == false`), or `flutter_tts` throws silently, or the
+reply body has no `message` field (TTS is not invoked). The dispatcher's
+`_waitForTtsToFinish` checks `ttsService.isSpeaking.value` first; if
+already false, it returns immediately. If the listener never fires (TTS
+stuck mid-utterance), the 3-second timeout (canonical per P049 §5) fires and
+the signal applies anyway.
+
+Order-of-signal-arrival edge: the signal must be handed to the
+dispatcher only *after* the reply's TTS utterance has actually started,
+so the dispatcher's first read of `isSpeaking.value` reliably observes
+`true` (when TTS plays) or `false` (when TTS is disabled / silently
+dropped).
+
+The current `_handleReply` calls
+`unawaited(ttsService.stop().then((_) => ttsService.speak(...)))` —
+`isSpeaking` does not flip to `true` synchronously on return from
+`stop()`, and the `.then(speak)` callback runs several event-loop
+turns later. If `dispatcher.dispatch(signal)` is scheduled between
+`stop()` returning and `speak()` actually starting, the dispatcher can
+observe `isSpeaking == false`, return immediately, and apply the
+signal before the farewell utterance is produced — cutting off the TTS
+the user is supposed to hear.
+
+**V1 fix (adopted):** `_handleReply` is changed to
+`await ttsService.stop()` first, then `await ttsService.speak(...)` to
+the point where `speak()` has returned (which resolves after the
+TTS engine's start-handler has flipped `isSpeaking` to `true`), and
+only then calls `dispatcher.dispatch(signal)` via `unawaited(...)`.
+This makes the dispatcher's first `isSpeaking.value` read
+deterministic: `true` when TTS is playing, `false` only when TTS is
+disabled or threw. No dispatcher-side grace window is needed.
+
+### Integration point: `SyncWorker._handleReply`
+
+The current handler
+(`lib/features/api_sync/sync_worker.dart:184-201`) parses `message` and
+`language` and calls `ttsService.speak`. The contract change:
+
+- Change the existing TTS invocation from fire-and-forget
+  `unawaited(ttsService.stop().then((_) => ttsService.speak(...)))` to
+  a sequenced `await ttsService.stop(); await ttsService.speak(...)`
+  so that by the time the next line runs, `ttsService.isSpeaking` has
+  deterministically flipped to `true` (or stayed `false` if TTS is
+  disabled / threw). See §Failure modes "Order-of-signal-arrival edge".
+- After the sequenced TTS kick, call
+  `SessionControlSignal.fromBody(json)` on the decoded body.
+- When non-null, dispatch via the injected
+  `SessionControlDispatcher.dispatch(signal)`. The call is `unawaited` so
+  the sync drain loop does not block on TTS completion + signal handling
+  (which can take seconds). Dispatch exceptions must be caught inside
+  `dispatch` (or logged via `debugPrint` at the catch seam) so
+  `unawaited` does not swallow errors silently.
+- The existing catch-all (non-JSON/unexpected shape → stay silent) is
+  preserved.
+
+`sessionControlDispatcher` is injected into `SyncWorker` via the
+constructor; `syncWorkerProvider` supplies
+`ref.watch(sessionControlDispatcherProvider)`.
+
+### Chat feature hook (forward-compat, deferred to Known Compromises)
+
+When `features/chat` P024 `ThreadNotifier` handles the SSE `result` event,
+it will call `SessionControlSignal.fromBody(resultJson)` on the decoded
+`result` payload and dispatch through
+`sessionControlDispatcherProvider` (same shared instance). No
+feature-to-feature import: both features reach into
+`core/session_control/`. This hook is out of scope for the three
+in-scope tasks below because the chat feature does not currently drive
+the hands-free recorder; the dispatcher's `stopSession` is a no-op on
+`HandsFreeIdle`, so wiring it later is safe. Called out here so the
+design is forward-compatible.
+
+## API Contracts
+
+Wire format (matches P049 T1/T3 exactly):
+
+```json
+{
+  "message": "Goodbye.",
+  "language": "en",
+  "session_control": {
+    "reset_session": false,
+    "stop_recording": true
+  }
+}
+```
+
+- `session_control` is optional; absence (key missing or value is not a
+  `Map`) is parsed as `null` on the client and carries no side effect.
+- When the envelope is present as a map, both booleans default to false
+  if missing. Missing keys are not an error. The client parses this as
+  a non-null no-op `SessionControlSignal` (`isNoop == true`) — the
+  dispatcher returns early without side-effects but the envelope's
+  presence is recorded for audit/debug. This preserves the distinction
+  between "backend sent nothing" and "backend sent an empty envelope"
+  and keeps forward-compat when a third boolean lands.
+- Per P049 the backend only attaches the envelope when at least one
+  known boolean is true, so the no-op branch is defensive: it becomes
+  reachable if a future backend version emits an envelope whose only
+  `true` key is one this client does not yet understand.
+- Any extra keys in `session_control` are ignored (forward-compat).
+
+Dart type shape (declared in
+`core/session_control/session_control_signal.dart`):
+
+- `class SessionControlSignal` — fields `resetSession: bool`,
+  `stopRecording: bool`; getter `isNoop` (true when both booleans are
+  false); static factory
+  `SessionControlSignal? fromBody(Map<String, dynamic> body)` parsing the
+  canonical envelope. Returns `null` only for absent key or non-`Map`
+  value; returns a non-null signal (possibly with `isNoop == true`) when
+  the envelope is present. The dispatcher is responsible for handling
+  the no-op branch (early return, no toast/haptic, no side-effect).
+
+No change to `ApiResult` / `ApiSuccess.body` — the body is already
+forwarded raw to `_handleReply`.
+
+No change to outbound request bodies — `reset_session` is client-local
+per canonical (P049 §5).
+
+No change to backend wire format beyond what P049 defines. P049 is the
+server contract source of truth; this document records the expected
+shape for verification.
+
+## Affected Mutation Points
+
+**New files:**
+
+- `lib/core/session_control/session_control_signal.dart` — value object
+  and `fromBody` constructor (see code above).
+- `lib/core/session_control/hands_free_control_port.dart` — `HandsFreeControlPort`
+  interface with three methods: `stopSession`, `isSessionActive`,
+  `isSuspendedForManualRecording`.
+- `lib/core/session_control/session_id_coordinator.dart` — holds
+  `currentConversationId`; exposes `resetSession()` and a getter.
+- `lib/core/session_control/toaster.dart` — wraps
+  `ScaffoldMessengerState` via a global key; `show(String message,
+  {Duration duration})`.
+- `lib/core/session_control/haptic_service.dart` — wraps
+  `HapticFeedback.lightImpact`.
+- `lib/core/session_control/session_control_dispatcher.dart` — the
+  dispatcher class described above; owns TTS-wait, ordering, toast/haptic.
+- `lib/core/session_control/session_control_provider.dart` — Riverpod
+  providers: `sessionControlDispatcherProvider`,
+  `sessionIdCoordinatorProvider`, `handsFreeControlPortProvider`
+  (overridden in `app/app.dart`), `toasterProvider`, `hapticServiceProvider`.
+
+**Needs change:**
+
+- `lib/features/api_sync/sync_worker.dart` — add `sessionControlDispatcher`
+  and `sessionIdCoordinator` constructor parameters; extend
+  `_handleReply` to parse the `session_control` envelope and dispatch.
+  Preserve every existing behaviour — TTS playback, `onAgentReply`
+  callback, error handling on malformed body. On successful reply that
+  carries `conversation_id`, call `adoptConversationId` for client-side
+  correlation (no request-side change).
+- `lib/features/api_sync/sync_provider.dart` — wire
+  `sessionControlDispatcherProvider` and `sessionIdCoordinatorProvider`
+  into `syncWorkerProvider`.
+- `lib/features/recording/presentation/hands_free_controller.dart` — add
+  `implements HandsFreeControlPort` to the class declaration. No method
+  body changes — `stopSession` and `isSuspendedForManualRecording` are
+  already implemented.
+- `lib/app/app.dart` — hold the `GlobalKey<ScaffoldMessengerState>`, pass
+  it to `MaterialApp.scaffoldMessengerKey`, expose it via
+  `toasterProvider` override; override `handsFreeControlPortProvider` to
+  delegate to `handsFreeControllerProvider.notifier`.
+- `lib/features/recording/presentation/recording_providers.dart` — nothing
+  structural; the `handsFreeControllerProvider` already exists.
+
+**No change needed:**
+
+- `lib/core/network/api_client.dart` — request body shape is unchanged.
+  Reset is client-local per canonical (P049 §5); no `conversation_id`
+  request field is added.
+- `lib/features/recording/data/hands_free_orchestrator.dart` — lifecycle
+  is driven entirely by `HandsFreeController`; no need to teach the
+  orchestrator about signals.
+- `lib/core/tts/*.dart` — TTS interface already exposes
+  `isSpeaking` as a `ValueListenable<bool>`.
+- `lib/features/chat/` — no v1 change; forward-compat integration noted
+  in Solution Design is deferred.
+
+## Test Impact / Verification
+
+**Dispatcher unit tests (T1)** (new,
+`test/core/session_control/session_control_dispatcher_test.dart`):
+
+One test per signal combination:
+
+- `dispatch(signal(reset=true, stop=false))` → after fake TTS finishes,
+  `sessionIdCoordinator.resetSession` called once, `stopSession` not
+  called, toaster.show called with "New conversation", haptic fires.
+- `dispatch(signal(reset=false, stop=true))` → `resetSession` not called,
+  `stopSession` called once, toast "Session ended", haptic fires.
+- `dispatch(signal(reset=true, stop=true))` → both called, `resetSession`
+  fires strictly before `stopSession` (verified via a recorded call-log
+  list).
+- `dispatch(noop signal)` → dispatcher returns early; `resetSession`
+  not called, `stopSession` not called, no toast, no haptic, no TTS
+  wait. Separate test on `SessionControlSignal.fromBody` asserts
+  `{"session_control": {"reset_session": false, "stop_recording": false}}`
+  returns a **non-null** `SessionControlSignal` with `isNoop == true`
+  (distinguishing "envelope present but no-op" from "envelope absent").
+- TTS never starts (`isSpeaking` starts false) → dispatcher applies
+  immediately.
+- TTS stuck (`isSpeaking` stays true for > 3s timeout) → dispatcher
+  applies after timeout fires.
+- `isSuspendedForManualRecording == true` before `stopSession` call →
+  `stopSession` is not invoked; toast/haptic are also suppressed.
+- Concurrent `dispatch` calls: two back-to-back `dispatch` invocations
+  are serialised — the second does not start its TTS-wait / side-effect
+  stage until the first's `Future` resolves. Recorded call log asserts
+  ordering.
+
+**`sync_worker_test.dart` updates (T2)**
+(`test/features/api_sync/sync_worker_test.dart`):
+
+- New case: `ApiSuccess.body` containing
+  `{"message": "...", "session_control": {"reset_session": false, "stop_recording": true}}` →
+  mocked `sessionControlDispatcher.dispatch` called once with
+  `stopRecording: true, resetSession: false`.
+- Existing case: body with only `message` → dispatcher NOT called (asserted).
+- Existing case: malformed JSON body → dispatcher NOT called, no
+  exception bubbles up.
+- Replace the `FakeSessionControlDispatcher` (v1 test double) with a
+  recorded-calls list so ordering of TTS vs dispatch is asserted where
+  relevant.
+
+**Widget integration tests per signal combination (T3)**
+(`test/features/api_sync/sync_worker_integration_test.dart`, pumps a
+minimal `ProviderScope` with overrides):
+
+- Combo A — stop-only: `ApiClient` returns body with
+  `session_control.stop_recording=true` → `HandsFreeController` transitions
+  to `HandsFreeIdle`, `ScaffoldMessenger` shows "Session ended", one
+  haptic fires.
+- Combo B — reset-only: body with
+  `session_control.reset_session=true` → `sessionIdCoordinator` cleared,
+  `ScaffoldMessenger` shows "New conversation", session stays active.
+- Combo C — both: body with both booleans true → reset applied first,
+  then stop; both toasts in order; both haptics fire.
+- Combo D — envelope present but both false: `fromBody` returns a
+  non-null no-op signal; dispatcher is invoked but returns early
+  (`isNoop` branch) without calling `stopSession`/`resetSession` and
+  without showing a toast/haptic; behaviour observable to the user is
+  identical to today.
+
+**Unit test** (`test/core/session_control/session_control_signal_test.dart`):
+
+- `fromBody` with full payload (both true) → non-null signal, both
+  booleans true, `isNoop == false`.
+- `fromBody` with absent `session_control` key → null.
+- `fromBody` with `session_control` value that is not a `Map` (e.g. list,
+  string) → null.
+- `fromBody` with `session_control` present as a map but both booleans
+  false (`{"reset_session": false, "stop_recording": false}`) → non-null
+  signal, `isNoop == true` (distinguishes envelope-present-no-op from
+  envelope-absent; forward-compat for a future third boolean).
+- `fromBody` with missing `reset_session` or `stop_recording` keys inside
+  a present map → treat as false; non-null signal returned.
+- `fromBody` with extra unknown keys inside a present map → ignored;
+  non-null signal returned.
+
+**Manual smoke** (required before marking implemented):
+
+- iOS iPhone 12 Pro and Android 14+ release builds.
+- Scenario 1: "goodbye" → backend (P049) emits `stop_recording: true` →
+  TTS farewell plays → toast + haptic → green mic disappears → tap mic →
+  session re-arms.
+- Scenario 2: "zacznij nową sesję" → backend emits `reset_session: true`
+  → TTS confirms → toast + haptic → next utterance lands on a new backend
+  conversation id (verified by checking personal-agent logs).
+- Scenario 3: a reply that carries both signals → both toasts + haptics
+  fire in order; session is ended; next tap opens a fresh conversation.
+- Scenario 4: a reply with no `session_control` → identical to today (no
+  toast, mic stays).
+- Scenario 5: with TTS disabled in settings → signal still applies after
+  ~100ms (immediate return from `_waitForTtsToFinish`).
+
+**Commands:** `flutter analyze && flutter test`. The dependency-rule
+check script in `voice-agent/CLAUDE.md:40-51` must still print OK for
+`lib/features/api_sync/` and `lib/features/recording/`.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| **Dependency-rule violation.** `SyncWorker` (api_sync) acting on `HandsFreeController` (recording) is a cross-feature import. | Mandatory: dispatcher + ports live in `core/session_control/`. `features/recording` implements `HandsFreeControlPort`; `features/api_sync` depends only on the core dispatcher. Run the `grep` checks in `voice-agent/CLAUDE.md` as part of CI before merge. |
+| TTS race: signal applies before farewell finishes, cutting off the user's last feedback. | `SessionControlDispatcher._waitForTtsToFinish` listens on `TtsService.isSpeaking` and waits up to 3 seconds (canonical per P049 §5). Unit tests cover both the "TTS finishes normally" and "TTS timeout" paths. |
+| TTS failure: `flutter_tts` silent drop leaves `isSpeaking=true` forever, stalling the signal. | 3-second hard timeout in `_waitForTtsToFinish` (canonical). The signal applies regardless — releasing the mic on timeout is strictly safer than holding it. |
+| User taps mic during TTS, overriding signal. | Dispatcher reads `HandsFreeControlPort.isSuspendedForManualRecording` before calling `stopSession`. Per canonical (P049 §Are We Solving the Right Problem?): backend emits signals advisory; client honors `stop_recording` always, honors `reset_session` after TTS completion — when the user has entered manual recording the dispatcher skips the direct `stopSession()` call and lets the manual-recording teardown handle mic release, which preserves the "always honor" guarantee with delay. |
+| iOS audio-session conflict (TTS `playback` ↔ mic `playAndRecord`) when `stopSession` fires immediately after TTS. | `HandsFreeController.stopSession` stops the foreground service and engine in the correct order already established by P026/P028 — the same flow that runs on user-initiated stop. No new conflict is introduced. |
+| Android 14+ foreground-service killer fires when `stopSession` tears down the service right after TTS. | `stopService` is idempotent; the FG service type set by P028 covers both `microphone` and `mediaPlayback` simultaneously. Post-stop, no FG service is required (app can be backgrounded or foregrounded). No new constraint. |
+| Backend emits conflicting signals rapidly (e.g. two replies in < 1s each carrying different signals). | Dispatcher serializes concurrent `dispatch()` calls via an internal `Future` chain (or a short queue), so the second waits for the first's `_waitForTtsToFinish` to return. Worst case: a ~3s delay on the second signal. Duplicate toasts/haptics are avoided by design. |
+| `reset_session` is purely client-local (no request-side wire change per canonical P049 §5). Observable behaviour depends on the backend's device-id-based conversation stitching on the next send. | Unit test on `SessionIdCoordinator.resetSession()` asserts the local id is cleared; integration test asserts the dispatcher calls `resetSession()` once. End-to-end new-conversation behaviour is verified via manual smoke scenario 2 (checking personal-agent logs). |
+| P049 names its fields differently at ship time (`session_control` → `client_commands`, etc.). | `SessionControlSignal.fromBody` is a single-file change. Coordination is handled by T1 (below) which explicitly couples the two PRs' merge timing. |
+| Toasts are noisy for users who happen to be looking at the screen when both signals fire. | v1 accepts two sequential toasts. If field reports call this out, follow up by merging the strings into one toast. Not worth a branch in v1. |
+| `flutter_tts` may not call `setCompletionHandler` on some Android devices (known quirk). | The 3-second timeout protects against this. Separately, manual smoke on Android 14 during implementation T1 verifies the happy-path firing. If widespread, we add an additional TTS-finished signal based on `tts.awaitSpeakCompletion`. |
+
+## Alternatives Considered
+
+- **Client-side farewell detection.** See "Are We Solving the Right
+  Problem?" — rejected. Duplicates logic, drifts from backend rules,
+  wastes battery.
+- **Separate websocket for control messages.** Rejected. Two network
+  channels; new auth surface; out-of-order risk.
+- **User-only control (do nothing).** Rejected. Defeats the hands-free
+  contract.
+- **Eager signal application (skip TTS wait).** Rejected. Cutting off
+  the farewell is worse UX than a 1–2s delay; the farewell is the signal
+  to the user that the session is ending.
+- **Persist signals across app restarts.** Rejected. A signal observed
+  but not applied during a crash is irrecoverable context — the next app
+  start is a new universe; if the backend still wants the session reset
+  or mic released, it will emit the signal again on the next reply.
+- **One-shot bus (Stream + broadcast) instead of direct dispatcher.**
+  Considered and rejected. A Stream bus adds a subscriber lifecycle that
+  the dispatcher's `async` method already provides in-line. Direct method
+  call on the singleton dispatcher is simpler and test-friendlier.
+- **Put the dispatcher in `features/api_sync/`.** Rejected — violates the
+  dependency rule once P024's `ThreadNotifier` needs to emit signals too.
+  See "Architecture caveat".
+- **Use a sealed class hierarchy for signals (`class
+  ResetSessionSignal`, `class StopRecordingSignal`).** Considered. A flat
+  struct with two booleans is simpler for a value object defined by two
+  independent booleans. If a third signal arrives that cannot be
+  orthogonal (e.g. "continue session with a new persona"), promote to
+  sealed at that time — pure refactor, no contract change.
+
+## Known Compromises and Follow-Up Direction
+
+- **Chat feature not wired in v1.** `features/chat` P024 `ThreadNotifier`
+  can reach the same dispatcher (the provider is in `core/session_control/`)
+  but does not currently drive the hands-free recorder. The dispatcher
+  will no-op on `stopSession` when the session is already idle, so a
+  future hook is safe. Follow-up: when `ThreadNotifier` parses
+  `session_control` in `ChatResult`, wire it into the same dispatcher.
+- **No telemetry on signal-applied.** Backend cannot verify the client
+  honoured the signal. Acceptable for v1; if abuse/misbehaviour appears
+  in production we add a `POST /api/v1/session-control/ack` ping.
+- **Toast copy is hard-coded English.** `voice-agent/CLAUDE.md` requires
+  English in code; user-visible strings will be localised in a future
+  proposal that introduces an ARB/i18n infrastructure. Until then, the
+  same English strings ship to all users.
+- **`SessionIdCoordinator.currentConversationId` is a plain field, not
+  persisted.** An app restart forgets the id — but that also implies a
+  fresh hands-free session, which implies a fresh backend conversation,
+  so the observable behaviour is correct. Follow-up if this ever needs
+  to survive process death.
+- **`HapticService` is a thin wrapper.** If we add more haptic patterns
+  (long press, success pattern), promote to `core/platform/haptic/`.
+- **Toast throttling.** Back-to-back dispatches may stack two toasts
+  before the first is dismissed. `ScaffoldMessenger` handles that via its
+  internal queue; the visual effect is one toast replacing another
+  quickly. Acceptable for v1.
+- **No rate-limit on backend signals.** If the backend ever emits
+  `stop_recording` on every reply (bug), the client honours each one.
+  Harmless (second `stopSession` on an already-idle session is a no-op)
+  but worth catching in an observability pass.
+- **3-second TTS ceiling is shorter than typical Polish farewells.**
+  P049 §5 sets the apply-after-TTS ceiling at 3s. A Polish confirmation
+  utterance like "Jasne, zaczynamy od nowa, powiedz o czym chcesz
+  pogadać dzisiaj" runs ~8–9s at normal TTS cadence, so in the common
+  case the 3s ceiling fires *before* natural TTS completion and the
+  farewell is cut short (mic releases while the utterance is still
+  playing — the farewell continues on the speaker but the recorder
+  stops). This is accepted for v1 as a predictability-over-polish
+  trade-off: a hard ceiling prevents a stuck TTS from holding the mic
+  forever, and the 3s value is canonical cross-project. If field
+  feedback flags this as jarring, widen to 15s in a coordinated
+  follow-up with P049 (both sides of the contract must agree).
+- **Forward-compat chat feature hook is deferred.** When
+  `features/chat` P024 `ThreadNotifier` gains the ability to drive the
+  hands-free recorder (not today), wire it to call
+  `SessionControlSignal.fromBody` on the SSE `result` payload and
+  dispatch through the same `sessionControlDispatcherProvider`. The
+  dispatcher no-ops on `stopSession` when the session is already idle,
+  so wiring later is safe. This was previously listed as T4 in the
+  Tasks table; it is not in-scope work for v1 and moves here to avoid
+  blocking reviewers on deferred surface.
+
+## Tasks
+
+Each task is an independently mergeable PR with tests. Implementation
+order: T1 → T2 → T3. Each compiles and passes CI on its own when merged
+alone.
+
+| # | Task | Layer | Notes |
+|---|------|-------|-------|
+| T1 | **Core skeleton.** Define `SessionControlSignal` + `fromBody`, `HandsFreeControlPort`, `SessionIdCoordinator`, `Toaster`, `HapticService`, `SessionControlDispatcher`, and the Riverpod providers in `lib/core/session_control/`. Unit tests: `SessionControlSignal.fromBody` (envelope parsing incl. absent-key → null, non-Map → null, present-with-both-false → non-null noop signal, missing inner keys → false, extra keys → ignored) and `SessionControlDispatcher` (all eight scenarios in Test Impact: TTS-wait, 3s timeout, suspended-for-manual override, reset-only, stop-only, both, noop-early-return, concurrent-dispatch serialisation). No feature wiring; dispatcher is unreachable from production code. | core/session_control (new), test | Mergeable alone. Same pattern as P049 T1 on the backend. |
+| T2 | **SyncWorker wiring.** Extend `SyncWorker` to take `SessionControlDispatcher` + `SessionIdCoordinator` via constructor; change `_handleReply` to `await ttsService.stop(); await ttsService.speak(...)` before parsing `session_control` and dispatching (deterministic `isSpeaking` observation — see §Failure modes). Update `syncWorkerProvider` to inject both. Extend `sync_worker_test.dart` with: (a) body containing `session_control.stop_recording=true` → dispatcher called once with matching flags; (b) body with only `message` → dispatcher NOT called; (c) malformed JSON → dispatcher NOT called, no exception bubbles; (d) dispatch is scheduled only after `ttsService.speak` has returned. **Coordinate merge with personal-agent P049 T4** (voice transport); the wire contract must match byte-for-byte. | features/api_sync, test | Depends on T1. Coordination gate with P049 T4. |
+| T3 | **HandsFreeController port + app wiring.** Add `implements HandsFreeControlPort` to `HandsFreeController` (no body changes; the two methods already exist). Wire `GlobalKey<ScaffoldMessengerState>` into `app/app.dart`, pass to `MaterialApp.scaffoldMessengerKey`, and register the `handsFreeControlPortProvider` override plus `toasterProvider` override. Decomposed widget integration tests (`test/features/api_sync/sync_worker_integration_test.dart`, pumps a minimal `ProviderScope` with overrides): (a) `stop_recording=true` only → controller goes to `HandsFreeIdle`, "Session ended" toast shown, one haptic; (b) `reset_session=true` only → coordinator cleared, "New conversation" toast shown, session remains active; (c) both → reset applied first then stop, both toasts in order. | features/recording, app, test | Depends on T1 + T2. Decomposed widget tests enforce the dispatch plumbing per signal combination. |
+
+The forward-compat chat hook that previously appeared here as T4 has
+moved to Known Compromises and Follow-Up Direction. It is not a tracked
+task for this proposal's ship; see that section for the deferral
+rationale.
+
+## Acceptance Criteria
+
+1. Reply carrying `session_control.stop_recording=true` stops the
+   recorder after TTS finishes and leaves the session idle, requiring a
+   user tap to resume.
+2. Reply carrying `session_control.reset_session=true` clears
+   `SessionIdCoordinator.currentConversationId` locally. The outbound
+   request body is unchanged (no `conversation_id` request field per
+   canonical P049 §5); there is no interruption in the audio session.
+3. A reply carrying both signals applies `reset_session` first, then
+   `stop_recording`, with both toasts and both haptics firing in the same
+   order.
+4. A reply carrying no `session_control` key (absent) behaves exactly
+   as today: `SessionControlSignal.fromBody` returns `null`, the
+   dispatcher is never invoked, no toast, no haptic, session continues.
+5. A reply with `session_control` present as a map but both booleans
+   false is observably equivalent to no signal, but the parsing path is
+   distinct: `SessionControlSignal.fromBody` returns a non-null signal
+   with `isNoop == true`, the dispatcher is invoked and returns early
+   (no TTS wait, no toast, no haptic, no `stopSession`/`resetSession`
+   call). This asymmetry-by-design preserves the "envelope present but
+   no-op" audit trail and keeps forward-compat: when a third boolean is
+   added to the envelope, a current-generation client parses the new
+   envelope as a non-null signal (third field unknown, current two
+   false) instead of silently dropping it.
+6. If TTS is still speaking when the signal is handed to the dispatcher,
+   the signal waits for `ttsService.isSpeaking` to flip false, or for 3
+   seconds — whichever comes first (canonical per P049 §5).
+7. If the user manually suspends the hands-free session (tap-to-record
+   or press-and-hold) before the dispatcher reaches `stopSession`, the
+   dispatcher skips `stopSession` (user wins).
+8. `flutter analyze` passes with zero issues. `flutter test` passes. The
+   `voice-agent/CLAUDE.md` dependency-rule grep check reports OK for
+   every feature directory.
+9. Manual smoke on iPhone 12 Pro and an Android 14+ device reproduces
+   each scenario in Test Impact.
+
+## Related
+
+- personal-agent proposal P049 session-control-signals (counterpart — wire
+  contract source of truth)
+- 014-recording-mode-overhaul
+- 015-tts-response-playback
+- 024-chat-screen
+- 025-shared-api-layer
+- 028-background-tts
+- P000-backlog entry "Honor session-control signals from backend metadata"

--- a/docs/proposals/030-tts-mixed-language-ssml.md
+++ b/docs/proposals/030-tts-mixed-language-ssml.md
@@ -1,0 +1,711 @@
+# Proposal 030 — TTS Mixed-Language Support via SSML `<lang>` Tags
+
+## Status: Draft (seed)
+
+## Origin
+
+Conversation 2026-04-22. Current TTS pronounces English technical terms
+("API", "action item", "hangover") with a Polish accent, to the point of
+being unintelligible. The decision: TTS must honour mixed-language content,
+with English fragments spoken in English.
+
+## Prerequisites
+
+- 015-tts-response-playback — the current TTS rendering path
+- 028-background-tts — background TTS behaviour and platform-specific
+  foreground service wiring
+
+Both are implemented.
+
+**Cross-project pair:** personal-agent proposal P054
+(`mixed-language-ssml.md`) emits the SSML tags. Without them, client-side
+work is dormant. Without client-side honouring, tags render as raw text.
+
+## Scope
+
+- Risk: Medium — touches TTS engine selection and cross-platform SSML
+  rendering, which differ by platform
+- Layers: `core/tts/` (the domain port + adapter both live here per
+  ADR-ARCH-006), `features/api_sync` (caller that already feeds message
+  text to `TtsService.speak`), `features/recording/presentation`
+  (HandsFreeController — VAD suspend/resume contract must be preserved)
+- Expected PRs: 2 (splitter + wiring, then per-platform verification).
+  A third "cloud TTS fallback" PR is a follow-up, not part of v1.
+
+## Problem Statement
+
+Polish-primary conversations routinely include English technical terms.
+Today those terms are sent to an on-device TTS that applies Polish phonetics,
+producing output that the user cannot understand. Backend proposal P054 will
+wrap those fragments in `<lang xml:lang="en-US">...</lang>`; the client must
+render those tags correctly on both iOS and Android.
+
+## Are We Solving the Right Problem?
+
+**Root cause:** `FlutterTtsService.speak()` in `lib/core/tts/flutter_tts_service.dart`
+calls `_tts.setLanguage(lang)` exactly once per utterance, where `lang` is
+a single resolved locale (e.g. `pl_PL` or `en-US`). The platform engine
+(AVSpeechSynthesizer on iOS, Google/Samsung/Pico TTS on Android) then
+applies that single language's phonetic model to the entire string — so
+an English term inside a Polish sentence is read with Polish phonetics.
+The problem is not the STT output, not the LLM output, and not the TTS
+engine selection; it is that we are asking one voice, once, to speak a
+string that is semantically in two languages.
+
+**Alternatives dismissed:**
+
+- *Correct STT input to turn perceived Polish back into English before
+  sending to the backend.* Rejected. Distorts the user's actual input,
+  which the backend records as canonical conversation history, and does
+  not fix the TTS output problem: even a clean English token still reaches
+  the TTS engine inside a Polish sentence and gets mispronounced. Backend
+  proposal P054 rejects the same alternative for the same reason.
+- *Always route replies through a cloud TTS (ElevenLabs / Azure) that
+  understands SSML natively.* Rejected for v1. Per-request cost,
+  non-trivial latency added to the hands-free flow, and a network
+  dependency on what is currently a zero-cost on-device feature. Cloud
+  TTS remains a follow-up for cases where the on-device engines cannot
+  deliver acceptable quality.
+- *Strip English fragments from the reply before TTS so they are simply
+  not spoken.* Rejected. Loses information — "set the hangover to 800 ms"
+  becomes "set the to 800 ms" — and degrades the reply from a voice
+  assistant to a broken summary.
+
+**Chosen approach — engine-aware split:**
+Parse the `<lang>`-tagged reply client-side into an ordered queue of
+`(text, language)` segments. For each segment, drive the existing
+`flutter_tts` engine with the right `setLanguage(...)` (and on iOS, the
+right `setVoice(...)`) before speaking that segment, then chain the next
+segment on completion. This preserves the current engine, the current
+audio session behaviour (`ambient` per ADR-AUDIO-007, `playAndRecord`
+during sessions per ADR-AUDIO-009), the current VAD suspend/resume
+contract, and the zero-cost on-device model — while giving English
+fragments an English voice.
+
+**Smallest change?** Yes — a pure-Dart splitter plus a per-segment
+queuing wrapper inside `FlutterTtsService`. No new engine, no new
+permission, no new platform channel. Tagged replies from P054 render
+correctly; untagged replies follow the existing single-segment path.
+
+## Goals
+
+- A reply containing `<lang xml:lang="en-US">API</lang>` is spoken with
+  English phonetics on both iOS and Android release builds.
+- No literal SSML tag audio reaches the user on any platform or any
+  engine — tags are always stripped before they reach a speech synth.
+- Untagged replies sound identical to the current 015/028 behaviour.
+- The VAD suspend/resume contract from 028 is preserved — TTS still
+  signals `ttsPlayingProvider` so `HandsFreeController.suspendForTts()`
+  and `resumeAfterTts()` fire at utterance boundaries.
+
+## Non-goals
+
+- **No arbitrary language pairs.** v1 covers PL + EN only. If a reply
+  contains `<lang xml:lang="de-DE">`, the segment is handled as a
+  best-effort on whatever voice the platform picks for `de-DE`; we do
+  not ship or configure German voices.
+- **No voice customization beyond default PL/EN voices.** iOS picks the
+  best available system voice per language (same premium/enhanced/normal
+  selection `_bestVoice()` already does for the single-language case);
+  Android uses `setLanguage()` with whatever engine the user has
+  installed. No settings UI for picking voices.
+- **No cloud TTS integration in v1.** Cloud fallback is explicitly
+  deferred (see Known Compromises and the T4 follow-up task).
+- **No streaming SSML from a partial reply.** The reply comes from
+  `SyncWorker._handleReply` as a complete string; we do not need to
+  parse partial `<lang>` tags arriving mid-stream.
+- **No changes to backend SSML shape.** The shape is defined by P054
+  and we consume it; we do not negotiate or propose alternatives here.
+
+## User-Visible Changes
+
+- With a P054-enabled backend: a reply like
+  `Ustawiłem <lang xml:lang="en-US">hangover</lang> na 800 ms.` is
+  heard as a Polish sentence with an English "hangover" in the middle,
+  rather than Polish phonetics applied to "hangover".
+- Without a P054-enabled backend: zero change — untagged replies play
+  via the existing single-segment path.
+- No new UI, no new setting, no new permission. The existing Settings
+  toggle "Read API response aloud" still gates all TTS output.
+- Brief pauses (tens to low-hundreds of ms) appear at language
+  boundaries where one utterance stops and the next begins. Acceptable
+  for v1 — better than mispronunciation.
+
+## Solution Design
+
+### SSML splitter (pure Dart, new file in `core/tts/`)
+
+New class `SsmlLangSplitter` in `lib/core/tts/ssml_lang_splitter.dart`.
+Input: the raw reply string (possibly containing `<lang xml:lang="…">…</lang>`).
+Output: an ordered `List<TtsSegment>` where each segment has `text` (tag-free)
+and `languageCode` (nullable — `null` means "use the default language this
+reply was invoked with", i.e. fall through to the existing
+`_resolveLanguage` path).
+
+Parser contract:
+
+- Walk the input left-to-right. Outside any tag, accumulate text as a
+  default-language segment. On encountering a well-formed
+  `<lang xml:lang="xx-YY">…</lang>` matching the P054 canonical shape
+  exactly, close the current default segment (if non-empty) and emit
+  one tagged segment with `languageCode = "xx-YY"` and `text = <inner>`.
+- **Case-sensitive matcher — canonical shape only.** The matcher
+  requires the exact lowercase element name `lang`, exact lowercase
+  attribute name `xml:lang`, double-quoted value, and BCP-47 value
+  formatted as `xx-YY` (lowercase primary, uppercase region). This
+  matches P054's lowercase-only emission contract byte-for-byte. Any
+  other casing (`<LANG>`, `<Lang xml:lang="EN-US">`, single-quoted
+  attribute, missing attribute, extra attributes before `xml:lang`) is
+  treated as **malformed** and falls through to the plain-text pathway
+  — the tag characters are preserved in the default-language segment
+  and pronounced literally. This surfaces any backend drift audibly
+  (loud, ugly, visible in logs) instead of silently failing over to
+  Polish phonetics on an unrecognised tag.
+- **Value passed through unchanged** to `_tts.setLanguage(value)` and
+  `_bestVoice(value)`. Both platforms accept the canonical `xx-YY` form
+  directly: iOS `AVSpeechSynthesisVoice.speechVoices()` returns
+  language codes in `xx-YY` form; Android `Locale.forLanguageTag`
+  accepts it natively. No client-side normalization is performed or
+  needed — if the value diverges from `xx-YY`, it failed the canonical
+  matcher above and the segment is plain text.
+- Nested `<lang>` is not supported in v1. On encountering a nested
+  open-tag while inside an outer `<lang>` region, the splitter adopts
+  rule (a): **inner wins, outer text around it emits as outer-language
+  segments**. Example:
+  `<lang xml:lang="en-US">Check the <lang xml:lang="pl-PL">polityka</lang> API</lang>`
+  produces three tagged segments: `[(en-US, "Check the "), (pl-PL,
+  "polityka"), (en-US, " API")]`. A log line records the nesting.
+  Backend P054 does not emit nested tags today; this rule is defensive.
+- **Malformed tags are emitted as plain text** (tag characters included
+  literally — we do not strip them silently, because that would hide
+  backend bugs; a visible-in-logs tag is louder than a pronounced one).
+  Cases: missing closing tag, missing or misspelled `xml:lang`
+  attribute, unmatched `</lang>`, wrong casing, single-quoted attribute,
+  any other parse failure. The splitter must never throw — on any
+  unexpected input it falls back to a single default-language segment
+  carrying the original string.
+- If the input begins with a `<speak>...</speak>` SSML envelope (P054
+  does not emit one today, but future revisions might), the outer
+  envelope is stripped before segmentation; content inside is parsed
+  normally. Low-cost defensive parse — keeps the contract
+  forward-compatible.
+- Whitespace between segments is preserved as part of the adjacent
+  default-language segment — we do not "trim" across tag boundaries.
+  Trailing/leading empty default-language segments are elided.
+- **Empty input** (`text == ""` or whitespace-only): splitter returns
+  zero segments. `FlutterTtsService.speak()` early-returns in this case
+  without touching `_tts`; `_speaking` stays `false`,
+  `ttsPlayingProvider` never fires. No native speak call, no listener
+  churn. Callers (`_handleReply`) are unaffected — `onAgentReply` still
+  fires with the original (empty) message.
+- No regex-only parser. Use a hand-rolled state machine so nested or
+  adjacent tags don't catastrophically misparse. The logic is small
+  (~40 lines) and fully unit-testable.
+
+This is a pure Dart class with zero platform dependencies — easy to
+unit test with high coverage and zero flakiness.
+
+### Integration point: `FlutterTtsService.speak()`
+
+Currently `FlutterTtsService.speak(text, languageCode: …)` does:
+
+1. Resolve language.
+2. `_tts.setLanguage(lang)` (and on iOS `_tts.setVoice(voice)` if a
+   better one exists).
+3. `_tts.speak(text)` — a single call, returns before playback finishes,
+   fires `_tts.setCompletionHandler` on end.
+
+Change: at the top of `speak()`, run the text through
+`SsmlLangSplitter.split(text)`:
+
+- If the result is a single segment with no explicit language override,
+  follow exactly the current path — zero behaviour change for untagged
+  replies.
+- Otherwise, enter a per-segment queuing loop (see below).
+
+### Per-segment queuing loop
+
+A `speak()` call with N segments becomes N sequential `_tts.speak(...)`
+calls, chained on the completion/error handlers. The queuing loop is the
+**enclosing guard** that keeps `_speaking.value` high for the entire
+logical utterance — the single invariant VAD depends on.
+
+**State on the service instance:**
+- `_SegmentQueue? _activeQueue` — nullable. Holds: remaining segments,
+  resolved default language, a monotonically-increasing `int generation`
+  (bumped every time a new queue starts), and a
+  `Completer<void> doneCompleter` that fires when the last segment ends
+  or when `stop()`/`dispose()` cancels.
+- `bool _queueEntered` — internal flag set `true` on first
+  `_tts.speak(segment[0])` of a queue, reset to `false` only when the
+  queue drains or is cleared.
+
+**Handler wiring (explicit):**
+- `setStartHandler`: on fire, if `_speaking.value == false`, set it to
+  `true`. On subsequent segments within the same queue, `_speaking` is
+  already `true`, so this is a no-op (gated assignment — never flaps).
+  No `ref.invalidateSelf()`-type re-notification fires on same-value
+  assignments because `ValueNotifier` only notifies on actual value
+  change.
+- `setCompletionHandler`: on fire, inspect `_activeQueue`. If non-null
+  AND has remaining segments, call `_advanceQueue()` — this advances the
+  pointer, sets per-segment language/voice, calls `_tts.speak(next)`.
+  **`_speaking.value` is NOT touched.** If `_activeQueue` is null OR the
+  queue has drained, clear `_activeQueue`, set `_speaking.value = false`,
+  complete `doneCompleter` (if not already completed).
+- `setCancelHandler`, `setErrorHandler`: clear `_activeQueue` FIRST (so
+  no racing completion advances), THEN set `_speaking.value = false`,
+  then complete `doneCompleter` with the cancellation/error.
+
+**Enclosing guard (try/finally around segment loop):**
+
+```
+Future<void> _runQueue(_SegmentQueue q) async {
+  _activeQueue = q;
+  _queueEntered = true;
+  try {
+    // First segment kicks off via _tts.speak; subsequent segments are
+    // advanced by setCompletionHandler. This method returns when
+    // doneCompleter completes.
+    await _tts.speak(q.segments.first.text);
+    await q.doneCompleter.future;
+  } finally {
+    // Invariant: when this method returns, _speaking is false exactly once
+    // per logical utterance. The guard runs even on throw or cancellation.
+    _activeQueue = null;
+    _queueEntered = false;
+    if (_speaking.value) _speaking.value = false;
+  }
+}
+```
+
+The try/finally is the enforcement point: no matter how the queue exits
+(completion, error, cancel, stop, dispose), `_speaking` transitions
+`true → false` exactly once, at the end.
+
+**`_speaking` invariant summary:**
+- false → true: exactly once, on first segment's `setStartHandler` fire.
+- true → false: exactly once, on queue completion or explicit cancel.
+- Between segments: stable at `true` — no flap, no transient `false`.
+- Downstream: `ttsPlayingProvider` fires exactly `[false→true, true→false]`
+  per logical utterance. `HandsFreeController.suspendForTts()` and
+  `resumeAfterTts()` each fire exactly once per reply.
+
+**`stop()` / `speak()` race ordering:**
+
+`SyncWorker._handleReply` (`sync_worker.dart:196`) calls
+`ttsService.stop().then((_) => ttsService.speak(message, …))`. With
+per-segment queuing, a stale completion handler from the previous
+queue's native-side `_tts.stop()` could fire after a new queue starts
+and mistakenly advance it, causing the first segment of the new reply to
+be skipped. Ordering to prevent this:
+
+1. `stop()` is `async`. It first sets `_activeQueue = null` (so any
+   stale completion sees null and exits early), then `await _tts.stop()`
+   (waits for the native-side cancel to complete), then completes any
+   pending `doneCompleter` with a cancellation marker. `stop()` returns
+   only after the native stop has been acknowledged.
+2. `speak()` bumps a `_queueGeneration` counter, builds a new
+   `_SegmentQueue` with that generation stamped in, sets it as
+   `_activeQueue`, and enters `_runQueue`.
+3. Every handler closure captures the generation at registration time
+   (in the queue struct) and on fire checks `_activeQueue?.generation ==
+   captured_generation`. A stale handler from generation N firing after
+   generation N+1 has started sees a mismatch and returns immediately,
+   without touching `_speaking` or advancing.
+
+This guarantees: back-to-back `stop().then(speak)` produces two
+independent queues; no cross-talk; segment 1 of the new queue is never
+dropped. A unit test (`test stop→speak does not swallow segment 1`)
+pins this behaviour.
+
+- Per-segment language is applied by calling `_tts.setLanguage(seg.lang)`
+  (and on iOS `setVoice(bestVoiceFor(seg.lang))`) before each
+  `_tts.speak(seg.text)`. The existing `_voiceCache` already benefits
+  multi-segment replies since the same `lang` repeats across replies.
+- Segments with `languageCode == null` resolve via the current
+  `_resolveLanguage` path using the `speak()` call's own `languageCode`
+  argument — so the default-language behaviour of an untagged reply is
+  preserved.
+
+### iOS path
+
+`flutter_tts` on iOS wraps `AVSpeechSynthesizer`. `AVSpeechSynthesizer`
+does not natively parse SSML `<lang>` — it takes an `AVSpeechUtterance`
+whose `.voice` property drives the phonetic model. `flutter_tts` does
+expose `setLanguage(...)` and `setVoice(Map<String,String>)` methods
+that set the next utterance's voice. Confirmed in the existing
+`_bestVoice()` lookup: we already call `setVoice()` per-call. **No
+bridge or platform channel needed** — we just call `setVoice` before
+each segment's `speak`. T1 will add a device smoke that verifies each
+segment uses its intended voice on a real iPhone.
+
+If a device does not have the required English voice installed (some
+region-locked devices), `AVSpeechSynthesizer` falls back to the system
+default and we still ship the reply without tag audio — degraded, not
+broken. Logged at info level.
+
+### Android path
+
+Android TTS engine behaviour for `<lang>` is engine-specific, and we
+deliberately do **not** probe engines in v1.
+
+- **Google TTS** (default on most Android 10+ devices): per public
+  documentation, Google TTS does not reliably parse SSML through
+  the `flutter_tts` plugin API. The plugin passes strings to
+  `TextToSpeech.speak()`, which treats SSML-like input as literal
+  text unless wrapped in an `<speak>` envelope and flagged — and the
+  plugin does not expose the SSML flag.
+- **Other engines** (Samsung, Pico, AOSP, etc.): variability in SSML
+  handling is why we do not attempt pass-through.
+
+**V1 decision: apply the splitter path uniformly on Android, regardless
+of engine.** This keeps the path deterministic, testable, and identical
+to iOS. `setLanguage(Locale)` is called per segment before each
+`_tts.speak()`. Since the splitter always strips tags when producing
+segments, no engine ever receives tag characters — no risk of a
+literally-spoken `<lang>`.
+
+**Engine capability probing is explicitly deferred, not impossible.**
+`flutter_tts` 4.x exposes `getEngines`, `setEngine`,
+`isLanguageInstalled`, and `getDefaultEngine` — a future proposal
+could probe the engine at splitter entry and short-circuit to a single
+`speak(raw_ssml)` call on engines known to handle SSML natively, reducing
+the inter-segment gap. We do not do this in v1 because (a) no engine has
+documented SSML `<lang>` support through `flutter_tts`'s current API
+surface, (b) engine variability across Samsung/Google/Pico/AOSP means a
+probe must be tested per device class, and (c) the v1 splitter path is
+the correctness baseline — a capability probe would be a latency
+optimisation, not a correctness fix. **Follow-up candidate:** if
+real-world inter-segment gap measurement on Android exceeds the
+tolerance threshold (see T3 smoke), a probe-based fast path is a
+natural next proposal alongside T4 (cloud TTS).
+
+### Fallback (deferred follow-up)
+
+Cloud TTS (ElevenLabs / Azure) would accept the full SSML string
+unchanged and return a single audio buffer we could play via
+`audioplayers` or a lightweight native bridge. This is scoped as T4
+in the Tasks table and **is not part of v1**. v1 ships the splitter
+path on both platforms and observes real-world quality. If a
+follow-up proposal decides the on-device output is insufficient,
+that proposal takes the decision to add a cloud dependency with
+explicit cost and latency budgets.
+
+### Tag stripping — safety net
+
+Two defensive behaviours must hold even on unexpected input:
+
+1. No platform `speak()` call ever receives a string containing `<lang`
+   or `</lang>`. Enforced by the splitter: every emitted segment's
+   `text` field is tag-free.
+2. For malformed input that the splitter declines to parse (see above),
+   the whole reply is passed to a single default-language `speak()`
+   call with the literal text — *not* silently dropped. The user hears
+   the tags as characters, which is ugly, but the fix is in P054
+   (backend), not in swallowing errors here.
+
+### VAD suspend/resume contract (preserved)
+
+- `ttsPlayingProvider` flips to true when the first segment begins and
+  back to false only after the last segment completes (see per-segment
+  queuing loop, above). This matches the 028 contract exactly.
+- `HandsFreeController.suspendForTts()` is called once per reply, not
+  per segment — VAD stays paused across the whole reply, no mid-reply
+  re-arming.
+- `HandsFreeController.resumeAfterTts()` fires once, on queue
+  completion or explicit `stop()`.
+- `EngineCapturing` (user started speaking) still calls
+  `ttsService.stop()` from `HandsFreeController._onEngineEvent` — that
+  path now clears the in-flight queue cleanly.
+
+## Affected Mutation Points
+
+**New files:**
+
+- `lib/core/tts/ssml_lang_splitter.dart` — pure-Dart splitter class
+  and `TtsSegment` model. No platform imports.
+
+**Needs change:**
+
+- `lib/core/tts/flutter_tts_service.dart` (`FlutterTtsService.speak`,
+  `stop`, `dispose`, handler wiring, internal queue state):
+  - Add `_SegmentQueue? _activeQueue` field carrying segments,
+    resolved default language, a `Completer<void> doneCompleter`, and
+    a monotonic `int generation` stamp.
+  - Add `int _queueGeneration` counter; bump on every new `speak()`
+    invocation.
+  - Rewrite `speak()` to run text through `SsmlLangSplitter.split()`
+    and, for N≥1 segments, drive a per-segment loop inside a
+    try/finally enclosing guard (see §Per-segment queuing loop) that
+    holds `_speaking.value = true` across the whole queue and flips it
+    `false` exactly once on queue exit.
+  - Adjust the existing `setStartHandler` to gate
+    `_speaking.value = true` on "only if currently false" (idempotent,
+    no listener flap between segments). Adjust
+    `setCompletionHandler` to advance the queue when
+    `_activeQueue != null` and has remaining segments, only flipping
+    `_speaking.value = false` when the queue is drained or cleared.
+    Adjust `setCancelHandler` / `setErrorHandler` to clear
+    `_activeQueue` BEFORE setting `_speaking.value = false` and
+    completing `doneCompleter`.
+  - Every handler closure captures its queue's `generation` at
+    registration. On fire, the handler checks
+    `_activeQueue?.generation == captured_generation` — if not, it is
+    stale (superseded by a newer `speak()`) and returns immediately
+    without touching state or advancing.
+  - Rewrite `stop()` to: (1) set `_activeQueue = null` so any racing
+    completion sees null, (2) `await _tts.stop()` so the native side
+    finishes before the caller's `.then(speak)` runs, (3) complete
+    any pending `doneCompleter` with a cancellation marker, (4)
+    ensure `_speaking.value = false`. `stop()` returns only after all
+    four steps.
+  - Rewrite `dispose()` to clear `_activeQueue`, complete any pending
+    `doneCompleter` with a cancellation error, then `_tts.stop()` and
+    dispose `_speaking`. Prevents leaked Completers on hot-reload.
+  - Keep the iOS `_bestVoice()` cache logic unchanged — it works
+    per-language and benefits the multi-segment case. First tagged
+    reply of a new language incurs one-time `getVoices` lookup
+    (≤10ms on iOS); subsequent replies hit the cache.
+
+**No change needed:**
+
+- `lib/core/tts/tts_service.dart` — the `TtsService` port already
+  takes `speak(String text, {String? languageCode})`; multi-segment
+  rendering is an implementation detail.
+- `lib/core/tts/tts_provider.dart` — no provider shape change.
+- `lib/features/api_sync/sync_worker.dart` (`SyncWorker._handleReply`) —
+  still calls `ttsService.stop().then((_) => ttsService.speak(message,
+  languageCode: language))`. The tagged message flows through unchanged.
+  The `stop→speak` race (stale completion handler from the previous
+  queue's native-side stop firing after a new queue starts) is handled
+  entirely inside `FlutterTtsService` via the generation counter plus
+  `stop()` awaiting `_tts.stop()` (see §Per-segment queuing loop).
+  `_handleReply` needs no change.
+- `lib/features/recording/presentation/hands_free_controller.dart`
+  (`HandsFreeController._onEngineEvent`, `suspendForTts`,
+  `resumeAfterTts`) — the suspend/resume contract is driven by
+  `ttsPlayingProvider`, which keys off `_speaking` now held `true`
+  across the queue.
+- `AndroidManifest.xml`, iOS `Info.plist`, background service
+  registration — unchanged from 028.
+
+## Test Impact / Verification
+
+### Unit tests (new)
+
+`test/core/tts/ssml_lang_splitter_test.dart`:
+
+- Empty input → one empty default segment (or zero segments — pick one
+  and document in the class doc).
+- Untagged text → one default segment with exact input text.
+- Single `<lang xml:lang="en-US">X</lang>` → three segments: leading
+  default, tagged en-US, trailing default (empty segments elided).
+- Multiple adjacent `<lang>` regions with different language tags.
+- Unclosed `<lang>` tag → full string returned as one default segment
+  (fallback path); must not throw.
+- Unmatched `</lang>` → same fallback.
+- Nested `<lang>` → inner wins, outer is logged; must not throw.
+- Mixed-case attribute `XML:LANG` or `<Lang>` element → treated as
+  malformed (case-sensitive matcher), emitted as plain text in the
+  default-language segment. Test asserts the tag characters appear
+  verbatim in the resulting segment.
+- Whitespace and punctuation adjacent to tags preserved.
+
+`test/core/tts/flutter_tts_service_test.dart` (extended):
+
+- Injected `MockFlutterTts` records `setLanguage`, `setVoice`, `speak`
+  calls in order. A two-segment input produces: `setLanguage('pl_PL')`,
+  `speak('…')`, (completion), `setLanguage('en-US')`, `speak('…')`.
+- `_speaking` (via `isSpeaking` listener) stays `true` between segment
+  1 completion and segment 2 start — not flapping.
+- `stop()` called mid-queue prevents segment 2 from being spoken.
+- Untagged input produces exactly one `setLanguage` and one `speak`
+  (no regression vs current behaviour).
+- **AC4 coverage — `ttsPlayingProvider` transition counter.** Pump a
+  two-segment speak through `FlutterTtsService` inside a
+  `ProviderContainer`. Attach a listener to `ttsPlayingProvider` that
+  appends each (prev, next) state pair to a list. Assert the list is
+  exactly `[(false, true), (true, false)]` — one pair, not two pairs.
+  This counts state transitions (not just the final value) and fails
+  if the handler wiring ever flaps `_speaking` mid-queue. This is the
+  direct test of AC4 ("`ttsPlayingProvider` transitions exactly once
+  per utterance").
+- **`stop→speak` race.** Call `ttsService.stop()` immediately followed
+  (in the `.then` continuation) by `ttsService.speak(twoSegmentInput)`.
+  Fire a stale completion event from the mock _after_ the new queue's
+  first segment starts. Assert: (a) the new queue's segment 1 is not
+  skipped, (b) the new queue's segment 2 is spoken after segment 1
+  completion, (c) `_speaking` follows `[false→true, true→false]`
+  exactly once across the new queue (not twice).
+- **Generation counter.** Start queue A (gen=1), call `stop()`, start
+  queue B (gen=2). Fire a completion handler captured against gen=1
+  after queue B has started; assert queue B's state is unchanged (no
+  accidental advance, no `_speaking` flip).
+
+### Existing tests — impact
+
+- `test/features/api_sync/sync_worker_test.dart` — no impact; it stubs
+  `TtsService` and verifies `.speak()` is called with the raw message.
+  The splitter is an implementation detail.
+- `test/features/recording/presentation/hands_free_controller_test.dart`
+  — no impact; still asserts `stop()` is called on `EngineCapturing`.
+- Widget tests that pump `RecordingScreen` / `SettingsScreen` with a
+  stub `TtsService` — no impact.
+
+### Device smoke (required before marking Implemented)
+
+1. **iOS (iPhone 12 Pro, release build), PL voice + EN voice installed.**
+   Trigger a P054-shaped reply. Expected: Polish sentence with an
+   English "hangover"/"action item" in the middle, unambiguously
+   English phonetics. No tag characters audible. No mid-reply VAD
+   re-arm. Lock screen during the reply — audible (028 behaviour).
+2. **Android 14+ (Pixel or similar, release build), Google TTS, PL + EN
+   language packs installed.** Same smoke as iOS.
+3. **Android 13 / pre-Android-14 device (if available).** Same smoke —
+   confirms the splitter path also works on the non-typed-FG-service
+   Android generation from 028.
+4. **iOS without EN voice installed.** Trigger tagged reply. Expected:
+   reply still plays, English fragment falls back to device default
+   voice, log line present; no crash, no tag audio.
+5. **Malformed backend input** (manual: send a handcrafted reply with
+   an unclosed tag via backend stub). Expected: user hears the raw
+   text including `<` characters; no crash; logs show the parse
+   failure.
+
+**Commands:** `make verify` (runs `flutter analyze && flutter test`).
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Per-segment queuing introduces audible gaps at language boundaries that feel sluggish | Accepted for v1 — better than mispronunciation. Measure real-world gap on device; if intolerable, T4 (cloud TTS) becomes the fallback. The gap is bounded by `AVSpeechSynthesizer` / Android TTS handler latency, typically tens of ms. |
+| iOS device lacks the required English voice pack (region-locked, storage-constrained) | `_bestVoice(en-US)` returns null → `setVoice()` skipped → `AVSpeechSynthesizer` falls back to default for the BCP-47 tag. Logged at info level. Degraded, not broken. |
+| Android engine variability (Samsung/Pico/AOSP) — `setLanguage(Locale("en","US"))` returns `LANG_NOT_SUPPORTED` | Log and fall through to default; the segment is still spoken (with default phonetics), no crash. A future proposal could surface a user warning. |
+| Malformed SSML from backend (unclosed `<lang>`, bad BCP-47 tag, nested tags) | Splitter returns a fallback single default-language segment; the full raw string is spoken including tag characters. Loud, ugly, but visible — better than silent drops. Unit-tested. |
+| Race: `stop()` called while segment N is still in `flutter_tts`'s native queue, segment N+1 starts after stop | `stop()` clears `_activeQueue` before calling `_tts.stop()`. Completion handler checks `_activeQueue != null` before advancing — if null, no next segment is scheduled. Unit-tested. |
+| `_speaking.value` held `true` across segments breaks an existing consumer that assumed per-utterance flapping | Only consumer is `ttsPlayingProvider` → `HandsFreeController.suspendForTts/resumeAfterTts`. This is the desired behaviour (VAD stays paused across the whole reply). Reviewed. |
+| VAD re-arms between segments if `_speaking.value` ever flips false mid-queue | Covered by explicit unit test: two-segment speak holds `isSpeaking == true` continuously from start of seg1 to end of segN. |
+| SSML tag reaches engine and is spoken literally | Splitter is the single source of truth; every emitted `TtsSegment.text` is asserted tag-free in unit tests. |
+
+## Alternatives Considered
+
+- **STT-side correction** — already dismissed in "Are We Solving the
+  Right Problem?" above. Distorts user input, doesn't fix TTS.
+- **Cloud TTS always-on** — v1 over-scope; deferred to T4 follow-up.
+  See Known Compromises.
+- **Strip English terms entirely** — loses information; reply becomes a
+  broken summary. Dismissed.
+- **Ask Android's Google TTS to parse `<speak>…<lang/>…</speak>`
+  SSML natively.** Investigated; `flutter_tts` does not expose the
+  bundle flags needed to flag input as SSML, and Google TTS's SSML
+  support for non-English voices is underdocumented. Even if it
+  worked, we'd still need the splitter path on iOS, so a uniform
+  splitter path on both platforms is simpler and more testable.
+- **Introduce a new TTS port with multi-segment API**
+  (`Future<void> speakQueue(List<TtsSegment>)`) and migrate callers.
+  Rejected — the only caller is `SyncWorker._handleReply`, which has
+  a single string. Keeping `speak(String)` as the port and hiding
+  multi-segment queuing inside the adapter preserves the current
+  contract and avoids port churn.
+- **Parse SSML with `xml` package.** Rejected — full XML parsing is
+  overkill for one tag, adds a dependency, and is slower than the
+  hand-rolled state machine on the happy path. Correctness for our
+  single supported tag is easy to cover with unit tests.
+
+## Known Compromises and Follow-Up Direction
+
+- **Cloud TTS fallback deferred.** We ship v1 with splitter-driven
+  on-device playback on both platforms. If real-world quality on the
+  available device matrix is insufficient — in particular if Android
+  engines produce noticeably worse English phonetics than iOS — a
+  follow-up proposal (see T4) will prototype ElevenLabs or Azure and
+  gate it on a "tagged reply detected" flag so cost is bounded.
+- **Per-user voice selection deferred.** No Settings UI for picking
+  specific iOS voices per language or forcing a particular Android
+  engine. iOS uses `_bestVoice()` selection heuristics already in
+  place; Android uses whatever engine the user's device came with.
+  A follow-up proposal could add a "TTS voices" section to Settings.
+- **PL + EN only in v1.** Other language pairs will *work* if the
+  device has the voices installed, but we do not test, document, or
+  support them as a feature.
+- **Minor audible gap at language boundaries.** Bounded by platform
+  handler latency; accepted as the cost of the splitter approach.
+  Cloud TTS (T4) would eliminate it by producing a single audio buffer.
+
+## ADR Impact
+
+- **ADR-ARCH-006 (Domain port pattern).** The change respects the
+  pattern: the port `TtsService` in `core/tts/` stays a thin
+  abstraction; multi-segment queuing is implementation detail in
+  `FlutterTtsService`, which already lives alongside the port. No
+  ADR amendment needed.
+- **ADR-AUDIO-007 (iOS ambient audio session for playback).** No
+  change — we do not alter the audio session category. TTS continues
+  to play via whatever category is active (`ambient` by default,
+  `playAndRecord` during hands-free sessions per ADR-AUDIO-009).
+- **ADR-AUDIO-009 (Conditional iOS audio session).** No change — the
+  splitter runs entirely above the audio session layer.
+- No new ADR proposed. The splitter is a localized implementation
+  pattern, not a cross-cutting architectural decision. If a future
+  proposal swaps in cloud TTS (T4), that proposal should decide
+  whether a new ADR on "TTS engine selection" is warranted.
+
+## Tasks
+
+Each task is a mergeable PR with tests unless marked as a follow-up.
+
+| # | Task | Layer | PR scope |
+|---|------|-------|----------|
+| T1 | Implement `SsmlLangSplitter` + `TtsSegment` model in `lib/core/tts/ssml_lang_splitter.dart`. Full unit test coverage (happy path, malformed input, mixed-case attributes, nested tags, whitespace). Pure Dart, no platform deps. | core/tts | PR 1 |
+| T2 | Wire splitter into `FlutterTtsService.speak()` with per-segment queuing; preserve `_speaking.value = true` across the whole queue; make `stop()` drain the queue. Extend `flutter_tts_service_test.dart` to cover: two-segment happy path (ordered `setLanguage`/`speak` calls), `isSpeaking` held across segments, `stop()` mid-queue prevents subsequent segments, untagged input unchanged from current behaviour. | core/tts | PR 1 (same branch as T1 — splitter and caller land together) |
+| T3 | Device smoke on iPhone 12 Pro + Android 14+ Pixel + one pre-Android-14 device; verify English fragment is audibly English, no tag audio, VAD does not re-arm mid-reply, lock-screen playback (028) still works. Record results in the proposal before marking Implemented. | manual | PR 2 — smoke-only doc update, no code diff |
+| T4 | **(Follow-up, not v1.)** Prototype cloud TTS fallback (ElevenLabs or Azure) for tagged replies only: detect `<lang` in body, route that reply to cloud synth, fall back to v1 splitter path on network error. Gated by a new `cloudTtsEnabled` setting, default off. Requires a follow-up proposal with cost/latency budgets before implementation. | core/tts + features/settings | Separate follow-up proposal + PR |
+
+## Acceptance Criteria
+
+1. A reply containing `<lang xml:lang="en-US">API</lang>` (exact
+   lowercase canonical shape) is spoken with English phonetics on both
+   iOS and Android release builds.
+2. No literal tag audio reaches the user on any platform, any engine —
+   every emitted `TtsSegment.text` is tag-free.
+3. Untagged replies sound identical to current 015/028 behaviour
+   (one `setLanguage`, one `_tts.speak`, unchanged path).
+4. **`ttsPlayingProvider` / `_speaking` transitions exactly once per
+   logical utterance.** During a multi-segment reply, the provider
+   emits exactly `[false→true, true→false]` — never flaps mid-queue.
+   `HandsFreeController.suspendForTts()` and
+   `resumeAfterTts()` each fire exactly once per reply, never
+   per-segment. Enforced by the try/finally enclosing guard in
+   `_runQueue()` and by gated `_speaking` assignments in the
+   `setStartHandler`. Covered by the unit test counting
+   `ttsPlayingProvider` state transitions (assert count == 1 pair per
+   utterance).
+5. Malformed SSML (wrong casing, missing attribute, unclosed tag,
+   nested `<speak>` envelope, non-canonical shape) does not crash the
+   app; the reply is spoken (tag characters included) and the parse
+   deviation is logged at info level.
+6. **Case-sensitive matcher.** The splitter matches only
+   `<lang xml:lang="xx-YY">` canonical form (lowercase element,
+   lowercase attribute, double-quoted BCP-47 `xx-YY` value). Any other
+   casing is treated as malformed and falls through to plain text.
+   Matches the P054 lowercase-only emission contract byte-for-byte.
+7. **`stop→speak` race is safe.** Back-to-back
+   `ttsService.stop().then((_) => ttsService.speak(newReply))` produces
+   two independent queues with no cross-talk; segment 1 of the new
+   reply is never dropped by a stale completion handler from the old
+   queue. Covered by unit test.
+8. `make verify` passes (`flutter analyze && flutter test`), and the
+   architecture dependency rule is respected (splitter in `core/tts/`,
+   no cross-feature imports).
+9. Device smoke (T3) is recorded in this proposal before status flips
+   to Implemented.
+
+## Related
+
+- personal-agent proposal P054 mixed-language-ssml (counterpart)
+- 015-tts-response-playback
+- 028-background-tts
+- P000-backlog entry "TTS mixed-language support — honor SSML `<lang>` tags"
+- ADR-ARCH-006 (domain port pattern), ADR-AUDIO-007 (iOS ambient),
+  ADR-AUDIO-009 (conditional iOS audio session)

--- a/docs/proposals/031-vad-hangover-tuning.md
+++ b/docs/proposals/031-vad-hangover-tuning.md
@@ -1,0 +1,168 @@
+# Proposal 031 — VAD Hangover Tuning and Dynamic Adjustment
+
+## Status: Draft (seed)
+
+## Origin
+
+Conversation 2026-04-22. During a live test session, utterances were
+fragmented — VAD treated natural pauses as end-of-speech and sent partial
+segments to STT. Tested 10 s -> 1000 ms -> 800 ms; 800 ms was the best
+compromise between natural pause tolerance and agent reaction latency.
+
+## Prerequisites
+
+- 012-hands-free-local-vad — VAD engine and session model
+- 013-vad-advanced-settings — user-facing VAD config (hangover slider)
+
+Both are implemented.
+
+**No cross-project dependency.** This is entirely client-side.
+
+## Scope
+
+- Risk: Medium — hangover changes affect perceived responsiveness of the
+  entire hands-free flow; too long feels sluggish, too short fragments speech
+- Layers: `core/audio/` (VAD engine adapter), `core/config/` (VadConfig),
+  `features/settings/` (advanced settings UI), `features/recording/`
+  (hands-free controller and orchestrator)
+- Expected PRs: 2 (metrics collection, then dynamic adjustment)
+
+## Problem Statement
+
+The code default for hangover is 500 ms (`VadConfig.defaults()` in
+`core/config/vad_config.dart:18`). During the 2026-04-22 test session, the
+user manually tuned the slider to 800 ms, which worked better for their
+speech pattern. The 500 ms default was chosen in P013 as a reasonable
+starting point, but:
+
+1. Different speakers have different pause patterns — a fast speaker pauses
+   ~300 ms between sentences; a deliberate speaker pauses ~1200 ms.
+2. Noisy environments cause the VAD to see micro-pauses as silence, leading
+   to more fragmentation at the same hangover value.
+3. Conversational context matters — after an open-ended question from the
+   agent, the user is more likely to pause while thinking.
+
+Without data from real usage, any fixed default is a guess. Without dynamic
+adjustment, the user must manually tune the slider for each environment.
+
+## Research Needed
+
+Before designing the solution, collect data:
+
+1. **Fragmentation metrics.** Track per-session: total segments sent to STT,
+   segments that arrived within N seconds of each other from the same
+   utterance (heuristic: same conversation turn), average segment duration,
+   and the active `VadConfig` snapshot (at minimum `hangoverMs`).
+   Without recording the active hangover value, correlating fragmentation
+   data with the configured setting is impossible — especially since P013
+   lets users change it via the slider.
+2. **Industry benchmarks.** Research typical hangover values in production
+   voice assistants (Alexa: ~700-1000 ms reported; Google Assistant: adaptive;
+   Siri: undocumented). Document findings in the proposal before implementation.
+3. **User feedback.** After 1+ week of real usage with the user's configured
+   hangover value, review whether fragmentation is a practical problem or
+   acceptable.
+
+## Proposed Direction
+
+### Phase 1 — Metrics (T1)
+
+Add lightweight fragmentation tracking to `HandsFreeController`:
+
+- Count segments per hands-free session
+- Track inter-segment gaps (time between `EngineSegmentReady` events)
+- Capture the active `VadConfig` snapshot at session start (at minimum
+  `hangoverMs`) so metrics can be correlated with the configured value
+- Log a structured session summary on `stopSession()` via `debugPrint` of
+  a JSON-formatted object: total segments, mean/max gap, fragmentation
+  ratio (multi-segment turns / total turns), active hangover value
+- No persistent storage in v1. If Phase 2 needs queryable history for
+  calibration, define a storage approach in the Phase 2 design after
+  reviewing Phase 1 data
+
+No user-visible change. Data collection only.
+
+### Phase 2 — Dynamic Hangover (T2)
+
+Based on Phase 1 data, implement one of:
+
+**Option A — Adaptive hangover (preferred if data supports it):**
+Formula: `hangover = base + (noise_proxy * scaling)`
+- `base`: user-configured default (whatever the slider says)
+- `noise_proxy`: needs research — Silero VAD exposes per-frame speech
+  probability (float 0-1), not a noise level estimate. Low probability
+  during non-speech could mean silence or noise. **Research question:** Does
+  Silero's frame-level probability distribution during non-speech segments
+  correlate with ambient noise level? If not, what other signal could serve
+  as a noise proxy (e.g., audio energy level from raw PCM)?
+- `scaling`: calibration constant, tuned from Phase 1 data
+- Clamp to [400 ms, 3000 ms] — note: the current `VadConfig.clamp()` uses
+  [100, 2000]; if dynamic adjustment can push beyond 2000 ms, the upper
+  bound in `VadConfig.clamp()` must be updated
+
+**Option B — Pragmatic (if data shows current default is good enough):**
+- Change default from 500 ms to whatever the Phase 1 data suggests is
+  optimal across sessions
+- Add an "auto" option to the hangover slider that applies Option A
+- Keep manual override as-is
+
+Context-aware hangover (adjusting based on agent question type) was
+considered but is **out of scope** for this proposal. It would require
+`SyncWorker` (in `features/api_sync/`) to relay question-type metadata to
+`HandsFreeController` (in `features/recording/`), which is a cross-feature
+dependency. If needed, a future proposal should route this signal through a
+shared provider in `core/` (same pattern as `agentReplyProvider`).
+
+### ADR Impact
+
+- **ADR-AUDIO-006 (session-scoped immutable VAD config):** If dynamic
+  hangover adjusts mid-session (Option A), this ADR needs amendment — the
+  hangover would become the one mutable parameter within a session. If
+  adjustment happens only at session start (based on last session's metrics),
+  the ADR is preserved. Phase 1 data will inform which approach is needed.
+
+## Acceptance Criteria (Phase 1)
+
+1. On `stopSession()`, a JSON-formatted session summary is logged via
+   `debugPrint` containing: total segments, mean inter-segment gap, max
+   inter-segment gap, fragmentation ratio, active `hangoverMs`.
+2. Metrics collection adds no disk I/O on the audio processing path —
+   counters and timestamps only.
+3. `make verify` passes. No cross-feature imports.
+4. Phase 2 acceptance criteria will be defined after Phase 1 data review.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Metrics collection overhead affects real-time audio performance | Keep it to in-memory counters and timestamps; no disk I/O, no allocations on the audio path. Log only on session stop. |
+| Phase 2 dynamic adjustment conflicts with user's manual slider (P013) — which takes precedence? | "Auto" mode is opt-in; when selected, dynamic adjustment overrides the slider value. When slider is manually set, dynamic adjustment is disabled. |
+| Option A mid-session mutation violates ADR-AUDIO-006 | Phase 1 data will show whether mid-session adjustment is actually needed or session-start adjustment suffices. If ADR amendment is needed, it goes through architectural review. |
+| Noise proxy from Silero probability is unvalidated | Explicitly flagged as a research question. Phase 1 data may reveal a simpler heuristic (e.g., fragmentation ratio alone). |
+
+## Tasks
+
+| # | Task | Layer | Notes |
+|---|------|-------|-------|
+| T1 | Add fragmentation metrics logging to `HandsFreeController`. Capture segment count, inter-segment gaps, active `hangoverMs`. Log JSON summary on `stopSession()`. | features/recording, core/config | Mergeable alone. No user-visible change. |
+| T2 | (After >= 1 week of T1 data) Design and implement dynamic hangover based on Phase 1 findings. Update `VadConfig.clamp()` if range changes. Amend ADR-AUDIO-006 if mid-session mutation is chosen. | core/config, features/recording, features/settings | Depends on T1 data. Separate proposal revision before implementation. |
+
+## Dependencies
+
+| Dependency | Status | Blocking? |
+|---|---|---|
+| 012-hands-free-local-vad | Implemented | No |
+| 013-vad-advanced-settings | Implemented | No |
+| ADR-AUDIO-006 | Accepted | May need amendment in Phase 2 |
+
+## When to Address
+
+Phase 1 (metrics) can start immediately. Phase 2 (dynamic adjustment)
+depends on Phase 1 data — at least 1 week of real usage.
+
+## Related
+
+- P000-backlog entry "VAD hangover tuning"
+- 012-hands-free-local-vad
+- 013-vad-advanced-settings
+- ADR-AUDIO-006-immutable-vad-config

--- a/docs/proposals/032-new-conversation-button.md
+++ b/docs/proposals/032-new-conversation-button.md
@@ -1,0 +1,140 @@
+# Proposal 032 — New Conversation Button
+
+## Status: Draft (seed)
+
+## Origin
+
+Conversation 2026-04-22. The user decided the "new conversation" action
+belongs in the mobile client (voice-agent), not in the web UI. Rationale:
+the primary flow is voice-first, on mobile — the web UI is a secondary view.
+
+## Prerequisites
+
+- 014-recording-mode-overhaul — recording lifecycle and gesture table
+- 024-chat-screen — chat UI with conversation context
+- 025-shared-api-layer — shared API client
+- **029-honor-session-control-signals — provides `SessionIdCoordinator` in
+  `core/session_control/`**. P032 reuses this coordinator for the manual
+  reset. Without it, there is nothing to clear — neither the recording
+  nor the api_sync feature currently maintains a local `conversation_id`.
+  The backend assigns conversations via device-id-based stitching with a
+  10-minute gap heuristic. P029's `SessionIdCoordinator` is the first
+  client-side conversation identity.
+
+P014, P024, P025 are implemented. **P029 is draft — this proposal depends
+on P029 shipping first** (or at minimum the `SessionIdCoordinator` class
+from P029 T1 being merged).
+
+**Cross-project relationship:** personal-agent P049 (session-control-signals)
+and voice-agent P029 define the automated conversation reset triggered by the
+backend. This proposal covers the manual, user-initiated reset — a
+complementary mechanism.
+
+## Scope
+
+- Risk: Low — UI-only change with local state reset; no API contract change,
+  no storage schema change, no platform behavior change
+- Layers: `features/recording/presentation/` (recording screen widget),
+  `features/chat/presentation/` (chat screen widget),
+  `core/session_control/` (reuses P029's `SessionIdCoordinator`)
+- Expected PRs: 1
+
+## Problem Statement
+
+Currently the user cannot start a fresh conversation from the mobile app
+without stopping and restarting the hands-free session. The backend's
+10-minute gap heuristic handles session rollover passively, but:
+
+- The user must wait 10 minutes of silence for an automatic rollover, or
+- Tap stop, wait, tap start — friction that breaks the voice-first promise.
+
+A single-tap "new conversation" action would let the user explicitly close
+the current context and start fresh.
+
+## Proposed Solution
+
+### Recording Screen
+
+An icon button (refresh icon) in the AppBar, alongside the existing history
+button. Tap calls `sessionIdCoordinator.resetSession()`, shows a "New
+conversation" toast and a light haptic.
+
+**State guard:** The button is disabled when:
+- `RecordingState` is `RecordingActive` or `RecordingTranscribing` (manual
+  recording in progress)
+- `HandsFreeSessionState` is `HandsFreeCapturing` or `HandsFreeStopping`
+  (VAD segment being captured or written)
+
+In all other states (`HandsFreeIdle`, `HandsFreeListening`,
+`HandsFreeWithBacklog`, `RecordingIdle`), the button is active.
+
+Reference: P014 gesture guard table for canonical state combinations.
+
+### Chat Screen
+
+From within a thread: navigate to `/chat` (conversations list) and let the
+user tap the existing "+" button to start a new conversation. This reuses
+the flow already established by P024's `ConversationsScreen`.
+
+Adding a separate "new conversation" action inside a thread is deferred —
+the recording screen button covers the primary voice-first use case, and
+the chat screen already has the "+" flow.
+
+### State Reset
+
+On tap, call `sessionIdCoordinator.resetSession()` from P029's
+`core/session_control/` package. This clears the local `conversation_id`
+— the backend's existing device-id-based stitching handles the new
+conversation on the server side.
+
+Keep the hands-free session alive (mic stays open, VAD stays running).
+Only the conversation identity changes, not the audio session.
+
+### Toast and Haptic
+
+If P029's `Toaster` and `HapticService` are available (they live in
+`core/session_control/`), reuse them. The toast text is "New conversation",
+matching P029's `reset_session` signal feedback.
+
+## Acceptance Criteria
+
+1. Tapping the "new conversation" button on the recording screen while in
+   idle/listening state calls `SessionIdCoordinator.resetSession()` and
+   shows a "New conversation" toast with a light haptic.
+2. The button is disabled (not tappable, visually dimmed) when
+   `RecordingState` is `RecordingActive` or `RecordingTranscribing`, or
+   when `HandsFreeSessionState` is `HandsFreeCapturing` or
+   `HandsFreeStopping`.
+3. The hands-free session (mic, VAD, foreground service) remains alive
+   after the reset — only the conversation identity changes.
+4. No cross-feature imports. The button uses only `core/session_control/`
+   providers.
+5. `flutter analyze` passes with zero issues. `flutter test` passes.
+
+## Tasks
+
+| # | Task | Layer | Notes |
+|---|------|-------|-------|
+| T1 | Add "new conversation" icon button to RecordingScreen AppBar. Wire to `SessionIdCoordinator.resetSession()` via provider. Disable during active recording/capturing states. Show toast + haptic via P029's abstractions. Widget test for button state and tap behavior. | features/recording/presentation | Depends on P029 T1. |
+| T2 | (Optional) If chat-screen "new conversation" action is needed beyond the existing "+" flow, add an AppBar action to ThreadScreen that navigates to `/chat` (conversations list). | features/chat/presentation | Low priority. |
+
+## Dependencies
+
+| Dependency | Status | Blocking? |
+|---|---|---|
+| 014-recording-mode-overhaul | Implemented | No |
+| 024-chat-screen | Implemented | No |
+| **029-honor-session-control-signals (T1)** | **Draft** | **Yes — provides SessionIdCoordinator, Toaster, HapticService** |
+| personal-agent P049 | Draft | Not blocking — independent mechanism |
+
+## When to Address
+
+After P029 T1 (core skeleton) is merged. At that point this becomes a
+trivial UI addition on top of the existing `SessionIdCoordinator`.
+
+## Related
+
+- P000-backlog entry "New conversation button in voice agent UI"
+- 029-honor-session-control-signals (automated reset, shared coordinator)
+- 014-recording-mode-overhaul (gesture table, state guards)
+- 024-chat-screen (ConversationsScreen "+" flow)

--- a/docs/proposals/033-api-cost-dashboard.md
+++ b/docs/proposals/033-api-cost-dashboard.md
@@ -1,0 +1,204 @@
+# Proposal 033 — API Cost Dashboard
+
+## Status: Draft (seed)
+
+## Origin
+
+Conversation 2026-04-22. The user wants to see aggregated API costs
+(daily / monthly) in the mobile app. This complements the ability to ask
+the agent about cost verbally (personal-agent P051) — the dashboard gives
+a retrospective visual view, while P051 gives a conversational on-demand
+answer.
+
+## Prerequisites
+
+- 020-navigation-restructure — 5-tab shell with route structure
+- 021-agenda-screen — pattern for a screen fetching backend aggregates
+- 025-shared-api-layer — shared API client with GET support
+
+All are implemented.
+
+**Cross-project dependencies:**
+
+| personal-agent proposal | Status | What it provides | Blocking? |
+|---|---|---|---|
+| P033 (api-usage-and-cost-tracking) | **Implemented** | `api_usage_log` table tracking per-request tokens and cost | Yes — data source |
+| P051 (agent-tool-cost-of-conversation) | **Draft** | Agent tool for conversational cost queries | No — complementary, not blocking |
+
+**Required backend work:** personal-agent P033 stores per-request usage data,
+but there is no aggregation endpoint yet. This proposal needs a new
+`GET /api/v1/usage/summary?from=DATE&to=DATE` endpoint on personal-agent
+that returns daily aggregates (input_tokens, output_tokens, cost_usd,
+cost_pln, model breakdown). This would be a lightweight backend addition
+— a new proposal seed (~P055) or an extension of P033.
+
+**Why server-side aggregation:** Keeping cost calculation, model pricing
+tables, and currency conversion on the backend is cheaper per request,
+cacheable, and keeps pricing logic in one place. The voice-agent just
+renders what it receives.
+
+## Scope
+
+- Risk: Low — read-only screen, no state mutation, no storage change, no
+  platform behavior change
+- Layers: `features/usage/` (new feature module), `core/network/` (API
+  client already supports GET), `app/router.dart` (new child route)
+- Expected PRs: 1 (after backend endpoint exists)
+
+## Problem Statement
+
+The user tracks API costs via personal-agent's web UI or by asking the agent.
+Neither gives a quick mobile-native view of spending trends. Opening the web
+UI on mobile is friction; asking the agent interrupts the voice flow and
+requires an active conversation.
+
+A dedicated screen in the mobile app would let the user glance at costs
+without context-switching.
+
+## Proposed Solution
+
+### Routing
+
+`/settings/usage` — child route of `/settings`, same pattern as
+`/settings/advanced` (P013). This is consistent with the CLAUDE.md routing
+convention: "Infrequently accessed screens (e.g., Settings) are top-level
+GoRoutes outside the shell." Cost checking is occasional, not daily — it
+fits as a settings sub-screen.
+
+Route ownership table in CLAUDE.md should be updated to include
+`/settings/usage` owned by P033.
+
+### Screen: Usage / Costs
+
+**Content:**
+
+1. **Current month summary** — total cost (PLN primary, USD secondary),
+   total tokens (input + output), number of requests.
+2. **Daily breakdown** — vertical list of daily rows with proportional-width
+   bars (Container width = daily cost / max daily cost). Tapping a day
+   expands to show per-model breakdown.
+3. **Previous month** — same summary for comparison, collapsed by default.
+
+**Loading state:** Centered `CircularProgressIndicator` (same pattern as
+P021 `AgendaScreen`).
+
+**Error state:** Error message with a "Retry" button. No cached fallback —
+this is a read-only, non-critical screen.
+
+**No charting library in v1.** Proportional bars via `Container` are
+sufficient. If a charting library is needed later, `fl_chart` is the
+standard Flutter choice.
+
+### Data Source
+
+`GET /api/v1/usage/summary?from=DATE&to=DATE` returning:
+
+```json
+{
+  "period": {"from": "2026-04-01", "to": "2026-04-23"},
+  "total_cost_usd": 12.34,
+  "total_cost_pln": 49.36,
+  "total_input_tokens": 1234567,
+  "total_output_tokens": 567890,
+  "total_requests": 42,
+  "daily": [
+    {
+      "date": "2026-04-01",
+      "cost_usd": 0.56,
+      "cost_pln": 2.24,
+      "requests": 3,
+      "models": {"claude-sonnet-4-20250514": {"cost_usd": 0.40}, "gpt-4o": {"cost_usd": 0.16}}
+    }
+  ]
+}
+```
+
+The UI shows "requests" (API calls), not "conversations" — these are
+different metrics and the backend tracks requests. The label should read
+"Requests" to match the data.
+
+### Feature Module Structure
+
+```
+lib/features/usage/
+  domain/
+    usage_summary.dart         -- UsageSummary, DailyUsage, ModelCost models
+  data/
+    usage_service.dart         -- fetches from API via shared ApiClient
+  presentation/
+    usage_screen.dart          -- ConsumerStatefulWidget rendering the dashboard
+    usage_controller.dart      -- StateNotifier<UsageState> managing period
+                                  selection (current/previous month), refresh,
+                                  loading/error states
+    usage_providers.dart       -- StateNotifierProvider for UsageController
+```
+
+`StateNotifierProvider` (not `FutureProvider`) because the screen needs:
+- Period switching (current month / previous month / custom range)
+- Pull-to-refresh
+- Loading/error state management
+
+This matches the P021 `AgendaNotifier` pattern.
+
+## Acceptance Criteria
+
+1. Screen is accessible via `/settings/usage` from the settings screen.
+2. Current-month summary renders total cost (PLN + USD), total tokens,
+   and request count.
+3. Daily breakdown renders with proportional-width bars. Tapping a day
+   shows per-model cost breakdown.
+4. Previous-month summary is displayed (collapsed by default).
+5. Loading state shows a centered spinner. Error state shows a message
+   with a "Retry" button.
+6. No cross-feature imports. `features/usage/` imports only from `core/`.
+7. `flutter analyze` passes. `flutter test` passes.
+
+## Tasks
+
+| # | Task | Layer | Notes |
+|---|------|-------|-------|
+| T1 | Domain models (`UsageSummary`, `DailyUsage`, `ModelCost`) + `UsageService` fetching from API. Unit tests with mocked `ApiClient`. | features/usage/domain, features/usage/data, test | Mergeable alone (no UI). |
+| T2 | `UsageController` (StateNotifier), `UsageScreen`, providers, route wiring in `router.dart`. Widget tests for loading/error/happy-path states. Settings screen link. | features/usage/presentation, app/router, test | Depends on T1. |
+
+## Test Impact
+
+**New test files:**
+- `test/features/usage/domain/usage_summary_test.dart` — model
+  `fromMap`/`toMap` round-trip
+- `test/features/usage/data/usage_service_test.dart` — API call with
+  mocked `ApiClient`, error handling
+- `test/features/usage/presentation/usage_screen_test.dart` — widget test:
+  loading spinner, error + retry, data rendering, period switching
+
+**No existing tests affected.**
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Backend aggregation endpoint contract not yet defined — response shape may change | The proposed shape is a starting point. When the backend proposal is written, voice-agent models adapt. Keep models in `features/usage/domain/`, not `core/models/`, to limit blast radius. |
+| Daily array could be large for long-time users (months of data) | Backend should paginate or cap to the requested `from-to` range. Client requests only one month at a time. |
+| Currency conversion accuracy depends on static backend rate | Acceptable for cost visibility — exact billing is not the goal. Backend P051 documents `USD_TO_PLN` as static config. |
+
+## Dependencies
+
+| Dependency | Status | Blocking? |
+|---|---|---|
+| personal-agent P033 (cost tracking) | Implemented | Data exists but no aggregation endpoint |
+| **personal-agent usage summary endpoint** | **Not yet proposed** | **Yes — blocks this proposal** |
+| personal-agent P051 (cost tool) | Draft | Not blocking — complementary |
+| 025-shared-api-layer | Implemented | No |
+| 021-agenda-screen | Implemented | Pattern reference |
+
+## When to Address
+
+After the backend usage summary endpoint is available. The voice-agent side
+is straightforward once the API contract is defined.
+
+## Related
+
+- P000-backlog entry "Daily / monthly API cost dashboard in mobile UI"
+- personal-agent P033 (api-usage-and-cost-tracking)
+- personal-agent P051 (agent-tool-cost-of-conversation)
+- 021-agenda-screen (pattern for aggregate data screens)
+- 006-settings-screen (navigation pattern for sub-screens)

--- a/docs/proposals/P000-backlog.md
+++ b/docs/proposals/P000-backlog.md
@@ -1,0 +1,84 @@
+# P000: Backlog
+
+Known issues and design gaps that don't yet warrant a standalone proposal. Each item should be resolved in the context of the slice where it becomes concrete.
+
+Cross-project items reference `personal-agent/docs/proposals/P000-backlog.md` where backend work must land together.
+
+---
+
+## VAD hangover tuning — optimal default and dynamic adjustment
+
+**Promoted to proposal:** [031-vad-hangover-tuning.md](031-vad-hangover-tuning.md)
+
+**Origin:** Rozmowa 2026-04-22 (sesja testów voice agenta)
+
+**Problem:** Wypowiedzi są dzielone na fragmenty — VAD za szybko uznaje przerwę za koniec wypowiedzi i wysyła kawałek do STT. W trakcie sesji przetestowano 10 s → 1000 ms → 800 ms. Wartość 800 ms daje rozsądny kompromis między swobodą naturalnych pauz a latencją reakcji agenta.
+
+**Proposed direction — dynamic hangover:**
+- Formuła: `hangover = base_hangover + (noise_level * scaling_factor)`
+- Sygnały do dynamicznej regulacji: poziom szumu tła, długość poprzedniej wypowiedzi, kontekst (agent zadał pytanie otwarte → większy bufor), tempo mowy użytkownika
+- Alternatywa pragmatyczna: start 800 ms + strojenie na podstawie feedbacku i metryk (ile razy wypowiedź dociera w wielu fragmentach vs. w całości)
+
+**Research needed:**
+- Zbadać typowe wartości hangover w produkcyjnych aplikacjach VAD (Alexa, Siri, Google Assistant)
+- Zebrać metryki fragmentacji wypowiedzi na realnych użyciach z 800 ms
+
+**Related proposals:** 012-hands-free-local-vad, 013-vad-advanced-settings.
+
+**Related ADRs:** ADR-AUDIO-006-immutable-vad-config (może wymagać rewizji, jeśli hangover staje się runtime-dynamic).
+
+**When to address:** Po okresie zbierania danych z 800 ms (≥ 1 tydzień realnych użyć).
+
+---
+
+## "New conversation" button in voice agent UI
+
+**Promoted to proposal:** [032-new-conversation-button.md](032-new-conversation-button.md)
+
+**Origin:** Rozmowa 2026-04-22
+
+**Decision:** Przycisk do rozpoczęcia nowej konwersacji ma być w kliencie mobilnym (voice agent), nie w web UI personal-agent. Uzasadnienie: primary flow jest głosowy, w mobilce — UI webowe to widok wtórny.
+
+**Proposed solution:** Widget (button albo swipe gesture) w recording screen lub chat screen. Akcja: zamknięcie bieżącej `conversation_id`, wyczyszczenie lokalnego stanu rozmowy, start nowej sesji i nowej konwersacji.
+
+**Related proposals:** 014-recording-mode-overhaul, 024-chat-screen, 029-honor-session-control-signals (shared SessionIdCoordinator).
+
+**When to address:** Niska priorytet — dotyka UX recording/chat screen; zrobić w ramach najbliższego pass nad mobile UX.
+
+---
+
+## Honor session-control signals from backend metadata (reset session, stop recording)
+
+**Promoted to proposal:** [029-honor-session-control-signals.md](029-honor-session-control-signals.md) (full draft)
+
+**Cross-project pair:** personal-agent P049 (full draft) — must ship together.
+
+**Status:** Both proposals are fully designed. Ready for review and implementation.
+
+---
+
+## Daily / monthly API cost dashboard in mobile UI
+
+**Promoted to proposal:** [033-api-cost-dashboard.md](033-api-cost-dashboard.md)
+
+**Origin:** Rozmowa 2026-04-22
+
+**Problem:** User chce widzieć agregaty kosztów API (dzień / miesiąc) w mobilce. Uzupełnienie możliwości zapytania agenta głosowo o koszt bieżącej rozmowy — dashboard dla wglądu retrospektywnego.
+
+**Proposed solution:** Nowy ekran "Usage" / "Koszty" albo sekcja w settings screen. Pobiera agregaty z `/api/v1/usage?from=&to=`. Wykres dzienny dla bieżącego miesiąca + licznik miesięczny (aktualny + poprzedni).
+
+**Related (personal-agent):** P033 api-usage-and-cost-tracking (dane istnieją, brak endpointu agregującego — potrzebny nowy proposal ~P055), P051 agent-tool-cost-of-conversation (komplementarnie z dashboardem).
+
+**Related proposals (voice-agent):** 021-agenda-screen (wzorzec ekranu z agregatami), 006-settings-screen (jeśli jako podsekcja).
+
+**When to address:** Po stworzeniu endpointu agregującego po stronie personal-agent. P051 nie blokuje — to komplementarna funkcja (głos + wizualne).
+
+---
+
+## TTS mixed-language support — honor SSML `<lang>` tags
+
+**Promoted to proposal:** [030-tts-mixed-language-ssml.md](030-tts-mixed-language-ssml.md) (full draft)
+
+**Cross-project pair:** personal-agent P054 (full draft) — must ship together; P054 has a kill switch (`CHAT_SSML_WRAPPER_ENABLED=false`) until voice-agent 030 is deployed.
+
+**Status:** Both proposals are fully designed. Ready for review and implementation.


### PR DESCRIPTION
## Summary

Promote all five P000-backlog items to standalone proposal seeds with cross-project dependency analysis.

### New proposal seeds (reviewed, P0/P1/P2 findings fixed):

| # | Title | Tier | Status | Cross-project |
|---|-------|------|--------|---------------|
| 031 | VAD Hangover Tuning | 2 | Ready (Phase 1 can start) | None |
| 032 | New Conversation Button | 1 | Ready (after P029 T1) | Shares SessionIdCoordinator with P029 |
| 033 | API Cost Dashboard | 1 | Blocked | Needs backend aggregation endpoint (~P055) |

### Pre-existing drafts (committed, not reviewed in this PR):

| # | Title | Tier | Cross-project |
|---|-------|------|---------------|
| 029 | Honor Session-Control Signals | 2 | Must ship with personal-agent P049 |
| 030 | TTS Mixed-Language SSML | 2 | Must ship with personal-agent P054 |

### Also included:
- P000-backlog updated with cross-references to all promoted proposals
- CLAUDE.md: proposals must merge to main before implementation begins

## Review notes

P031, P032, P033 went through primary proposal review. All P0/P1/P2 findings were fixed:
- P031: corrected hangover default (500ms not 800ms), scoped out cross-feature Option B, fixed event name, added acceptance criteria/risks/tasks
- P032: added acceptance criteria and tasks, fixed HandsFreeState names, made P029 an explicit blocking dependency
- P033: added acceptance criteria, switched to StateNotifier pattern, resolved routing to /settings/usage, added test plan and risks

P029 and P030 are pre-existing full drafts — they should go through their own review cycle before implementation.

## Test plan

- [x] Proposal review completed for 031, 032, 033
- [ ] P029 needs its own Tier 2 review before implementation
- [ ] P030 needs its own Tier 2 review before implementation
- [ ] Backend proposals (P049, P054, ~P055) need review on personal-agent side
