### PR TITLE
feat(core/session_control): P029-T1 session control core skeleton

### DIFF
--- a/lib/core/session_control/hands_free_control_port.dart
+++ b/lib/core/session_control/hands_free_control_port.dart
@@ -1,0 +1,15 @@
+/// Port interface for controlling the hands-free recording session.
+///
+/// Lives in `core/` so the [SessionControlDispatcher] depends only on
+/// core types, preserving the dependency rule. The adapter is
+/// `HandsFreeController` in `features/recording/` (T3).
+abstract class HandsFreeControlPort {
+  /// Stops the hands-free session: closes the mic, stops the foreground
+  /// service, and drains in-flight jobs.
+  Future<void> stopSession();
+
+  /// Whether the user has manually suspended the hands-free session
+  /// (e.g. tap-to-record or press-and-hold). When true, the dispatcher
+  /// skips [stopSession] because the user wins.
+  bool get isSuspendedForManualRecording;
+}

--- a/lib/core/session_control/haptic_service.dart
+++ b/lib/core/session_control/haptic_service.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/services.dart';
+
+/// Wraps [HapticFeedback.lightImpact] for testability.
+///
+/// The dispatcher fires a light haptic tap after applying each signal,
+/// providing non-visual confirmation for screenless use.
+class HapticService {
+  /// Triggers a light haptic impact.
+  Future<void> lightImpact() => HapticFeedback.lightImpact();
+}

--- a/lib/core/session_control/session_control_dispatcher.dart
+++ b/lib/core/session_control/session_control_dispatcher.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:voice_agent/core/session_control/hands_free_control_port.dart';
+import 'package:voice_agent/core/session_control/haptic_service.dart';
+import 'package:voice_agent/core/session_control/session_control_signal.dart';
+import 'package:voice_agent/core/session_control/session_id_coordinator.dart';
+import 'package:voice_agent/core/session_control/toaster.dart';
+import 'package:voice_agent/core/tts/tts_service.dart';
+
+/// Dispatches [SessionControlSignal]s after TTS finishes, applying
+/// `resetSession` then `stopRecording` in canonical order (P049 section 5).
+///
+/// Concurrent [dispatch] calls are serialized via an internal Future
+/// chain so a second call waits for the first to settle.
+class SessionControlDispatcher {
+  SessionControlDispatcher({
+    required TtsService ttsService,
+    required HandsFreeControlPort handsFreeControlPort,
+    required SessionIdCoordinator sessionIdCoordinator,
+    required Toaster toaster,
+    required HapticService hapticService,
+    Duration ttsTimeout = const Duration(seconds: 3),
+  })  : _ttsService = ttsService,
+        _handsFreeControlPort = handsFreeControlPort,
+        _sessionIdCoordinator = sessionIdCoordinator,
+        _toaster = toaster,
+        _hapticService = hapticService,
+        _ttsTimeout = ttsTimeout;
+
+  final TtsService _ttsService;
+  final HandsFreeControlPort _handsFreeControlPort;
+  final SessionIdCoordinator _sessionIdCoordinator;
+  final Toaster _toaster;
+  final HapticService _hapticService;
+  final Duration _ttsTimeout;
+
+  /// Internal Future chain for serializing concurrent dispatch calls.
+  Future<void> _chain = Future.value();
+
+  /// Single entry point. When [signal.isNoop], returns early without
+  /// waiting for TTS and without firing toast/haptic.
+  Future<void> dispatch(SessionControlSignal signal) {
+    if (signal.isNoop) {
+      debugPrint(
+        '[SessionControlDispatcher] noop signal received, skipping',
+      );
+      return Future.value();
+    }
+    _chain = _chain.then((_) => _dispatchImpl(signal));
+    return _chain;
+  }
+
+  Future<void> _dispatchImpl(SessionControlSignal signal) async {
+    try {
+      await _waitForTtsToFinish();
+
+      // Canonical order (P049 section 5): reset first, then stop.
+      if (signal.resetSession) {
+        await _sessionIdCoordinator.resetSession();
+        _toaster.show('New conversation');
+        await _hapticService.lightImpact();
+      }
+
+      if (signal.stopRecording) {
+        if (_handsFreeControlPort.isSuspendedForManualRecording) {
+          debugPrint(
+            '[SessionControlDispatcher] stopRecording skipped: '
+            'user is in manual recording mode',
+          );
+        } else {
+          await _handsFreeControlPort.stopSession();
+          _toaster.show('Session ended');
+          await _hapticService.lightImpact();
+        }
+      }
+    } catch (e) {
+      debugPrint('[SessionControlDispatcher] dispatch error: $e');
+    }
+  }
+
+  /// Waits for [TtsService.isSpeaking] to flip to false, or for
+  /// [_ttsTimeout] -- whichever comes first.
+  Future<void> _waitForTtsToFinish() async {
+    if (!_ttsService.isSpeaking.value) return;
+
+    final completer = Completer<void>();
+
+    void listener() {
+      if (!_ttsService.isSpeaking.value && !completer.isCompleted) {
+        completer.complete();
+      }
+    }
+
+    _ttsService.isSpeaking.addListener(listener);
+
+    try {
+      await completer.future.timeout(_ttsTimeout, onTimeout: () {
+        debugPrint(
+          '[SessionControlDispatcher] TTS timeout after $_ttsTimeout',
+        );
+      });
+    } finally {
+      _ttsService.isSpeaking.removeListener(listener);
+    }
+  }
+}

