### PR TITLE
fix(chat): handle null source_event_refs in ConversationRecord

### DIFF
--- a/lib/core/models/conversation_record.dart
+++ b/lib/core/models/conversation_record.dart
@@ -101,7 +101,7 @@ class ConversationRecord {
       originRole: OriginRole.fromString(map['origin_role'] as String),
       assertionMode: map['assertion_mode'] as String,
       userEndorsed: map['user_endorsed'] as bool,
-      sourceEventRefs: (map['source_event_refs'] as List<dynamic>)
+      sourceEventRefs: (map['source_event_refs'] as List<dynamic>? ?? [])
           .cast<String>(),
     );
   }

--- a/test/core/models/conversation_record_test.dart
+++ b/test/core/models/conversation_record_test.dart
@@ -87,5 +87,19 @@ void main() {
         expect(record.recordType, type);
       }
     });
+
+    test('fromMap handles null source_event_refs', () {
+      final map = Map<String, dynamic>.from(sampleMap);
+      map['source_event_refs'] = null;
+      final record = ConversationRecord.fromMap(map);
+      expect(record.sourceEventRefs, isEmpty);
+    });
+
+    test('fromMap handles missing source_event_refs', () {
+      final map = Map<String, dynamic>.from(sampleMap);
+      map.remove('source_event_refs');
+      final record = ConversationRecord.fromMap(map);
+      expect(record.sourceEventRefs, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
---
Backend may return null or omit `source_event_refs`, causing a type cast crash when opening a conversation thread in the Chat tab.

Adds `?? []` fallback and two test cases for null/missing field.
