### PR TITLE
feat(p029-t2t3): wire session control into SyncWorker and app

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -2,7 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:voice_agent/app/router.dart';
 
 class App extends StatefulWidget {
-  const App({super.key});
+  const App({super.key, this.scaffoldMessengerKey});
+
+  /// Global key for [ScaffoldMessengerState], used by [Toaster] to show
+  /// toasts without a [BuildContext]. Created in `main.dart` and shared
+  /// via the [toasterProvider] override in [ProviderScope].
+  ///
+  /// When null (tests), [MaterialApp] uses its own internal key and
+  /// toast functionality is not available.
+  final GlobalKey<ScaffoldMessengerState>? scaffoldMessengerKey;
 
   @override
   State<App> createState() => _AppState();
@@ -15,6 +23,7 @@ class _AppState extends State<App> {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: 'Voice Agent',
+      scaffoldMessengerKey: widget.scaffoldMessengerKey,
       theme: ThemeData(
         colorSchemeSeed: Colors.blue,
         useMaterial3: true,

--- a/lib/features/api_sync/sync_provider.dart
+++ b/lib/features/api_sync/sync_provider.dart
@@ -6,6 +6,7 @@ import 'package:voice_agent/core/providers/agent_reply_provider.dart';
 import 'package:voice_agent/core/providers/api_client_provider.dart';
 import 'package:voice_agent/core/providers/app_foreground_provider.dart';
 import 'package:voice_agent/core/providers/session_active_provider.dart';
+import 'package:voice_agent/core/session_control/session_control_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/features/api_sync/api_config.dart';
@@ -34,6 +35,8 @@ final syncWorkerProvider = Provider<SyncWorker>((ref) {
     // cover background TTS.
     shouldProcessQueue: () =>
         ref.read(appForegroundedProvider) || ref.read(sessionActiveProvider),
+    sessionControlDispatcher: ref.watch(sessionControlDispatcherProvider),
+    sessionIdCoordinator: ref.watch(sessionIdCoordinatorProvider),
     onAgentReply: (reply) {
       ref.read(latestAgentReplyProvider.notifier).state = reply;
     },

--- a/lib/features/api_sync/sync_worker.dart
+++ b/lib/features/api_sync/sync_worker.dart
@@ -4,6 +4,9 @@ import 'dart:convert';
 import 'package:voice_agent/core/audio/audio_feedback_service.dart';
 import 'package:voice_agent/core/network/api_client.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/session_control/session_control_dispatcher.dart';
+import 'package:voice_agent/core/session_control/session_control_signal.dart';
+import 'package:voice_agent/core/session_control/session_id_coordinator.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/api_sync/api_config.dart';
@@ -20,6 +23,8 @@ class SyncWorker {
     required this.getTtsEnabled,
     required this.audioFeedbackService,
     required this.shouldProcessQueue,
+    required this.sessionControlDispatcher,
+    required this.sessionIdCoordinator,
     this.onAgentReply,
   });
 
@@ -34,6 +39,9 @@ class SyncWorker {
   /// Returns true when the queue should be drained. After P027 this is
   /// `foreground OR hands-free session active`. See ADR-NET-002.
   final bool Function() shouldProcessQueue;
+
+  final SessionControlDispatcher sessionControlDispatcher;
+  final SessionIdCoordinator sessionIdCoordinator;
 
   final void Function(String reply)? onAgentReply;
 
@@ -155,7 +163,7 @@ class SyncWorker {
         case ApiSuccess(:final body):
           await storageService.markSent(item.id);
           unawaited(audioFeedbackService.playSuccess());
-          _handleReply(body);
+          await _handleReply(body);
         case ApiPermanentFailure(:final message):
           // Exhaust retry budget — permanent failures should never be auto-retried
           await storageService.markFailed(
@@ -181,7 +189,7 @@ class SyncWorker {
     }
   }
 
-  void _handleReply(String? body) {
+  Future<void> _handleReply(String? body) async {
     if (body == null) return;
     try {
       final json = jsonDecode(body) as Map<String, dynamic>;
@@ -192,10 +200,28 @@ class SyncWorker {
       // and background. iOS: covered by UIBackgroundModes:audio + playAndRecord.
       // Android: covered by FOREGROUND_SERVICE_MEDIA_PLAYBACK + mediaPlayback
       // service type on the active FG service.
+      //
+      // P029: sequenced stop+speak so that by the time the next line runs,
+      // ttsService.isSpeaking has deterministically flipped to true (or
+      // stayed false if TTS is disabled / threw). See P029 Failure modes
+      // "Order-of-signal-arrival edge".
       if (getTtsEnabled()) {
-        unawaited(ttsService.stop().then((_) => ttsService.speak(message, languageCode: language)));
+        await ttsService.stop();
+        await ttsService.speak(message, languageCode: language);
       }
       onAgentReply?.call(message);
+
+      // P029: adopt conversation_id for client-side correlation.
+      final conversationId = json['conversation_id'] as String?;
+      if (conversationId != null && conversationId.isNotEmpty) {
+        sessionIdCoordinator.adoptConversationId(conversationId);
+      }
+
+      // P029: parse and dispatch session control signal.
+      final signal = SessionControlSignal.fromBody(json);
+      if (signal != null) {
+        unawaited(sessionControlDispatcher.dispatch(signal));
+      }
     } catch (_) {
       // Non-JSON or unexpected shape — stay silent.
     }

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -10,6 +10,7 @@ import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/providers/session_active_provider.dart';
 import 'package:voice_agent/core/config/vad_config.dart';
 import 'package:voice_agent/core/models/transcript.dart';
+import 'package:voice_agent/core/session_control/hands_free_control_port.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
@@ -31,7 +32,8 @@ import 'package:voice_agent/features/recording/presentation/recording_providers.
 ///   • [StorageService.saveTranscript] + [enqueue] with rollback on enqueue failure
 ///   • WAV cleanup for rejections and session stop
 class HandsFreeController extends StateNotifier<HandsFreeSessionState>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver
+    implements HandsFreeControlPort {
   HandsFreeController(this._ref) : super(const HandsFreeIdle()) {
     WidgetsBinding.instance.addObserver(this);
   }
@@ -62,6 +64,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   bool _suspendedForManualRecording = false;
   bool _suspendedForTts = false;
 
+  @override
   bool get isSuspendedForManualRecording => _suspendedForManualRecording;
 
   /// Interrupts the active VAD segment and releases the microphone so that
@@ -226,6 +229,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     );
   }
 
+  @override
   Future<void> stopSession() async {
     if (state is HandsFreeIdle) return;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,8 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/app/app.dart';
 import 'package:voice_agent/core/background/flutter_foreground_task_service.dart';
+import 'package:voice_agent/core/session_control/session_control_provider.dart';
+import 'package:voice_agent/core/session_control/toaster.dart';
 import 'package:voice_agent/core/storage/sqlite_storage_service.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
+import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -18,12 +21,18 @@ void main() async {
     debugPrint('Recovered $recovered stale sending items');
   }
 
+  final scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
+
   runApp(
     ProviderScope(
       overrides: [
         storageServiceProvider.overrideWithValue(storage),
+        toasterProvider.overrideWithValue(Toaster(scaffoldMessengerKey)),
+        handsFreeControlPortProvider.overrideWith(
+          (ref) => ref.watch(handsFreeControllerProvider.notifier),
+        ),
       ],
-      child: const App(),
+      child: App(scaffoldMessengerKey: scaffoldMessengerKey),
     ),
   );
 }

--- a/test/app/app_shell_scaffold_test.dart
+++ b/test/app/app_shell_scaffold_test.dart
@@ -31,6 +31,7 @@ import 'package:voice_agent/features/recording/presentation/hands_free_controlle
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 
 import '../helpers/stub_background_service.dart';
+import '../helpers/stub_session_control.dart';
 
 // ── Stub dependencies ─────────────────────────────────────────────────────────
 
@@ -110,6 +111,7 @@ List<Override> get _baseOverrides => [
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedback()),
   backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
   agendaRepositoryProvider.overrideWithValue(_StubAgendaRepository()),
+  ...sessionControlTestOverrides,
 ];
 
 // ── Tracking HandsFreeController stubs ───────────────────────────────────────

--- a/test/app/app_test.dart
+++ b/test/app/app_test.dart
@@ -16,6 +16,7 @@ import 'package:voice_agent/features/agenda/domain/agenda_repository.dart';
 import 'package:voice_agent/features/agenda/presentation/agenda_providers.dart';
 
 import '../helpers/stub_background_service.dart';
+import '../helpers/stub_session_control.dart';
 
 class _StubStorageService implements StorageService {
   @override
@@ -87,6 +88,7 @@ List<Override> get _testOverrides => [
       connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
       backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
       agendaRepositoryProvider.overrideWithValue(_StubAgendaRepository()),
+      ...sessionControlTestOverrides,
     ];
 
 void main() {

--- a/test/app/router_test.dart
+++ b/test/app/router_test.dart
@@ -14,6 +14,7 @@ import 'package:voice_agent/features/agenda/domain/agenda_repository.dart';
 import 'package:voice_agent/features/agenda/presentation/agenda_providers.dart';
 
 import '../helpers/stub_background_service.dart';
+import '../helpers/stub_session_control.dart';
 
 class _StubStorageService implements StorageService {
   @override
@@ -80,6 +81,7 @@ void main() {
     storageServiceProvider.overrideWithValue(_StubStorageService()),
     backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
     agendaRepositoryProvider.overrideWithValue(_StubAgendaRepository()),
+    ...sessionControlTestOverrides,
   ];
 
   group('5-tab navigation', () {

--- a/test/features/api_sync/sync_worker_integration_test.dart
+++ b/test/features/api_sync/sync_worker_integration_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/session_control/hands_free_control_port.dart';
+import 'package:voice_agent/core/session_control/haptic_service.dart';
+import 'package:voice_agent/core/session_control/session_control_dispatcher.dart';
+import 'package:voice_agent/core/session_control/session_control_signal.dart';
+import 'package:voice_agent/core/session_control/session_id_coordinator.dart';
+import 'package:voice_agent/core/session_control/toaster.dart';
+import 'package:voice_agent/core/tts/tts_service.dart';
+
+// -- Test doubles --------------------------------------------------------
+
+class _FakeTtsService implements TtsService {
+  @override
+  ValueListenable<bool> get isSpeaking => ValueNotifier(false);
+
+  @override
+  Future<void> speak(String text, {String? languageCode}) async {}
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  void dispose() {}
+}
+
+class _FakeHandsFreeControlPort implements HandsFreeControlPort {
+  int stopSessionCalls = 0;
+
+  @override
+  bool isSuspendedForManualRecording = false;
+
+  @override
+  Future<void> stopSession() async {
+    stopSessionCalls++;
+  }
+}
+
+class _FakeToaster extends Toaster {
+  _FakeToaster() : super(GlobalKey<ScaffoldMessengerState>());
+  final List<String> messages = [];
+
+  @override
+  void show(String message, {Duration duration = const Duration(seconds: 2)}) {
+    messages.add(message);
+  }
+}
+
+class _FakeHapticService extends HapticService {
+  int calls = 0;
+
+  @override
+  Future<void> lightImpact() async {
+    calls++;
+  }
+}
+
+// -- Tests ---------------------------------------------------------------
+
+void main() {
+  late _FakeTtsService ttsService;
+  late _FakeHandsFreeControlPort controlPort;
+  late SessionIdCoordinator coordinator;
+  late _FakeToaster toaster;
+  late _FakeHapticService haptic;
+  late SessionControlDispatcher dispatcher;
+
+  setUp(() {
+    ttsService = _FakeTtsService();
+    controlPort = _FakeHandsFreeControlPort();
+    coordinator = SessionIdCoordinator();
+    toaster = _FakeToaster();
+    haptic = _FakeHapticService();
+    dispatcher = SessionControlDispatcher(
+      ttsService: ttsService,
+      handsFreeControlPort: controlPort,
+      sessionIdCoordinator: coordinator,
+      toaster: toaster,
+      hapticService: haptic,
+      ttsTimeout: Duration.zero,
+    );
+  });
+
+  group('full integration: signal parsing + dispatch', () {
+    test('stop_recording=true dispatches and calls stopSession', () async {
+      final body = {
+        'message': 'Goodbye',
+        'session_control': {'stop_recording': true},
+      };
+      final signal = SessionControlSignal.fromBody(body);
+      expect(signal, isNotNull);
+
+      await dispatcher.dispatch(signal!);
+
+      expect(controlPort.stopSessionCalls, 1);
+      expect(toaster.messages, ['Session ended']);
+      expect(haptic.calls, 1);
+      expect(coordinator.currentConversationId, isNull);
+    });
+
+    test('reset_session=true dispatches and clears coordinator', () async {
+      coordinator.adoptConversationId('old-conv-id');
+      expect(coordinator.currentConversationId, 'old-conv-id');
+
+      final body = {
+        'message': 'New session',
+        'session_control': {'reset_session': true},
+      };
+      final signal = SessionControlSignal.fromBody(body);
+      expect(signal, isNotNull);
+
+      await dispatcher.dispatch(signal!);
+
+      expect(coordinator.currentConversationId, isNull);
+      expect(controlPort.stopSessionCalls, 0);
+      expect(toaster.messages, ['New conversation']);
+      expect(haptic.calls, 1);
+    });
+
+    test('both signals: reset applied first, then stop', () async {
+      coordinator.adoptConversationId('old-id');
+      final callOrder = <String>[];
+
+      // Use a custom control port that records call order
+      final orderPort = _OrderedControlPort(callOrder);
+      final orderCoordinator = _OrderedSessionIdCoordinator(callOrder);
+      orderCoordinator.adoptConversationId('old-id');
+
+      final orderDispatcher = SessionControlDispatcher(
+        ttsService: ttsService,
+        handsFreeControlPort: orderPort,
+        sessionIdCoordinator: orderCoordinator,
+        toaster: toaster,
+        hapticService: haptic,
+        ttsTimeout: Duration.zero,
+      );
+
+      final body = {
+        'message': 'Goodbye',
+        'session_control': {'reset_session': true, 'stop_recording': true},
+      };
+      final signal = SessionControlSignal.fromBody(body);
+      expect(signal, isNotNull);
+
+      await orderDispatcher.dispatch(signal!);
+
+      expect(callOrder, ['resetSession', 'stopSession']);
+      expect(toaster.messages, ['New conversation', 'Session ended']);
+      expect(haptic.calls, 2);
+    });
+
+    test('both false (noop envelope) dispatches but does not call actions',
+        () async {
+      final body = {
+        'message': 'Hello',
+        'session_control': {'reset_session': false, 'stop_recording': false},
+      };
+      final signal = SessionControlSignal.fromBody(body);
+      expect(signal, isNotNull);
+      expect(signal!.isNoop, isTrue);
+
+      await dispatcher.dispatch(signal);
+
+      expect(controlPort.stopSessionCalls, 0);
+      expect(toaster.messages, isEmpty);
+      expect(haptic.calls, 0);
+    });
+
+    test('absent session_control key produces null signal', () {
+      final body = {'message': 'Hello'};
+      final signal = SessionControlSignal.fromBody(body);
+      expect(signal, isNull);
+    });
+  });
+}
+
+// -- Ordered test doubles for verifying call order -----------------------
+
+class _OrderedControlPort implements HandsFreeControlPort {
+  _OrderedControlPort(this._log);
+  final List<String> _log;
+
+  @override
+  bool isSuspendedForManualRecording = false;
+
+  @override
+  Future<void> stopSession() async {
+    _log.add('stopSession');
+  }
+}
+
+class _OrderedSessionIdCoordinator extends SessionIdCoordinator {
+  _OrderedSessionIdCoordinator(this._log);
+  final List<String> _log;
+
+  @override
+  Future<void> resetSession() async {
+    _log.add('resetSession');
+    await super.resetSession();
+  }
+}

--- a/test/features/api_sync/sync_worker_test.dart
+++ b/test/features/api_sync/sync_worker_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -9,6 +10,12 @@ import 'package:voice_agent/core/models/transcript_with_status.dart';
 import 'package:voice_agent/core/network/api_client.dart';
 import 'package:voice_agent/core/audio/audio_feedback_service.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/session_control/hands_free_control_port.dart';
+import 'package:voice_agent/core/session_control/haptic_service.dart';
+import 'package:voice_agent/core/session_control/session_control_dispatcher.dart';
+import 'package:voice_agent/core/session_control/session_control_signal.dart';
+import 'package:voice_agent/core/session_control/session_id_coordinator.dart';
+import 'package:voice_agent/core/session_control/toaster.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/api_sync/api_config.dart';
@@ -182,6 +189,70 @@ class _StubAudioFeedbackService implements AudioFeedbackService {
   @override void dispose() {}
 }
 
+class _FakeHandsFreeControlPort implements HandsFreeControlPort {
+  @override
+  bool isSuspendedForManualRecording = false;
+
+  int stopSessionCalls = 0;
+
+  @override
+  Future<void> stopSession() async {
+    stopSessionCalls++;
+  }
+}
+
+class _FakeToaster extends Toaster {
+  _FakeToaster() : super(GlobalKey<ScaffoldMessengerState>());
+  final List<String> messages = [];
+
+  @override
+  void show(String message, {Duration duration = const Duration(seconds: 2)}) {
+    messages.add(message);
+  }
+}
+
+class _FakeHapticService extends HapticService {
+  int calls = 0;
+
+  @override
+  Future<void> lightImpact() async {
+    calls++;
+  }
+}
+
+class _RecordingDispatcher extends SessionControlDispatcher {
+  _RecordingDispatcher()
+      : super(
+          ttsService: _NoopTtsService(),
+          handsFreeControlPort: _FakeHandsFreeControlPort(),
+          sessionIdCoordinator: SessionIdCoordinator(),
+          toaster: _FakeToaster(),
+          hapticService: _FakeHapticService(),
+          ttsTimeout: Duration.zero,
+        );
+
+  final List<SessionControlSignal> dispatched = [];
+
+  @override
+  Future<void> dispatch(SessionControlSignal signal) async {
+    dispatched.add(signal);
+  }
+}
+
+class _NoopTtsService implements TtsService {
+  @override
+  ValueListenable<bool> get isSpeaking => ValueNotifier(false);
+
+  @override
+  Future<void> speak(String text, {String? languageCode}) async {}
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  void dispose() {}
+}
+
 class FakeConnectivityService extends ConnectivityService {
   final _controller = StreamController<ConnectivityStatus>.broadcast();
 
@@ -203,6 +274,8 @@ void main() {
   late FakeConnectivityService connectivity;
   late _SpyTtsService tts;
   late bool ttsEnabled;
+  late _RecordingDispatcher dispatcher;
+  late SessionIdCoordinator sessionIdCoordinator;
   late SyncWorker worker;
 
   final transcript = Transcript(
@@ -219,6 +292,8 @@ void main() {
     connectivity = FakeConnectivityService();
     tts = _SpyTtsService();
     ttsEnabled = true;
+    dispatcher = _RecordingDispatcher();
+    sessionIdCoordinator = SessionIdCoordinator();
     worker = SyncWorker(
       storageService: storage,
       apiClient: apiClient,
@@ -228,6 +303,8 @@ void main() {
       getTtsEnabled: () => ttsEnabled,
       audioFeedbackService: _StubAudioFeedbackService(),
       shouldProcessQueue: () => true,
+      sessionControlDispatcher: dispatcher,
+      sessionIdCoordinator: sessionIdCoordinator,
     );
   });
 
@@ -315,6 +392,8 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => true,
+        sessionControlDispatcher: dispatcher,
+        sessionIdCoordinator: sessionIdCoordinator,
       );
 
       await storage.saveTranscript(transcript);
@@ -428,6 +507,8 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => true,
+        sessionControlDispatcher: dispatcher,
+        sessionIdCoordinator: sessionIdCoordinator,
         onAgentReply: (reply) => receivedReply = reply,
       );
 
@@ -454,6 +535,8 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => true,
+        sessionControlDispatcher: dispatcher,
+        sessionIdCoordinator: sessionIdCoordinator,
         onAgentReply: (reply) => receivedReply = reply,
       );
 
@@ -480,6 +563,8 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => true,
+        sessionControlDispatcher: dispatcher,
+        sessionIdCoordinator: sessionIdCoordinator,
         onAgentReply: (reply) => receivedReply = reply,
       );
 
@@ -505,6 +590,8 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => true,
+        sessionControlDispatcher: dispatcher,
+        sessionIdCoordinator: sessionIdCoordinator,
         onAgentReply: (reply) => receivedReply = reply,
       );
 
@@ -653,6 +740,8 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: predicate,
+        sessionControlDispatcher: dispatcher,
+        sessionIdCoordinator: sessionIdCoordinator,
       );
     }
 
@@ -725,6 +814,8 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => canProcess,
+        sessionControlDispatcher: dispatcher,
+        sessionIdCoordinator: sessionIdCoordinator,
       );
 
       await storage.saveTranscript(transcript);
@@ -830,6 +921,8 @@ void main() {
         getTtsEnabled: () => ttsEnabled,
         audioFeedbackService: _StubAudioFeedbackService(),
         shouldProcessQueue: () => true,
+        sessionControlDispatcher: dispatcher,
+        sessionIdCoordinator: sessionIdCoordinator,
         onAgentReply: (reply) => capturedReply = reply,
       );
 
@@ -864,6 +957,135 @@ void main() {
 
     test('attempt 10 returns 1 hour (capped)', () {
       expect(SyncWorker.backoffForAttempt(10), const Duration(hours: 1));
+    });
+  });
+
+  group('session control dispatch (P029-T2)', () {
+    test('body with stop_recording=true dispatches signal', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody =
+          '{"message":"Goodbye","language":"en","session_control":{"stop_recording":true,"reset_session":false}}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(dispatcher.dispatched, hasLength(1));
+      expect(dispatcher.dispatched.first.stopRecording, isTrue);
+      expect(dispatcher.dispatched.first.resetSession, isFalse);
+    });
+
+    test('body with only message does NOT dispatch', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody = '{"message":"Hello","language":"en"}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(dispatcher.dispatched, isEmpty);
+    });
+
+    test('malformed JSON body does NOT dispatch and does not throw', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody = 'not valid json {{';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(dispatcher.dispatched, isEmpty);
+    });
+
+    test('body with reset_session=true dispatches signal', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody =
+          '{"message":"New session","language":"en","session_control":{"reset_session":true}}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(dispatcher.dispatched, hasLength(1));
+      expect(dispatcher.dispatched.first.resetSession, isTrue);
+      expect(dispatcher.dispatched.first.stopRecording, isFalse);
+    });
+
+    test('body with both signals dispatches signal with both flags', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody =
+          '{"message":"Bye","language":"en","session_control":{"reset_session":true,"stop_recording":true}}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(dispatcher.dispatched, hasLength(1));
+      expect(dispatcher.dispatched.first.resetSession, isTrue);
+      expect(dispatcher.dispatched.first.stopRecording, isTrue);
+    });
+
+    test('conversation_id in reply is adopted by coordinator', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody =
+          '{"message":"ok","language":"en","conversation_id":"conv-42"}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(sessionIdCoordinator.currentConversationId, 'conv-42');
+    });
+
+    test('empty conversation_id is NOT adopted', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody =
+          '{"message":"ok","language":"en","conversation_id":""}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(sessionIdCoordinator.currentConversationId, isNull);
+    });
+
+    test('TTS stop and speak are awaited before dispatch', () async {
+      final orderTts = _SpyTtsService();
+      final orderDispatcher = _RecordingDispatcher();
+
+      worker = SyncWorker(
+        storageService: storage,
+        apiClient: apiClient,
+        apiConfig: const ApiConfig(url: 'https://example.com/api', token: 'tok'),
+        connectivityService: connectivity,
+        ttsService: orderTts,
+        getTtsEnabled: () => true,
+        audioFeedbackService: _StubAudioFeedbackService(),
+        shouldProcessQueue: () => true,
+        sessionControlDispatcher: orderDispatcher,
+        sessionIdCoordinator: sessionIdCoordinator,
+      );
+
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody =
+          '{"message":"bye","language":"en","session_control":{"stop_recording":true}}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      // TTS must have been called (stop then speak)
+      expect(orderTts.log, ['stop', 'speak:bye:en']);
+      // Dispatcher must have been called
+      expect(orderDispatcher.dispatched, hasLength(1));
     });
   });
 }