--- a/lib/core/session_control/session_control_provider.dart
+++ b/lib/core/session_control/session_control_provider.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:voice_agent/core/session_control/hands_free_control_port.dart';
+import 'package:voice_agent/core/session_control/haptic_service.dart';
+import 'package:voice_agent/core/session_control/session_control_dispatcher.dart';
+import 'package:voice_agent/core/session_control/session_id_coordinator.dart';
+import 'package:voice_agent/core/session_control/toaster.dart';
+import 'package:voice_agent/core/tts/tts_provider.dart';
+
+/// Provides a singleton [SessionIdCoordinator].
+final sessionIdCoordinatorProvider = Provider<SessionIdCoordinator>((ref) {
+  return SessionIdCoordinator();
+});
+
+/// Provides a [HandsFreeControlPort] implementation.
+///
+/// Throws by default -- must be overridden in `main.dart` (T3) to
+/// delegate to [HandsFreeController].
+final handsFreeControlPortProvider = Provider<HandsFreeControlPort>((ref) {
+  throw UnimplementedError(
+    'handsFreeControlPortProvider must be overridden in ProviderScope',
+  );
+});
+
+/// Provides a [Toaster] instance.
+///
+/// Throws by default -- must be overridden in `main.dart` (T3) to
+/// pass the app-level [GlobalKey<ScaffoldMessengerState>].
+final toasterProvider = Provider<Toaster>((ref) {
+  throw UnimplementedError(
+    'toasterProvider must be overridden in ProviderScope',
+  );
+});
+
+/// Provides a [HapticService] instance.
+final hapticServiceProvider = Provider<HapticService>((ref) {
+  return HapticService();
+});
+
+/// Provides a singleton [SessionControlDispatcher] wired to all
+/// required dependencies.
+final sessionControlDispatcherProvider =
+    Provider<SessionControlDispatcher>((ref) {
+  return SessionControlDispatcher(
+    ttsService: ref.watch(ttsServiceProvider),
+    handsFreeControlPort: ref.watch(handsFreeControlPortProvider),
+    sessionIdCoordinator: ref.watch(sessionIdCoordinatorProvider),
+    toaster: ref.watch(toasterProvider),
+    hapticService: ref.watch(hapticServiceProvider),
+  );
+});

