### PR TITLE
feat(usage): add API cost dashboard (P033 T1+T2)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -11,6 +11,7 @@ import 'package:voice_agent/features/history/transcript_detail_screen.dart';
 import 'package:voice_agent/features/recording/presentation/recording_screen.dart';
 import 'package:voice_agent/features/settings/advanced_settings_screen.dart';
 import 'package:voice_agent/features/settings/settings_screen.dart';
+import 'package:voice_agent/features/usage/presentation/usage_screen.dart';
 
 GoRouter createRouter() => GoRouter(
   initialLocation: '/record',
@@ -108,6 +109,10 @@ GoRouter createRouter() => GoRouter(
         GoRoute(
           path: 'advanced',
           builder: (context, state) => const AdvancedSettingsScreen(),
+        ),
+        GoRoute(
+          path: 'usage',
+          builder: (context, state) => const UsageScreen(),
         ),
       ],
     ),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -273,6 +273,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             trailing: const Icon(Icons.chevron_right),
             onTap: () => context.push('/settings/advanced'),
           ),
+          _buildSectionHeader('Usage'),
+          ListTile(
+            key: const Key('usage-costs-tile'),
+            title: const Text('Usage & Costs'),
+            subtitle: const Text('API cost dashboard'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.push('/settings/usage'),
+          ),
           _buildSectionHeader('About'),
           ListTile(
             title: const Text('Version'),

--- a/lib/features/usage/data/usage_service.dart
+++ b/lib/features/usage/data/usage_service.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/features/usage/domain/usage_summary.dart';
+
+class UsageException implements Exception {
+  UsageException(this.message);
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class UsageService {
+  UsageService(this._apiClient);
+
+  final ApiClient _apiClient;
+
+  Future<UsageSummary> getSummary({
+    required String from,
+    required String to,
+  }) async {
+    final result = await _apiClient.get(
+      '/usage/summary',
+      queryParameters: {'from': from, 'to': to},
+    );
+
+    return switch (result) {
+      ApiSuccess(body: final body) => _parseResponse(body),
+      ApiPermanentFailure(message: final msg, statusCode: final code) =>
+        throw UsageException('Server error $code: $msg'),
+      ApiTransientFailure(reason: final reason) =>
+        throw UsageException(reason),
+      ApiNotConfigured() => throw UsageException('API not configured'),
+    };
+  }
+
+  UsageSummary _parseResponse(String? body) {
+    if (body == null) throw UsageException('Empty response');
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    return UsageSummary.fromMap(json);
+  }
+}

--- a/lib/features/usage/domain/usage_state.dart
+++ b/lib/features/usage/domain/usage_state.dart
@@ -1,0 +1,20 @@
+import 'package:voice_agent/features/usage/domain/usage_summary.dart';
+
+sealed class UsageState {
+  const UsageState();
+}
+
+class UsageLoading extends UsageState {
+  const UsageLoading();
+}
+
+class UsageLoaded extends UsageState {
+  const UsageLoaded({required this.currentMonth, this.previousMonth});
+  final UsageSummary currentMonth;
+  final UsageSummary? previousMonth;
+}
+
+class UsageError extends UsageState {
+  const UsageError({required this.message});
+  final String message;
+}

--- a/lib/features/usage/domain/usage_summary.dart
+++ b/lib/features/usage/domain/usage_summary.dart
@@ -1,0 +1,127 @@
+class ModelCost {
+  const ModelCost({
+    required this.model,
+    required this.costUsd,
+  });
+
+  final String model;
+  final double costUsd;
+
+  factory ModelCost.fromMap(Map<String, dynamic> map) {
+    return ModelCost(
+      model: map['model'] as String,
+      costUsd: (map['cost_usd'] as num).toDouble(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'model': model,
+      'cost_usd': costUsd,
+    };
+  }
+}
+
+class DailyUsage {
+  const DailyUsage({
+    required this.date,
+    required this.costUsd,
+    required this.costPln,
+    required this.requests,
+    required this.models,
+  });
+
+  final String date;
+  final double costUsd;
+  final double costPln;
+  final int requests;
+  final List<ModelCost> models;
+
+  factory DailyUsage.fromMap(Map<String, dynamic> map) {
+    final modelsMap = map['models'] as Map<String, dynamic>? ?? {};
+    final modelsList = modelsMap.entries.map((e) {
+      final value = e.value as Map<String, dynamic>;
+      return ModelCost(
+        model: e.key,
+        costUsd: (value['cost_usd'] as num).toDouble(),
+      );
+    }).toList();
+
+    return DailyUsage(
+      date: map['date'] as String,
+      costUsd: (map['cost_usd'] as num).toDouble(),
+      costPln: (map['cost_pln'] as num).toDouble(),
+      requests: map['requests'] as int,
+      models: modelsList,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    final modelsMap = <String, dynamic>{};
+    for (final m in models) {
+      modelsMap[m.model] = {'cost_usd': m.costUsd};
+    }
+    return {
+      'date': date,
+      'cost_usd': costUsd,
+      'cost_pln': costPln,
+      'requests': requests,
+      'models': modelsMap,
+    };
+  }
+}
+
+class UsageSummary {
+  const UsageSummary({
+    required this.periodFrom,
+    required this.periodTo,
+    required this.totalCostUsd,
+    required this.totalCostPln,
+    required this.totalInputTokens,
+    required this.totalOutputTokens,
+    required this.totalRequests,
+    required this.daily,
+  });
+
+  final String periodFrom;
+  final String periodTo;
+  final double totalCostUsd;
+  final double totalCostPln;
+  final int totalInputTokens;
+  final int totalOutputTokens;
+  final int totalRequests;
+  final List<DailyUsage> daily;
+
+  factory UsageSummary.fromMap(Map<String, dynamic> map) {
+    final period = map['period'] as Map<String, dynamic>;
+    final dailyList = (map['daily'] as List<dynamic>)
+        .map((e) => DailyUsage.fromMap(e as Map<String, dynamic>))
+        .toList();
+
+    return UsageSummary(
+      periodFrom: period['from'] as String,
+      periodTo: period['to'] as String,
+      totalCostUsd: (map['total_cost_usd'] as num).toDouble(),
+      totalCostPln: (map['total_cost_pln'] as num).toDouble(),
+      totalInputTokens: map['total_input_tokens'] as int,
+      totalOutputTokens: map['total_output_tokens'] as int,
+      totalRequests: map['total_requests'] as int,
+      daily: dailyList,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'period': {
+        'from': periodFrom,
+        'to': periodTo,
+      },
+      'total_cost_usd': totalCostUsd,
+      'total_cost_pln': totalCostPln,
+      'total_input_tokens': totalInputTokens,
+      'total_output_tokens': totalOutputTokens,
+      'total_requests': totalRequests,
+      'daily': daily.map((d) => d.toMap()).toList(),
+    };
+  }
+}

--- a/lib/features/usage/presentation/usage_controller.dart
+++ b/lib/features/usage/presentation/usage_controller.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/features/usage/data/usage_service.dart';
+import 'package:voice_agent/features/usage/domain/usage_state.dart';
+import 'package:voice_agent/features/usage/domain/usage_summary.dart';
+
+class UsageController extends StateNotifier<UsageState> {
+  UsageController(this._service) : super(const UsageLoading()) {
+    _load();
+  }
+
+  final UsageService _service;
+
+  Future<void> _load() async {
+    state = const UsageLoading();
+
+    try {
+      final now = DateTime.now();
+      final currentFrom = _firstOfMonth(now.year, now.month);
+      final currentTo = _formatDate(now);
+
+      final prevMonth = now.month == 1
+          ? DateTime(now.year - 1, 12)
+          : DateTime(now.year, now.month - 1);
+      final previousFrom = _firstOfMonth(prevMonth.year, prevMonth.month);
+      final previousTo = _lastOfMonth(prevMonth.year, prevMonth.month);
+
+      final currentSummary = await _service.getSummary(
+        from: currentFrom,
+        to: currentTo,
+      );
+
+      UsageSummary? previousSummary;
+      try {
+        previousSummary = await _service.getSummary(
+          from: previousFrom,
+          to: previousTo,
+        );
+      } catch (_) {
+        // Previous month data is optional; ignore errors
+      }
+
+      state = UsageLoaded(
+        currentMonth: currentSummary,
+        previousMonth: previousSummary,
+      );
+    } catch (e) {
+      state = UsageError(message: e.toString());
+    }
+  }
+
+  Future<void> refresh() => _load();
+
+  String _firstOfMonth(int year, int month) {
+    return '$year-${month.toString().padLeft(2, '0')}-01';
+  }
+
+  String _lastOfMonth(int year, int month) {
+    final lastDay = DateTime(year, month + 1, 0).day;
+    return '$year-${month.toString().padLeft(2, '0')}-${lastDay.toString().padLeft(2, '0')}';
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/features/usage/presentation/usage_providers.dart
+++ b/lib/features/usage/presentation/usage_providers.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/providers/api_client_provider.dart';
+import 'package:voice_agent/features/usage/data/usage_service.dart';
+import 'package:voice_agent/features/usage/domain/usage_state.dart';
+import 'package:voice_agent/features/usage/presentation/usage_controller.dart';
+
+final usageServiceProvider = Provider<UsageService>((ref) {
+  final apiClient = ref.watch(apiClientProvider);
+  return UsageService(apiClient);
+});
+
+final usageControllerProvider =
+    StateNotifierProvider<UsageController, UsageState>((ref) {
+  final service = ref.watch(usageServiceProvider);
+  return UsageController(service);
+});

--- a/lib/features/usage/presentation/usage_screen.dart
+++ b/lib/features/usage/presentation/usage_screen.dart
@@ -1,0 +1,315 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/features/usage/domain/usage_summary.dart';
+import 'package:voice_agent/features/usage/domain/usage_state.dart';
+import 'package:voice_agent/features/usage/presentation/usage_providers.dart';
+
+class UsageScreen extends ConsumerWidget {
+  const UsageScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(usageControllerProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Usage & Costs')),
+      body: switch (state) {
+        UsageLoading() => const Center(
+            child: CircularProgressIndicator(),
+          ),
+        UsageError(message: final message) => _buildError(context, ref, message),
+        UsageLoaded(
+          currentMonth: final current,
+          previousMonth: final previous,
+        ) =>
+          _buildLoaded(context, ref, current, previous),
+      },
+    );
+  }
+
+  Widget _buildError(BuildContext context, WidgetRef ref, String message) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.error_outline, size: 64, color: Colors.red),
+          const SizedBox(height: 16),
+          Text(message, textAlign: TextAlign.center),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () =>
+                ref.read(usageControllerProvider.notifier).refresh(),
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLoaded(
+    BuildContext context,
+    WidgetRef ref,
+    UsageSummary current,
+    UsageSummary? previous,
+  ) {
+    return RefreshIndicator(
+      onRefresh: () => ref.read(usageControllerProvider.notifier).refresh(),
+      child: ListView(
+        children: [
+          _SummaryHeader(summary: current),
+          if (current.daily.isNotEmpty) ...[
+            _SectionTitle(title: 'Daily Breakdown'),
+            _DailyBreakdown(daily: current.daily),
+          ],
+          if (previous != null)
+            _PreviousMonthSection(summary: previous),
+        ],
+      ),
+    );
+  }
+}
+
+class _SummaryHeader extends StatelessWidget {
+  const _SummaryHeader({required this.summary});
+  final UsageSummary summary;
+
+  String _formatTokens(int tokens) {
+    if (tokens >= 1000000) {
+      return '${(tokens / 1000000).toStringAsFixed(1)}M';
+    }
+    if (tokens >= 1000) {
+      return '${(tokens / 1000).toStringAsFixed(1)}K';
+    }
+    return tokens.toString();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.all(16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Current Month',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '${summary.periodFrom} - ${summary.periodTo}',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '${summary.totalCostPln.toStringAsFixed(2)} PLN',
+              key: const Key('usage-total-pln'),
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            Text(
+              '\$${summary.totalCostUsd.toStringAsFixed(2)} USD',
+              key: const Key('usage-total-usd'),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: _StatChip(
+                    label: 'Requests',
+                    value: summary.totalRequests.toString(),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _StatChip(
+                    label: 'Input tokens',
+                    value: _formatTokens(summary.totalInputTokens),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _StatChip(
+                    label: 'Output tokens',
+                    value: _formatTokens(summary.totalOutputTokens),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatChip extends StatelessWidget {
+  const _StatChip({required this.label, required this.value});
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          value,
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  const _SectionTitle({required this.title});
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+              color: Theme.of(context).colorScheme.primary,
+            ),
+      ),
+    );
+  }
+}
+
+class _DailyBreakdown extends StatelessWidget {
+  const _DailyBreakdown({required this.daily});
+  final List<DailyUsage> daily;
+
+  @override
+  Widget build(BuildContext context) {
+    final maxCost =
+        daily.map((d) => d.costUsd).reduce((a, b) => max(a, b));
+
+    return Column(
+      children: daily.map((day) => _DailyRow(day: day, maxCost: maxCost)).toList(),
+    );
+  }
+}
+
+class _DailyRow extends StatelessWidget {
+  const _DailyRow({required this.day, required this.maxCost});
+  final DailyUsage day;
+  final double maxCost;
+
+  @override
+  Widget build(BuildContext context) {
+    final fraction = maxCost > 0 ? day.costUsd / maxCost : 0.0;
+
+    return ExpansionTile(
+      title: Row(
+        children: [
+          SizedBox(
+            width: 80,
+            child: Text(
+              day.date.substring(5), // MM-DD
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final barWidth = constraints.maxWidth * fraction;
+                return Align(
+                  alignment: Alignment.centerLeft,
+                  child: Container(
+                    key: Key('usage-bar-${day.date}'),
+                    height: 16,
+                    width: barWidth,
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.primary,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            '\$${day.costUsd.toStringAsFixed(2)}',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+      ),
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '${day.costPln.toStringAsFixed(2)} PLN | ${day.requests} requests',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 4),
+              ...day.models.map((m) => Padding(
+                    padding: const EdgeInsets.only(left: 8, top: 2),
+                    child: Text(
+                      '${m.model}: \$${m.costUsd.toStringAsFixed(2)}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  )),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PreviousMonthSection extends StatelessWidget {
+  const _PreviousMonthSection({required this.summary});
+  final UsageSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    return ExpansionTile(
+      key: const Key('usage-previous-month'),
+      title: Text(
+        'Previous Month (${summary.periodFrom} - ${summary.periodTo})',
+      ),
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '${summary.totalCostPln.toStringAsFixed(2)} PLN',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              Text(
+                '\$${summary.totalCostUsd.toStringAsFixed(2)} USD',
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '${summary.totalRequests} requests | '
+                '${summary.totalInputTokens} input tokens | '
+                '${summary.totalOutputTokens} output tokens',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/usage/data/usage_service_test.dart
+++ b/test/features/usage/data/usage_service_test.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/features/usage/data/usage_service.dart';
+
+class _StubApiClient extends ApiClient {
+  _StubApiClient() : super(baseUrl: 'https://test.com/api/v1');
+
+  ApiResult nextGetResult = const ApiSuccess(body: '{}');
+
+  String? lastGetPath;
+  Map<String, dynamic>? lastGetParams;
+
+  @override
+  Future<ApiResult> get(String path,
+      {Map<String, dynamic>? queryParameters}) async {
+    lastGetPath = path;
+    lastGetParams = queryParameters;
+    return nextGetResult;
+  }
+}
+
+Map<String, dynamic> _sampleResponse() => {
+      'period': {'from': '2026-04-01', 'to': '2026-04-23'},
+      'total_cost_usd': 12.34,
+      'total_cost_pln': 49.36,
+      'total_input_tokens': 1234567,
+      'total_output_tokens': 567890,
+      'total_requests': 42,
+      'daily': [
+        {
+          'date': '2026-04-01',
+          'cost_usd': 0.56,
+          'cost_pln': 2.24,
+          'requests': 3,
+          'models': {
+            'claude-sonnet-4-20250514': {'cost_usd': 0.40},
+          },
+        },
+      ],
+    };
+
+void main() {
+  late _StubApiClient apiClient;
+  late UsageService service;
+
+  setUp(() {
+    apiClient = _StubApiClient();
+    service = UsageService(apiClient);
+  });
+
+  group('getSummary', () {
+    test('sends correct path and query parameters', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode(_sampleResponse()),
+      );
+
+      await service.getSummary(from: '2026-04-01', to: '2026-04-23');
+
+      expect(apiClient.lastGetPath, '/usage/summary');
+      expect(apiClient.lastGetParams, {
+        'from': '2026-04-01',
+        'to': '2026-04-23',
+      });
+    });
+
+    test('parses successful response', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode(_sampleResponse()),
+      );
+
+      final summary =
+          await service.getSummary(from: '2026-04-01', to: '2026-04-23');
+
+      expect(summary.periodFrom, '2026-04-01');
+      expect(summary.periodTo, '2026-04-23');
+      expect(summary.totalCostUsd, 12.34);
+      expect(summary.totalCostPln, 49.36);
+      expect(summary.totalInputTokens, 1234567);
+      expect(summary.totalOutputTokens, 567890);
+      expect(summary.totalRequests, 42);
+      expect(summary.daily, hasLength(1));
+      expect(summary.daily[0].models, hasLength(1));
+    });
+
+    test('throws on empty body', () async {
+      apiClient.nextGetResult = const ApiSuccess(body: null);
+
+      expect(
+        () => service.getSummary(from: '2026-04-01', to: '2026-04-23'),
+        throwsA(isA<UsageException>()),
+      );
+    });
+
+    test('throws on permanent failure', () async {
+      apiClient.nextGetResult = const ApiPermanentFailure(
+        statusCode: 404,
+        message: 'Not found',
+      );
+
+      expect(
+        () => service.getSummary(from: '2026-04-01', to: '2026-04-23'),
+        throwsA(
+          isA<UsageException>().having(
+            (e) => e.message,
+            'message',
+            contains('404'),
+          ),
+        ),
+      );
+    });
+
+    test('throws on transient failure', () async {
+      apiClient.nextGetResult = const ApiTransientFailure(
+        reason: 'Timeout: connectionTimeout',
+      );
+
+      expect(
+        () => service.getSummary(from: '2026-04-01', to: '2026-04-23'),
+        throwsA(
+          isA<UsageException>().having(
+            (e) => e.message,
+            'message',
+            contains('Timeout'),
+          ),
+        ),
+      );
+    });
+
+    test('throws on not configured', () async {
+      apiClient.nextGetResult = const ApiNotConfigured();
+
+      expect(
+        () => service.getSummary(from: '2026-04-01', to: '2026-04-23'),
+        throwsA(
+          isA<UsageException>().having(
+            (e) => e.message,
+            'message',
+            contains('not configured'),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/features/usage/domain/usage_summary_test.dart
+++ b/test/features/usage/domain/usage_summary_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/features/usage/domain/usage_summary.dart';
+
+Map<String, dynamic> _sampleSummaryMap() => {
+      'period': {'from': '2026-04-01', 'to': '2026-04-23'},
+      'total_cost_usd': 12.34,
+      'total_cost_pln': 49.36,
+      'total_input_tokens': 1234567,
+      'total_output_tokens': 567890,
+      'total_requests': 42,
+      'daily': [
+        {
+          'date': '2026-04-01',
+          'cost_usd': 0.56,
+          'cost_pln': 2.24,
+          'requests': 3,
+          'models': {
+            'claude-sonnet-4-20250514': {'cost_usd': 0.40},
+            'gpt-4o': {'cost_usd': 0.16},
+          },
+        },
+        {
+          'date': '2026-04-02',
+          'cost_usd': 1.10,
+          'cost_pln': 4.40,
+          'requests': 5,
+          'models': {
+            'claude-sonnet-4-20250514': {'cost_usd': 1.10},
+          },
+        },
+      ],
+    };
+
+void main() {
+  group('ModelCost', () {
+    test('fromMap creates instance', () {
+      final cost = ModelCost.fromMap({
+        'model': 'gpt-4o',
+        'cost_usd': 0.16,
+      });
+
+      expect(cost.model, 'gpt-4o');
+      expect(cost.costUsd, 0.16);
+    });
+
+    test('toMap round-trips', () {
+      final original = ModelCost.fromMap({
+        'model': 'claude-sonnet-4-20250514',
+        'cost_usd': 0.40,
+      });
+      final restored = ModelCost.fromMap(original.toMap());
+
+      expect(restored.model, original.model);
+      expect(restored.costUsd, original.costUsd);
+    });
+  });
+
+  group('DailyUsage', () {
+    test('fromMap creates instance with model breakdown', () {
+      final daily = DailyUsage.fromMap({
+        'date': '2026-04-01',
+        'cost_usd': 0.56,
+        'cost_pln': 2.24,
+        'requests': 3,
+        'models': {
+          'claude-sonnet-4-20250514': {'cost_usd': 0.40},
+          'gpt-4o': {'cost_usd': 0.16},
+        },
+      });
+
+      expect(daily.date, '2026-04-01');
+      expect(daily.costUsd, 0.56);
+      expect(daily.costPln, 2.24);
+      expect(daily.requests, 3);
+      expect(daily.models, hasLength(2));
+      expect(daily.models[0].model, 'claude-sonnet-4-20250514');
+      expect(daily.models[0].costUsd, 0.40);
+      expect(daily.models[1].model, 'gpt-4o');
+      expect(daily.models[1].costUsd, 0.16);
+    });
+
+    test('fromMap handles missing models map', () {
+      final daily = DailyUsage.fromMap({
+        'date': '2026-04-01',
+        'cost_usd': 0.00,
+        'cost_pln': 0.00,
+        'requests': 0,
+      });
+
+      expect(daily.models, isEmpty);
+    });
+
+    test('toMap round-trips', () {
+      final original = DailyUsage.fromMap({
+        'date': '2026-04-01',
+        'cost_usd': 0.56,
+        'cost_pln': 2.24,
+        'requests': 3,
+        'models': {
+          'claude-sonnet-4-20250514': {'cost_usd': 0.40},
+        },
+      });
+      final restored = DailyUsage.fromMap(original.toMap());
+
+      expect(restored.date, original.date);
+      expect(restored.costUsd, original.costUsd);
+      expect(restored.costPln, original.costPln);
+      expect(restored.requests, original.requests);
+      expect(restored.models, hasLength(1));
+      expect(restored.models[0].model, original.models[0].model);
+      expect(restored.models[0].costUsd, original.models[0].costUsd);
+    });
+  });
+
+  group('UsageSummary', () {
+    test('fromMap creates full instance', () {
+      final summary = UsageSummary.fromMap(_sampleSummaryMap());
+
+      expect(summary.periodFrom, '2026-04-01');
+      expect(summary.periodTo, '2026-04-23');
+      expect(summary.totalCostUsd, 12.34);
+      expect(summary.totalCostPln, 49.36);
+      expect(summary.totalInputTokens, 1234567);
+      expect(summary.totalOutputTokens, 567890);
+      expect(summary.totalRequests, 42);
+      expect(summary.daily, hasLength(2));
+      expect(summary.daily[0].date, '2026-04-01');
+      expect(summary.daily[1].date, '2026-04-02');
+    });
+
+    test('toMap round-trips', () {
+      final original = UsageSummary.fromMap(_sampleSummaryMap());
+      final restored = UsageSummary.fromMap(original.toMap());
+
+      expect(restored.periodFrom, original.periodFrom);
+      expect(restored.periodTo, original.periodTo);
+      expect(restored.totalCostUsd, original.totalCostUsd);
+      expect(restored.totalCostPln, original.totalCostPln);
+      expect(restored.totalInputTokens, original.totalInputTokens);
+      expect(restored.totalOutputTokens, original.totalOutputTokens);
+      expect(restored.totalRequests, original.totalRequests);
+      expect(restored.daily, hasLength(original.daily.length));
+    });
+
+    test('fromMap with empty daily list', () {
+      final summary = UsageSummary.fromMap({
+        'period': {'from': '2026-04-01', 'to': '2026-04-30'},
+        'total_cost_usd': 0.0,
+        'total_cost_pln': 0.0,
+        'total_input_tokens': 0,
+        'total_output_tokens': 0,
+        'total_requests': 0,
+        'daily': [],
+      });
+
+      expect(summary.daily, isEmpty);
+      expect(summary.totalRequests, 0);
+    });
+  });
+}

--- a/test/features/usage/presentation/usage_screen_test.dart
+++ b/test/features/usage/presentation/usage_screen_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/features/usage/domain/usage_summary.dart';
+import 'package:voice_agent/features/usage/domain/usage_state.dart';
+import 'package:voice_agent/features/usage/presentation/usage_controller.dart';
+import 'package:voice_agent/features/usage/presentation/usage_providers.dart';
+import 'package:voice_agent/features/usage/presentation/usage_screen.dart';
+
+/// A minimal StateNotifier that holds a fixed UsageState without triggering
+/// any network calls.  This avoids the auto-load in UsageController's
+/// constructor.
+class _FixedStateController extends StateNotifier<UsageState>
+    implements UsageController {
+  _FixedStateController(super.initial);
+
+  @override
+  Future<void> refresh() async {}
+}
+
+UsageSummary _sampleSummary({
+  String from = '2026-04-01',
+  String to = '2026-04-23',
+  double costUsd = 12.34,
+  double costPln = 49.36,
+}) =>
+    UsageSummary(
+      periodFrom: from,
+      periodTo: to,
+      totalCostUsd: costUsd,
+      totalCostPln: costPln,
+      totalInputTokens: 1234567,
+      totalOutputTokens: 567890,
+      totalRequests: 42,
+      daily: [
+        const DailyUsage(
+          date: '2026-04-01',
+          costUsd: 0.56,
+          costPln: 2.24,
+          requests: 3,
+          models: [
+            ModelCost(model: 'claude-sonnet-4-20250514', costUsd: 0.40),
+            ModelCost(model: 'gpt-4o', costUsd: 0.16),
+          ],
+        ),
+        const DailyUsage(
+          date: '2026-04-02',
+          costUsd: 1.10,
+          costPln: 4.40,
+          requests: 5,
+          models: [
+            ModelCost(model: 'claude-sonnet-4-20250514', costUsd: 1.10),
+          ],
+        ),
+      ],
+    );
+
+Future<void> _pumpScreen(
+  WidgetTester tester, {
+  required UsageState state,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        usageControllerProvider.overrideWith(
+          (_) => _FixedStateController(state),
+        ),
+      ],
+      child: const MaterialApp(home: UsageScreen()),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  group('UsageScreen', () {
+    testWidgets('shows loading spinner', (tester) async {
+      await _pumpScreen(tester, state: const UsageLoading());
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('shows error state with retry button', (tester) async {
+      await _pumpScreen(
+        tester,
+        state: const UsageError(message: 'Server error 500: Internal'),
+      );
+
+      expect(find.text('Server error 500: Internal'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    });
+
+    testWidgets('shows cost summary in loaded state', (tester) async {
+      await _pumpScreen(
+        tester,
+        state: UsageLoaded(
+          currentMonth: _sampleSummary(),
+          previousMonth: _sampleSummary(
+            from: '2026-03-01',
+            to: '2026-03-31',
+            costUsd: 8.00,
+            costPln: 32.00,
+          ),
+        ),
+      );
+
+      // Primary PLN cost
+      expect(find.text('49.36 PLN'), findsOneWidget);
+      // Secondary USD cost
+      expect(find.text('\$12.34 USD'), findsOneWidget);
+      // Request count
+      expect(find.text('42'), findsOneWidget);
+      // Section title
+      expect(find.text('Current Month'), findsOneWidget);
+      // Daily breakdown section
+      expect(find.text('Daily Breakdown'), findsOneWidget);
+      // Previous month section (collapsed)
+      expect(find.textContaining('Previous Month'), findsOneWidget);
+    });
+
+    testWidgets('shows app bar with title', (tester) async {
+      await _pumpScreen(tester, state: const UsageLoading());
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text('Usage & Costs'),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `features/usage/` module with domain models (`UsageSummary`, `DailyUsage`, `ModelCost`), `UsageService` calling `GET /api/v1/usage/summary`, `UsageController` (StateNotifier), and `UsageScreen` with loading/error/loaded states
- Wire `/settings/usage` route as child of `/settings` and add "Usage & Costs" ListTile to the settings screen
- The backend endpoint does not exist yet -- the service will return errors until personal-agent ships the aggregation endpoint

Implements P033 T1 + T2 per `docs/proposals/033-api-cost-dashboard.md`.

## Test plan

- [x] `make verify` passes (804 tests, 0 analysis issues)
- [x] Model `fromMap`/`toMap` round-trip tests
- [x] Service tests with mocked `ApiClient` (correct endpoint, parsing, error handling)
- [x] Widget tests: loading spinner, error state with retry button, loaded state with cost summary
- [x] No cross-feature imports (usage imports only from core)