--- a/test/features/recording/presentation/recording_screen_hands_free_test.dart
+++ b/test/features/recording/presentation/recording_screen_hands_free_test.dart
@@ -31,6 +31,7 @@ import 'package:voice_agent/features/recording/presentation/recording_providers.
 import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../../helpers/stub_background_service.dart';
+import '../../../helpers/stub_session_control.dart';
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
@@ -136,6 +137,7 @@ List<Override> baseOverrides(FakeHfEngine engine) => [
       ttsServiceProvider.overrideWithValue(_StubTtsService()),
       audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
       backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+      ...sessionControlTestOverrides,
     ];
 
 Future<void> pumpRecordScreen(

--- a/test/features/recording/presentation/recording_screen_mic_button_test.dart
+++ b/test/features/recording/presentation/recording_screen_mic_button_test.dart
@@ -33,6 +33,7 @@ import 'package:voice_agent/features/recording/presentation/recording_providers.
 import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../../helpers/stub_background_service.dart';
+import '../../../helpers/stub_session_control.dart';
 
 // ── Stubs ────────────────────────────────────────────────────────────────────
 
@@ -156,6 +157,7 @@ List<Override> get _baseOverrides => [
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
   backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+  ...sessionControlTestOverrides,
 ];
 
 Future<void> pumpApp(WidgetTester tester) async {
@@ -190,6 +192,7 @@ Future<_SpyTtsService> _pumpAppWithSpyTts(WidgetTester tester) async {
         ttsServiceProvider.overrideWithValue(spy),
         audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
         backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+        ...sessionControlTestOverrides,
       ],
       child: const App(),
     ),

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -33,6 +33,7 @@ import 'package:voice_agent/features/recording/presentation/recording_providers.
 import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../../helpers/stub_background_service.dart';
+import '../../../helpers/stub_session_control.dart';
 
 class _StubStorage implements StorageService {
   @override Future<String> getDeviceId() async => 'test';
@@ -98,6 +99,7 @@ List<Override> get _baseOverrides => [
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
   backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+  ...sessionControlTestOverrides,
 ];
 
 void main() {

--- a/test/features/settings/advanced_settings_screen_test.dart
+++ b/test/features/settings/advanced_settings_screen_test.dart
@@ -26,6 +26,7 @@ import 'package:voice_agent/features/recording/presentation/recording_providers.
 import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../helpers/stub_background_service.dart';
+import '../../helpers/stub_session_control.dart';
 import 'package:voice_agent/features/settings/advanced_settings_screen.dart';
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────
@@ -106,6 +107,7 @@ List<Override> _baseOverrides({AppConfigService? configService}) => [
   if (configService != null)
     appConfigServiceProvider.overrideWithValue(configService),
   backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+  ...sessionControlTestOverrides,
 ];
 
 /// Pumps [AdvancedSettingsScreen] directly inside a minimal scaffold+router

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -20,6 +20,7 @@ import 'package:voice_agent/features/api_sync/sync_provider.dart';
 import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../helpers/stub_background_service.dart';
+import '../../helpers/stub_session_control.dart';
 
 class _StubStorage implements StorageService {
   @override Future<String> getDeviceId() async => 'test';
@@ -85,6 +86,7 @@ List<Override> _baseOverrides() => [
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
   backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+  ...sessionControlTestOverrides,
 ];
 
 Future<void> _navigateToSettings(WidgetTester tester) async {

--- a/test/helpers/stub_session_control.dart
+++ b/test/helpers/stub_session_control.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/session_control/hands_free_control_port.dart';
+import 'package:voice_agent/core/session_control/session_control_provider.dart';
+import 'package:voice_agent/core/session_control/toaster.dart';
+
+/// No-op [HandsFreeControlPort] for tests that render the full app widget
+/// tree. Prevents `UnimplementedError` from `handsFreeControlPortProvider`.
+class StubHandsFreeControlPort implements HandsFreeControlPort {
+  @override
+  bool get isSuspendedForManualRecording => false;
+
+  @override
+  Future<void> stopSession() async {}
+}
+
+/// No-op [Toaster] for tests. Does not show any toasts.
+class StubToaster extends Toaster {
+  StubToaster() : super(GlobalKey<ScaffoldMessengerState>());
+
+  @override
+  void show(String message, {Duration duration = const Duration(seconds: 2)}) {
+    // No-op in tests.
+  }
+}
+
+/// Provider overrides for tests that build the full widget tree (via [App]).
+///
+/// These are required because `handsFreeControlPortProvider` and
+/// `toasterProvider` throw by default and must be overridden.
+List<Override> get sessionControlTestOverrides => [
+      handsFreeControlPortProvider
+          .overrideWithValue(StubHandsFreeControlPort()),
+      toasterProvider.overrideWithValue(StubToaster()),
+    ];


### PR DESCRIPTION
## Summary

Implements P029 Tasks T2 and T3: wires session control signals from the backend into the SyncWorker reply handler and connects the app-level provider overrides.

- **T2 (SyncWorker wiring):** Adds `SessionControlDispatcher` and `SessionIdCoordinator` as constructor parameters to `SyncWorker`. Changes `_handleReply` to use sequenced `await ttsService.stop(); await ttsService.speak(...)` so `isSpeaking` is deterministic before dispatch. Parses `SessionControlSignal.fromBody(json)` on each reply body and dispatches non-null signals via `unawaited(dispatcher.dispatch(signal))`. Adopts `conversation_id` from replies for client-side correlation. Updates `syncWorkerProvider` to inject both new dependencies.

- **T3 (HandsFreeController port + app wiring):** Adds `implements HandsFreeControlPort` to `HandsFreeController` (no method body changes). Adds optional `scaffoldMessengerKey` to `App` for `MaterialApp.scaffoldMessengerKey`. Overrides `handsFreeControlPortProvider` and `toasterProvider` in `main.dart` `ProviderScope`.

- **Tests:** Adds 8 new test cases in `sync_worker_test.dart` covering signal dispatch, no-dispatch on message-only and malformed JSON, conversation_id adoption, and TTS ordering. Creates `sync_worker_integration_test.dart` with 5 integration tests verifying full signal parsing through dispatch (stop-only, reset-only, both with ordering, noop envelope, absent key). Creates shared `stub_session_control.dart` test helper and updates all widget tests that render `App()`.

Ref: `docs/proposals/029-honor-session-control-signals.md` (Tasks T2, T3)

## Test plan

- [x] `make analyze` passes with zero issues
- [x] `make test` passes (799 tests, 0 failures)
- [x] Dependency rule grep checks pass for all feature directories and core
- [x] All new test cases exercise the signal dispatch, ordering, and no-dispatch paths
- [ ] Manual smoke on iOS/Android (post-merge with P049 backend changes)

Generated with [Claude Code](https://claude.com/claude-code)