--- a/lib/core/session_control/session_control_signal.dart
+++ b/lib/core/session_control/session_control_signal.dart
@@ -1,0 +1,47 @@
+/// Immutable value object representing session-control signals from the
+/// backend response envelope.
+///
+/// Parsed from the `session_control` key in the chat reply JSON body.
+/// See proposal P029 and personal-agent P049 for the wire contract.
+class SessionControlSignal {
+  const SessionControlSignal({
+    required this.resetSession,
+    required this.stopRecording,
+  });
+
+  final bool resetSession;
+  final bool stopRecording;
+
+  /// True when both booleans are false -- the envelope was present but
+  /// carries no actionable signal. The dispatcher returns early on noop.
+  bool get isNoop => !resetSession && !stopRecording;
+
+  /// Parses the `session_control` key from a decoded JSON response body.
+  ///
+  /// Returns `null` when the key is absent or its value is not a `Map`.
+  /// Returns a non-null [SessionControlSignal] (possibly with [isNoop]
+  /// true) when the envelope is present as a map. Missing boolean keys
+  /// inside the map default to `false`. Unknown keys are ignored.
+  static SessionControlSignal? fromBody(Map<String, dynamic> body) {
+    final raw = body['session_control'];
+    if (raw is! Map) return null;
+    return SessionControlSignal(
+      resetSession: raw['reset_session'] == true,
+      stopRecording: raw['stop_recording'] == true,
+    );
+  }
+
+  @override
+  String toString() =>
+      'SessionControlSignal(resetSession: $resetSession, stopRecording: $stopRecording)';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SessionControlSignal &&
+          other.resetSession == resetSession &&
+          other.stopRecording == stopRecording;
+
+  @override
+  int get hashCode => Object.hash(resetSession, stopRecording);
+}

--- a/lib/core/session_control/session_id_coordinator.dart
+++ b/lib/core/session_control/session_id_coordinator.dart
@@ -1,0 +1,24 @@
+/// Holds the current client-local conversation ID.
+///
+/// The ID is purely client-side -- used for diagnostics and log
+/// correlation. The outbound request body is unchanged (no
+/// `conversation_id` field per canonical P049 section 5).
+class SessionIdCoordinator {
+  String? _currentConversationId;
+
+  /// The current conversation ID, or null when a fresh conversation
+  /// will be opened on the next send.
+  String? get currentConversationId => _currentConversationId;
+
+  /// Clears the local conversation ID so the next outbound request
+  /// allows the backend to open a fresh conversation.
+  Future<void> resetSession() async {
+    _currentConversationId = null;
+  }
+
+  /// Adopts a conversation ID returned by the backend after a
+  /// successful reply so subsequent sends keep the same local tag.
+  void adoptConversationId(String id) {
+    _currentConversationId = id;
+  }
+}

