### PR TITLE
docs(p029, p030): address Tier 2 review findings

### DIFF
--- a/docs/proposals/029-honor-session-control-signals.md
+++ b/docs/proposals/029-honor-session-control-signals.md
@@ -567,8 +567,10 @@ shape for verification.
 - `lib/core/session_control/session_control_signal.dart` — value object
   and `fromBody` constructor (see code above).
 - `lib/core/session_control/hands_free_control_port.dart` — `HandsFreeControlPort`
-  interface with three methods: `stopSession`, `isSessionActive`,
-  `isSuspendedForManualRecording`.
+  interface with two methods: `Future<void> stopSession()` and
+  `bool get isSuspendedForManualRecording`. (`isSessionActive` is tracked
+  in a separate Riverpod provider, not on the controller — omitted from
+  the port to keep it minimal.)
 - `lib/core/session_control/session_id_coordinator.dart` — holds
   `currentConversationId`; exposes `resetSession()` and a getter.
 - `lib/core/session_control/toaster.dart` — wraps
@@ -871,6 +873,28 @@ rationale.
    every feature directory.
 9. Manual smoke on iPhone 12 Pro and an Android 14+ device reproduces
    each scenario in Test Impact.
+
+## Review Notes (2026-04-23)
+
+Reviewed as Tier 2. Verdict: Ready with caveats. P1 fixed (port method
+list). P2 findings accepted as implementation notes:
+
+- **`_handleReply` async + drain interaction:** `_drain()` should `await`
+  `_handleReply` up to and including `speak()` (fast — platform ack only),
+  then `unawaited(dispatcher.dispatch(signal))` for the TTS-wait stage.
+- **`speak()` does not guarantee `isSpeaking == true` on return:** The
+  `setStartHandler` fires asynchronously after `_tts.speak()` resolves.
+  Mitigated by the 3-second timeout ceiling — if the dispatcher observes
+  `isSpeaking == false` and the start handler fires within that window,
+  the dispatcher catches it. Worst case: signal applies immediately
+  (farewell cut short) — still safe (mic released).
+- **ProviderScope override:** `handsFreeControlPortProvider` override must
+  live in `main.dart` where `ProviderScope` is created, not in `app.dart`.
+- **`reset_session` client-side behavior in v1:** Beyond the toast, the
+  only observable effect is clearing `SessionIdCoordinator.currentConversationId`.
+  This has no wire effect — the backend manages conversation boundaries
+  via device-id stitching. The coordinator is a future extensibility point
+  and a log/telemetry tag.
 
 ## Related
 

--- a/docs/proposals/030-tts-mixed-language-ssml.md
+++ b/docs/proposals/030-tts-mixed-language-ssml.md
@@ -496,8 +496,8 @@ Two defensive behaviours must hold even on unexpected input:
 
 `test/core/tts/ssml_lang_splitter_test.dart`:
 
-- Empty input → one empty default segment (or zero segments — pick one
-  and document in the class doc).
+- Empty input → zero segments (consistent with the splitter contract;
+  `speak()` early-returns without touching `_tts`).
 - Untagged text → one default segment with exact input text.
 - Single `<lang xml:lang="en-US">X</lang>` → three segments: leading
   default, tagged en-US, trailing default (empty segments elided).
@@ -700,6 +700,28 @@ Each task is a mergeable PR with tests unless marked as a follow-up.
    no cross-feature imports).
 9. Device smoke (T3) is recorded in this proposal before status flips
    to Implemented.
+
+## Review Notes (2026-04-23)
+
+Reviewed as Tier 2. Verdict: Ready with caveats. No P0/P1. P2 findings
+accepted as implementation notes:
+
+- **`_runQueue` pseudocode:** `await _tts.speak(...)` returns on platform
+  acknowledgement, not playback end. `doneCompleter.future` is the actual
+  "wait for all segments" signal. Implementer must not confuse the two.
+- **Mock rework for T2 tests:** `_MockFlutterTts` must be extended to
+  capture `setStartHandler`/`setCompletionHandler`/`setCancelHandler`/
+  `setErrorHandler` registrations and expose methods to fire them on
+  demand. This is a T2 prerequisite, not optional.
+- **Empty input contract:** Committed to zero segments (fixed in test
+  plan). `speak()` early-returns without touching `_tts`.
+- **`speak()` completion semantics change:** With queuing, `speak()`
+  returns after all segments complete (via `doneCompleter`), not after
+  platform ack. No caller currently awaits it, so no functional impact.
+  Documented as conscious change.
+- **Per-language cache miss cost:** `_bestVoice()` incurs one platform
+  channel call per new language per session. First tagged reply pays
+  ~20ms (PL + EN). Acceptable for v1.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Address review findings for P029 and P030 proposals.

**P029 (session-control signals):**
- Fix HandsFreeControlPort: 2 methods, not 3 (remove isSessionActive — tracked in separate provider)
- Add review addendum documenting accepted P2 caveats (drain/async, isSpeaking timing, ProviderScope location, reset_session v1 behavior)

**P030 (TTS mixed-language SSML):**
- Fix empty input contract: zero segments (was inconsistent)
- Add review addendum documenting accepted P2 caveats (mock rework prerequisite, speak() completion semantics, cache miss cost)

## Test plan

- [x] Proposal review completed — no P0/P1 remaining
- [ ] Implementation follows on separate branches