--- a/lib/core/session_control/toaster.dart
+++ b/lib/core/session_control/toaster.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// Lightweight toast abstraction wrapping [ScaffoldMessengerState] via
+/// a [GlobalKey].
+///
+/// The key is owned by `app/app.dart` and passed to
+/// `MaterialApp.scaffoldMessengerKey`. The [Toaster] is exposed through
+/// `toasterProvider` so the [SessionControlDispatcher] can show toasts
+/// without a `BuildContext`.
+class Toaster {
+  Toaster(this._messengerKey);
+
+  final GlobalKey<ScaffoldMessengerState> _messengerKey;
+
+  /// Shows a floating [SnackBar] with the given [message].
+  void show(
+    String message, {
+    Duration duration = const Duration(seconds: 2),
+  }) {
+    final messenger = _messengerKey.currentState;
+    if (messenger == null) return;
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(message),
+        duration: duration,
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+}

--- a/test/core/session_control/session_control_dispatcher_test.dart
+++ b/test/core/session_control/session_control_dispatcher_test.dart
@@ -1,0 +1,422 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/session_control/hands_free_control_port.dart';
+import 'package:voice_agent/core/session_control/haptic_service.dart';
+import 'package:voice_agent/core/session_control/session_control_dispatcher.dart';
+import 'package:voice_agent/core/session_control/session_control_signal.dart';
+import 'package:voice_agent/core/session_control/session_id_coordinator.dart';
+import 'package:voice_agent/core/session_control/toaster.dart';
+import 'package:voice_agent/core/tts/tts_service.dart';
+
+// -- Fakes ----------------------------------------------------------------
+
+class _FakeTtsService implements TtsService {
+  final ValueNotifier<bool> _speaking = ValueNotifier(false);
+
+  @override
+  ValueListenable<bool> get isSpeaking => _speaking;
+
+  void setSpeaking(bool value) => _speaking.value = value;
+
+  @override
+  Future<void> speak(String text, {String? languageCode}) async {}
+
+  @override
+  Future<void> stop() async {
+    _speaking.value = false;
+  }
+
+  @override
+  void dispose() {
+    _speaking.dispose();
+  }
+}
+
+class _FakeHandsFreeControlPort implements HandsFreeControlPort {
+  final List<String> calls = [];
+  bool _suspended = false;
+
+  set suspended(bool value) => _suspended = value;
+
+  @override
+  bool get isSuspendedForManualRecording => _suspended;
+
+  @override
+  Future<void> stopSession() async {
+    calls.add('stopSession');
+  }
+}
+
+class _FakeToaster implements Toaster {
+  final List<String> messages = [];
+
+  @override
+  void show(String message, {Duration duration = const Duration(seconds: 2)}) {
+    messages.add(message);
+  }
+}
+
+class _FakeHapticService implements HapticService {
+  int callCount = 0;
+
+  @override
+  Future<void> lightImpact() async {
+    callCount++;
+  }
+}
+
+/// Tracks all side-effect calls in invocation order for ordering assertions.
+class _CallLog {
+  final List<String> entries = [];
+}
+
+// -- Tests ----------------------------------------------------------------
+
+void main() {
+  late _FakeTtsService tts;
+  late _FakeHandsFreeControlPort handsFree;
+  late SessionIdCoordinator coordinator;
+  late _FakeToaster toaster;
+  late _FakeHapticService haptic;
+  late _CallLog callLog;
+  late SessionControlDispatcher dispatcher;
+
+  setUp(() {
+    tts = _FakeTtsService();
+    handsFree = _FakeHandsFreeControlPort();
+    coordinator = SessionIdCoordinator();
+    toaster = _FakeToaster();
+    haptic = _FakeHapticService();
+    callLog = _CallLog();
+
+    // Wrap coordinator and handsFree to record call ordering.
+    final loggingCoordinator = _LoggingSessionIdCoordinator(
+      coordinator,
+      callLog,
+    );
+    final loggingHandsFree = _LoggingHandsFreeControlPort(
+      handsFree,
+      callLog,
+    );
+
+    dispatcher = SessionControlDispatcher(
+      ttsService: tts,
+      handsFreeControlPort: loggingHandsFree,
+      sessionIdCoordinator: loggingCoordinator,
+      toaster: toaster,
+      hapticService: haptic,
+      ttsTimeout: const Duration(milliseconds: 200),
+    );
+  });
+
+  group('SessionControlDispatcher', () {
+    test('reset=true, stop=false: resetSession called, stopSession not, '
+        'toast "New conversation", haptic fires', () async {
+      const signal = SessionControlSignal(
+        resetSession: true,
+        stopRecording: false,
+      );
+
+      await dispatcher.dispatch(signal);
+
+      expect(callLog.entries, ['resetSession']);
+      expect(handsFree.calls, isEmpty);
+      expect(toaster.messages, ['New conversation']);
+      expect(haptic.callCount, 1);
+    });
+
+    test('reset=false, stop=true: stopSession called, resetSession not, '
+        'toast "Session ended", haptic fires', () async {
+      const signal = SessionControlSignal(
+        resetSession: false,
+        stopRecording: true,
+      );
+
+      await dispatcher.dispatch(signal);
+
+      expect(callLog.entries, ['stopSession']);
+      expect(toaster.messages, ['Session ended']);
+      expect(haptic.callCount, 1);
+    });
+
+    test('both true: both called, resetSession before stopSession', () async {
+      const signal = SessionControlSignal(
+        resetSession: true,
+        stopRecording: true,
+      );
+
+      await dispatcher.dispatch(signal);
+
+      expect(callLog.entries, ['resetSession', 'stopSession']);
+      expect(toaster.messages, ['New conversation', 'Session ended']);
+      expect(haptic.callCount, 2);
+    });
+
+    test('noop: no calls, no toast, no haptic, no TTS wait', () async {
+      // Set TTS speaking to verify it is NOT observed for noop.
+      tts.setSpeaking(true);
+
+      const signal = SessionControlSignal(
+        resetSession: false,
+        stopRecording: false,
+      );
+
+      await dispatcher.dispatch(signal);
+
+      expect(callLog.entries, isEmpty);
+      expect(toaster.messages, isEmpty);
+      expect(haptic.callCount, 0);
+
+      // TTS is still speaking -- dispatcher did not wait.
+      expect(tts.isSpeaking.value, isTrue);
+    });
+
+    test('TTS not speaking: signal applies immediately', () async {
+      // isSpeaking starts false by default.
+      const signal = SessionControlSignal(
+        resetSession: true,
+        stopRecording: false,
+      );
+
+      final stopwatch = Stopwatch()..start();
+      await dispatcher.dispatch(signal);
+      stopwatch.stop();
+
+      expect(callLog.entries, ['resetSession']);
+      // Should complete well before the 200ms timeout.
+      expect(stopwatch.elapsedMilliseconds, lessThan(100));
+    });
+
+    test('TTS stuck (isSpeaking stays true > timeout): '
+        'signal applies after timeout', () async {
+      tts.setSpeaking(true);
+
+      const signal = SessionControlSignal(
+        resetSession: true,
+        stopRecording: false,
+      );
+
+      final stopwatch = Stopwatch()..start();
+      await dispatcher.dispatch(signal);
+      stopwatch.stop();
+
+      expect(callLog.entries, ['resetSession']);
+      // Should have waited at least the timeout duration.
+      expect(stopwatch.elapsedMilliseconds, greaterThanOrEqualTo(180));
+    });
+
+    test('TTS finishes before timeout: signal applies when TTS stops',
+        () async {
+      tts.setSpeaking(true);
+
+      const signal = SessionControlSignal(
+        resetSession: true,
+        stopRecording: false,
+      );
+
+      // Stop TTS after a short delay.
+      Timer(const Duration(milliseconds: 50), () {
+        tts.setSpeaking(false);
+      });
+
+      final stopwatch = Stopwatch()..start();
+      await dispatcher.dispatch(signal);
+      stopwatch.stop();
+
+      expect(callLog.entries, ['resetSession']);
+      // Should complete well before the 200ms timeout.
+      expect(stopwatch.elapsedMilliseconds, lessThan(150));
+    });
+
+    test('isSuspendedForManualRecording == true: '
+        'stopSession skipped, toast/haptic suppressed', () async {
+      handsFree.suspended = true;
+
+      const signal = SessionControlSignal(
+        resetSession: false,
+        stopRecording: true,
+      );
+
+      await dispatcher.dispatch(signal);
+
+      expect(callLog.entries, isEmpty);
+      expect(toaster.messages, isEmpty);
+      expect(haptic.callCount, 0);
+    });
+
+    test('isSuspendedForManualRecording == true with both signals: '
+        'resetSession applies, stopSession skipped', () async {
+      handsFree.suspended = true;
+
+      const signal = SessionControlSignal(
+        resetSession: true,
+        stopRecording: true,
+      );
+
+      await dispatcher.dispatch(signal);
+
+      // resetSession should still apply.
+      expect(callLog.entries, ['resetSession']);
+      expect(toaster.messages, ['New conversation']);
+      expect(haptic.callCount, 1);
+    });
+
+    test('concurrent dispatch calls are serialized', () async {
+      tts.setSpeaking(true);
+
+      const signal1 = SessionControlSignal(
+        resetSession: true,
+        stopRecording: false,
+      );
+      const signal2 = SessionControlSignal(
+        resetSession: false,
+        stopRecording: true,
+      );
+
+      // Dispatch two signals concurrently.
+      final future1 = dispatcher.dispatch(signal1);
+      final future2 = dispatcher.dispatch(signal2);
+
+      // TTS finishes after a short delay -- only the first dispatch
+      // should see isSpeaking=true.
+      Timer(const Duration(milliseconds: 50), () {
+        tts.setSpeaking(false);
+      });
+
+      await Future.wait([future1, future2]);
+
+      // Both signals applied, in order: first reset, then stop.
+      expect(callLog.entries, ['resetSession', 'stopSession']);
+      expect(
+        toaster.messages,
+        ['New conversation', 'Session ended'],
+      );
+      expect(haptic.callCount, 2);
+    });
+
+    test('concurrent dispatch: second waits for first to complete',
+        () async {
+      tts.setSpeaking(true);
+
+      final timestamps = <String>[];
+
+      const signal1 = SessionControlSignal(
+        resetSession: true,
+        stopRecording: false,
+      );
+      const signal2 = SessionControlSignal(
+        resetSession: false,
+        stopRecording: true,
+      );
+
+      final future1 = dispatcher.dispatch(signal1).then((_) {
+        timestamps.add('first-done');
+      });
+      final future2 = dispatcher.dispatch(signal2).then((_) {
+        timestamps.add('second-done');
+      });
+
+      // Let TTS timeout fire for first dispatch.
+      await Future.wait([future1, future2]);
+
+      // First must complete before second.
+      expect(timestamps, ['first-done', 'second-done']);
+    });
+
+    test('dispatch error does not break the chain', () async {
+      // Create a dispatcher with a handler that throws on first call.
+      var throwOnce = true;
+      final throwingCoordinator = _ThrowingSessionIdCoordinator(
+        coordinator,
+        () {
+          if (throwOnce) {
+            throwOnce = false;
+            throw Exception('test error');
+          }
+        },
+      );
+
+      final errorDispatcher = SessionControlDispatcher(
+        ttsService: tts,
+        handsFreeControlPort: handsFree,
+        sessionIdCoordinator: throwingCoordinator,
+        toaster: toaster,
+        hapticService: haptic,
+        ttsTimeout: const Duration(milliseconds: 200),
+      );
+
+      const signal = SessionControlSignal(
+        resetSession: true,
+        stopRecording: false,
+      );
+
+      // First dispatch -- the error is caught internally.
+      await errorDispatcher.dispatch(signal);
+
+      // Second dispatch should still work.
+      await errorDispatcher.dispatch(signal);
+
+      // The second call succeeded (no throw), so toast should appear.
+      expect(toaster.messages, ['New conversation']);
+    });
+  });
+}
+
+// -- Logging wrappers for ordering assertions --------------------------------
+
+class _LoggingSessionIdCoordinator extends SessionIdCoordinator {
+  _LoggingSessionIdCoordinator(this._delegate, this._log);
+
+  final SessionIdCoordinator _delegate;
+  final _CallLog _log;
+
+  @override
+  String? get currentConversationId => _delegate.currentConversationId;
+
+  @override
+  Future<void> resetSession() async {
+    _log.entries.add('resetSession');
+    await _delegate.resetSession();
+  }
+
+  @override
+  void adoptConversationId(String id) => _delegate.adoptConversationId(id);
+}
+
+class _LoggingHandsFreeControlPort implements HandsFreeControlPort {
+  _LoggingHandsFreeControlPort(this._delegate, this._log);
+
+  final _FakeHandsFreeControlPort _delegate;
+  final _CallLog _log;
+
+  @override
+  bool get isSuspendedForManualRecording =>
+      _delegate.isSuspendedForManualRecording;
+
+  @override
+  Future<void> stopSession() async {
+    _log.entries.add('stopSession');
+    await _delegate.stopSession();
+  }
+}
+
+class _ThrowingSessionIdCoordinator extends SessionIdCoordinator {
+  _ThrowingSessionIdCoordinator(this._delegate, this._onReset);
+
+  final SessionIdCoordinator _delegate;
+  final void Function() _onReset;
+
+  @override
+  String? get currentConversationId => _delegate.currentConversationId;
+
+  @override
+  Future<void> resetSession() async {
+    _onReset();
+    await _delegate.resetSession();
+  }
+
+  @override
+  void adoptConversationId(String id) => _delegate.adoptConversationId(id);
+}

--- a/test/core/session_control/session_control_signal_test.dart
+++ b/test/core/session_control/session_control_signal_test.dart
@@ -1,0 +1,220 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/session_control/session_control_signal.dart';
+
+void main() {
+  group('SessionControlSignal.fromBody', () {
+    test('full payload with both true returns non-null, both true, isNoop false',
+        () {
+      final body = <String, dynamic>{
+        'message': 'Goodbye.',
+        'session_control': {
+          'reset_session': true,
+          'stop_recording': true,
+        },
+      };
+
+      final signal = SessionControlSignal.fromBody(body);
+
+      expect(signal, isNotNull);
+      expect(signal!.resetSession, isTrue);
+      expect(signal.stopRecording, isTrue);
+      expect(signal.isNoop, isFalse);
+    });
+
+    test('absent session_control key returns null', () {
+      final body = <String, dynamic>{
+        'message': 'Hello.',
+      };
+
+      final signal = SessionControlSignal.fromBody(body);
+
+      expect(signal, isNull);
+    });
+
+    test('session_control value is not a Map (string) returns null', () {
+      final body = <String, dynamic>{
+        'session_control': 'not-a-map',
+      };
+
+      final signal = SessionControlSignal.fromBody(body);
+
+      expect(signal, isNull);
+    });
+
+    test('session_control value is not a Map (list) returns null', () {
+      final body = <String, dynamic>{
+        'session_control': [1, 2, 3],
+      };
+
+      final signal = SessionControlSignal.fromBody(body);
+
+      expect(signal, isNull);
+    });
+
+    test('session_control value is not a Map (null) returns null', () {
+      final body = <String, dynamic>{
+        'session_control': null,
+      };
+
+      final signal = SessionControlSignal.fromBody(body);
+
+      expect(signal, isNull);
+    });
+
+    test('both false returns non-null with isNoop true', () {
+      final body = <String, dynamic>{
+        'session_control': {
+          'reset_session': false,
+          'stop_recording': false,
+        },
+      };
+
+      final signal = SessionControlSignal.fromBody(body);
+
+      expect(signal, isNotNull);
+      expect(signal!.resetSession, isFalse);
+      expect(signal.stopRecording, isFalse);
+      expect(signal.isNoop, isTrue);
+    });
+
+    test('missing keys inside map default to false, returns non-null', () {
+      final body = <String, dynamic>{
+        'session_control': <String, dynamic>{},
+      };
+
+      final signal = SessionControlSignal.fromBody(body);
+
+      expect(signal, isNotNull);
+      expect(signal!.resetSession, isFalse);
+      expect(signal.stopRecording, isFalse);
+      expect(signal.isNoop, isTrue);
+    });
+
+    test('missing reset_session defaults to false', () {
+      final body = <String, dynamic>{
+        'session_control': {
+          'stop_recording': true,
+        },
+      };
+
+      final signal = SessionControlSignal.fromBody(body);
+
+      expect(signal, isNotNull);
+      expect(signal!.resetSession, isFalse);
+      expect(signal.stopRecording, isTrue);
+    });
+
+    test('missing stop_recording defaults to false', () {
+      final body = <String, dynamic>{
+        'session_control': {
+          'reset_session': true,
+        },
+      };
+
+      final signal = SessionControlSignal.fromBody(body);
+
+      expect(signal, isNotNull);
+      expect(signal!.resetSession, isTrue);
+      expect(signal.stopRecording, isFalse);
+    });
+
+    test('extra unknown keys are ignored, returns non-null', () {
+      final body = <String, dynamic>{
+        'session_control': {
+          'reset_session': true,
+          'stop_recording': false,
+          'future_signal': true,
+          'another_field': 42,
+        },
+      };
+
+      final signal = SessionControlSignal.fromBody(body);
+
+      expect(signal, isNotNull);
+      expect(signal!.resetSession, isTrue);
+      expect(signal.stopRecording, isFalse);
+      expect(signal.isNoop, isFalse);
+    });
+
+    test('non-boolean truthy values are not treated as true', () {
+      final body = <String, dynamic>{
+        'session_control': {
+          'reset_session': 1,
+          'stop_recording': 'yes',
+        },
+      };
+
+      final signal = SessionControlSignal.fromBody(body);
+
+      expect(signal, isNotNull);
+      expect(signal!.resetSession, isFalse);
+      expect(signal.stopRecording, isFalse);
+    });
+  });
+
+  group('SessionControlSignal', () {
+    test('isNoop is true when both booleans are false', () {
+      const signal = SessionControlSignal(
+        resetSession: false,
+        stopRecording: false,
+      );
+
+      expect(signal.isNoop, isTrue);
+    });
+
+    test('isNoop is false when resetSession is true', () {
+      const signal = SessionControlSignal(
+        resetSession: true,
+        stopRecording: false,
+      );
+
+      expect(signal.isNoop, isFalse);
+    });
+
+    test('isNoop is false when stopRecording is true', () {
+      const signal = SessionControlSignal(
+        resetSession: false,
+        stopRecording: true,
+      );
+
+      expect(signal.isNoop, isFalse);
+    });
+
+    test('equality by value', () {
+      const a = SessionControlSignal(
+        resetSession: true,
+        stopRecording: false,
+      );
+      const b = SessionControlSignal(
+        resetSession: true,
+        stopRecording: false,
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('inequality when fields differ', () {
+      const a = SessionControlSignal(
+        resetSession: true,
+        stopRecording: false,
+      );
+      const b = SessionControlSignal(
+        resetSession: false,
+        stopRecording: true,
+      );
+
+      expect(a, isNot(equals(b)));
+    });
+
+    test('toString includes field values', () {
+      const signal = SessionControlSignal(
+        resetSession: true,
+        stopRecording: false,
+      );
+
+      expect(signal.toString(), contains('resetSession: true'));
+      expect(signal.toString(), contains('stopRecording: false'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements P029-T1 (Core skeleton) -- the `core/session_control/` package with all types, dispatcher, and Riverpod providers. No feature wiring; the dispatcher is unreachable from production code in this PR.

- **SessionControlSignal**: immutable value object with `fromBody` parser for the `session_control` JSON envelope. Strict `== true` parsing, missing keys default to false, unknown keys ignored.
- **HandsFreeControlPort**: abstract port interface (`stopSession`, `isSuspendedForManualRecording`) so the dispatcher depends only on core types.
- **SessionIdCoordinator**: holds the client-local `conversationId`; `resetSession()` clears it, `adoptConversationId()` sets it.
- **Toaster**: wraps `ScaffoldMessengerState` via `GlobalKey` for showing floating SnackBars without `BuildContext`.
- **HapticService**: wraps `HapticFeedback.lightImpact()` for testability.
- **SessionControlDispatcher**: serialized dispatch with TTS-wait (or 3s timeout), canonical reset-before-stop ordering, toast/haptic feedback, noop early-return, and suspended-for-manual-recording guard.
- **Riverpod providers**: `sessionIdCoordinatorProvider`, `handsFreeControlPortProvider` (throwing default, T3 override), `toasterProvider` (throwing default, T3 override), `hapticServiceProvider`, `sessionControlDispatcherProvider`.

## Test plan

- [x] 17 signal parsing tests: full payload, absent key, non-Map values, both-false noop, missing inner keys, extra unknown keys, non-boolean truthy values, equality, toString
- [x] 12 dispatcher tests: reset-only, stop-only, both (order verified via call log), noop (no TTS wait/no side effects), TTS-not-speaking (immediate), TTS-stuck (timeout fires), TTS-finishes-before-timeout, suspended-for-manual (skip + suppress), suspended with both signals (reset applies, stop skipped), concurrent serialization (two approaches), error resilience
- [x] `make verify` passes (752 tests, zero analysis issues)
- [x] Dependency rule check passes (no cross-feature imports in core/)

Ref: `docs/proposals/029-honor-session-control-signals.md` T1

Generated with [Claude Code](https://claude.com/claude-code)
