### PR TITLE
feat(core/media_button): add platform channel for media button events (P034-T1)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -39,6 +39,10 @@ android {
     }
 }
 
+dependencies {
+    implementation("androidx.media:media:1.7.0")
+}
+
 flutter {
     source = "../.."
 }

--- a/android/app/src/main/kotlin/com/voiceagent/voice_agent/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/voiceagent/voice_agent/MainActivity.kt
@@ -1,5 +1,22 @@
 package com.voiceagent.voice_agent
 
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        val messenger = flutterEngine.dartExecutor.binaryMessenger
+        val bridge = MediaButtonBridge(this)
+
+        MethodChannel(messenger, "com.voiceagent/media_button")
+            .setMethodCallHandler(bridge)
+
+        EventChannel(messenger, "com.voiceagent/media_button/events")
+            .setStreamHandler(bridge)
+    }
+}

--- a/android/app/src/main/kotlin/com/voiceagent/voice_agent/MediaButtonBridge.kt
+++ b/android/app/src/main/kotlin/com/voiceagent/voice_agent/MediaButtonBridge.kt
@@ -1,0 +1,98 @@
+package com.voiceagent.voice_agent
+
+import android.content.Context
+import android.support.v4.media.session.MediaSessionCompat
+import android.support.v4.media.session.PlaybackStateCompat
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+/// Bridges Android media-session events (e.g. Bluetooth headset play/pause)
+/// to Dart via platform channels.
+///
+/// - MethodChannel `com.voiceagent/media_button` handles `activate` /
+///   `deactivate` calls from Dart.
+/// - EventChannel `com.voiceagent/media_button/events` streams toggle
+///   events back to Dart.
+class MediaButtonBridge(
+    private val context: Context,
+) : MethodChannel.MethodCallHandler, EventChannel.StreamHandler {
+
+    private var mediaSession: MediaSessionCompat? = null
+    private var eventSink: EventChannel.EventSink? = null
+
+    // -- MethodChannel handler ------------------------------------------------
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "activate" -> {
+                activateSession()
+                result.success(null)
+            }
+            "deactivate" -> {
+                deactivateSession()
+                result.success(null)
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    // -- Media session management ---------------------------------------------
+
+    private fun activateSession() {
+        if (mediaSession != null) return
+
+        val session = MediaSessionCompat(context, "VoiceAgentMediaSession").apply {
+            setCallback(object : MediaSessionCompat.Callback() {
+                override fun onPlay() {
+                    eventSink?.success("togglePlayPause")
+                }
+
+                override fun onPause() {
+                    eventSink?.success("togglePlayPause")
+                }
+
+                override fun onMediaButtonEvent(mediaButtonEvent: android.content.Intent?): Boolean {
+                    // Let the default handler dispatch to onPlay/onPause.
+                    return super.onMediaButtonEvent(mediaButtonEvent)
+                }
+            })
+
+            // Set a paused playback state so the session is eligible to receive
+            // media button events.
+            setPlaybackState(
+                PlaybackStateCompat.Builder()
+                    .setState(
+                        PlaybackStateCompat.STATE_PAUSED,
+                        PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN,
+                        0f,
+                    )
+                    .setActions(
+                        PlaybackStateCompat.ACTION_PLAY or
+                            PlaybackStateCompat.ACTION_PAUSE or
+                            PlaybackStateCompat.ACTION_PLAY_PAUSE,
+                    )
+                    .build(),
+            )
+
+            isActive = true
+        }
+        mediaSession = session
+    }
+
+    private fun deactivateSession() {
+        mediaSession?.isActive = false
+        mediaSession?.release()
+        mediaSession = null
+    }
+
+    // -- EventChannel StreamHandler -------------------------------------------
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        eventSink = events
+    }
+
+    override fun onCancel(arguments: Any?) {
+        eventSink = null
+    }
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -17,5 +17,8 @@ import UIKit
     if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "AudioSessionBridge") {
       AudioSessionBridge.shared.configure(with: registrar.messenger())
     }
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "MediaButtonBridge") {
+      MediaButtonBridge.shared.configure(with: registrar.messenger())
+    }
   }
 }

--- a/ios/Runner/MediaButtonBridge.swift
+++ b/ios/Runner/MediaButtonBridge.swift
@@ -1,0 +1,97 @@
+import Flutter
+import MediaPlayer
+
+/// Bridges iOS media remote-command events (e.g. AirPods play/pause)
+/// to Dart via platform channels.
+///
+/// - MethodChannel `com.voiceagent/media_button` handles `activate` /
+///   `deactivate` calls from Dart.
+/// - EventChannel `com.voiceagent/media_button/events` streams toggle
+///   events back to Dart.
+///
+/// Pattern mirrors `AudioSessionBridge`.
+class MediaButtonBridge: NSObject, FlutterStreamHandler {
+    static let shared = MediaButtonBridge()
+
+    private let methodChannelName = "com.voiceagent/media_button"
+    private let eventChannelName = "com.voiceagent/media_button/events"
+
+    private var methodChannel: FlutterMethodChannel?
+    private var eventSink: FlutterEventSink?
+
+    private override init() {
+        super.init()
+    }
+
+    /// Call from AppDelegate after the Flutter engine is available.
+    func configure(with messenger: FlutterBinaryMessenger) {
+        methodChannel = FlutterMethodChannel(
+            name: methodChannelName,
+            binaryMessenger: messenger
+        )
+        methodChannel?.setMethodCallHandler { [weak self] call, result in
+            self?.handle(call, result: result)
+        }
+
+        let eventChannel = FlutterEventChannel(
+            name: eventChannelName,
+            binaryMessenger: messenger
+        )
+        eventChannel.setStreamHandler(self)
+    }
+
+    // MARK: - MethodChannel handler
+
+    private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "activate":
+            activateRemoteCommands()
+            result(nil)
+        case "deactivate":
+            deactivateRemoteCommands()
+            result(nil)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    // MARK: - Remote command management
+
+    private func activateRemoteCommands() {
+        let center = MPRemoteCommandCenter.shared()
+        center.togglePlayPauseCommand.isEnabled = true
+        center.togglePlayPauseCommand.addTarget { [weak self] _ in
+            self?.eventSink?("togglePlayPause")
+            return .success
+        }
+
+        // Set minimal now-playing info so the system recognizes this app
+        // as an active media participant (required for AirPods routing).
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = [
+            MPMediaItemPropertyTitle: "Voice Agent"
+        ]
+    }
+
+    private func deactivateRemoteCommands() {
+        let center = MPRemoteCommandCenter.shared()
+        center.togglePlayPauseCommand.isEnabled = false
+        center.togglePlayPauseCommand.removeTarget(nil)
+
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+    }
+
+    // MARK: - FlutterStreamHandler
+
+    func onListen(
+        withArguments arguments: Any?,
+        eventSink events: @escaping FlutterEventSink
+    ) -> FlutterError? {
+        eventSink = events
+        return nil
+    }
+
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        eventSink = nil
+        return nil
+    }
+}

--- a/lib/core/media_button/media_button_port.dart
+++ b/lib/core/media_button/media_button_port.dart
@@ -1,0 +1,22 @@
+/// Events emitted by a media button source (e.g. AirPods play/pause).
+enum MediaButtonEvent { togglePlayPause }
+
+/// Port interface for listening to hardware media-button presses.
+///
+/// Lives in `core/` so higher layers can depend on it without coupling
+/// to platform channel details. The concrete adapter is
+/// [MediaButtonService] backed by platform channels registered in
+/// `AppDelegate.swift` (iOS) and `MainActivity.kt` (Android).
+abstract class MediaButtonPort {
+  /// Stream of media button events forwarded from the native layer.
+  Stream<MediaButtonEvent> get events;
+
+  /// Registers the app as the active media-button receiver on the
+  /// platform (e.g. enables `MPRemoteCommandCenter` on iOS, activates
+  /// `MediaSessionCompat` on Android).
+  Future<void> activate();
+
+  /// Unregisters the app as the active media-button receiver and
+  /// releases platform resources.
+  Future<void> deactivate();
+}

--- a/lib/core/media_button/media_button_provider.dart
+++ b/lib/core/media_button/media_button_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:voice_agent/core/media_button/media_button_port.dart';
+import 'package:voice_agent/core/media_button/media_button_service.dart';
+
+/// Provides a [MediaButtonPort] backed by platform channels.
+final mediaButtonProvider = Provider<MediaButtonPort>((ref) {
+  return MediaButtonService();
+});

--- a/lib/core/media_button/media_button_service.dart
+++ b/lib/core/media_button/media_button_service.dart
@@ -1,0 +1,61 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/services.dart';
+
+import 'package:voice_agent/core/media_button/media_button_port.dart';
+
+/// Platform-channel implementation of [MediaButtonPort].
+///
+/// Uses a [MethodChannel] for activate/deactivate commands and an
+/// [EventChannel] for receiving media button events from the native
+/// layer. Channel names follow ADR-PLATFORM-005.
+class MediaButtonService implements MediaButtonPort {
+  MediaButtonService({
+    MethodChannel? methodChannel,
+    EventChannel? eventChannel,
+  })  : _methodChannel =
+            methodChannel ?? const MethodChannel('com.voiceagent/media_button'),
+        _eventChannel = eventChannel ??
+            const EventChannel('com.voiceagent/media_button/events');
+
+  final MethodChannel _methodChannel;
+  final EventChannel _eventChannel;
+
+  @override
+  Stream<MediaButtonEvent> get events {
+    return _eventChannel.receiveBroadcastStream().map((dynamic event) {
+      if (event == 'togglePlayPause') {
+        return MediaButtonEvent.togglePlayPause;
+      }
+      developer.log(
+        'Unknown media button event: $event',
+        name: 'MediaButtonService',
+      );
+      return MediaButtonEvent.togglePlayPause;
+    });
+  }
+
+  @override
+  Future<void> activate() async {
+    try {
+      await _methodChannel.invokeMethod<void>('activate');
+    } catch (e) {
+      developer.log(
+        'Failed to activate media button: $e',
+        name: 'MediaButtonService',
+      );
+    }
+  }
+
+  @override
+  Future<void> deactivate() async {
+    try {
+      await _methodChannel.invokeMethod<void>('deactivate');
+    } catch (e) {
+      developer.log(
+        'Failed to deactivate media button: $e',
+        name: 'MediaButtonService',
+      );
+    }
+  }
+}

--- a/test/core/media_button/media_button_service_test.dart
+++ b/test/core/media_button/media_button_service_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/media_button/media_button_port.dart';
+import 'package:voice_agent/core/media_button/media_button_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const methodChannelName = 'com.voiceagent/media_button';
+  const eventChannelName = 'com.voiceagent/media_button/events';
+
+  late MethodChannel methodChannel;
+  late EventChannel eventChannel;
+  late MediaButtonService service;
+  late List<MethodCall> methodCalls;
+
+  setUp(() {
+    methodCalls = [];
+    methodChannel = const MethodChannel(methodChannelName);
+    eventChannel = const EventChannel(eventChannelName);
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(methodChannel, (call) async {
+      methodCalls.add(call);
+      return null;
+    });
+
+    service = MediaButtonService(
+      methodChannel: methodChannel,
+      eventChannel: eventChannel,
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(methodChannel, null);
+  });
+
+  group('MediaButtonService', () {
+    test('activate() sends activate method call to native', () async {
+      await service.activate();
+
+      expect(methodCalls, hasLength(1));
+      expect(methodCalls.first.method, 'activate');
+    });
+
+    test('deactivate() sends deactivate method call to native', () async {
+      await service.deactivate();
+
+      expect(methodCalls, hasLength(1));
+      expect(methodCalls.first.method, 'deactivate');
+    });
+
+    test('activate() then deactivate() sends both method calls', () async {
+      await service.activate();
+      await service.deactivate();
+
+      expect(methodCalls, hasLength(2));
+      expect(methodCalls[0].method, 'activate');
+      expect(methodCalls[1].method, 'deactivate');
+    });
+
+    test('activate() failure is handled gracefully (no crash)', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(methodChannel, (call) async {
+        throw PlatformException(
+          code: 'UNAVAILABLE',
+          message: 'Media session not available',
+        );
+      });
+
+      // Should not throw.
+      await expectLater(service.activate(), completes);
+    });
+
+    test('deactivate() failure is handled gracefully (no crash)', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(methodChannel, (call) async {
+        throw PlatformException(
+          code: 'UNAVAILABLE',
+          message: 'Media session not available',
+        );
+      });
+
+      // Should not throw.
+      await expectLater(service.deactivate(), completes);
+    });
+
+    test('events stream maps EventChannel data to MediaButtonEvent', () async {
+      // Simulate the native side sending events via the event channel.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+        eventChannel,
+        MockStreamHandler.inline(
+          onListen: (arguments, events) {
+            events.success('togglePlayPause');
+            events.endOfStream();
+          },
+        ),
+      );
+
+      final events = await service.events.toList();
+
+      expect(events, [MediaButtonEvent.togglePlayPause]);
+
+      // Clean up.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(eventChannel, null);
+    });
+
+    test('events stream handles unknown event strings', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+        eventChannel,
+        MockStreamHandler.inline(
+          onListen: (arguments, events) {
+            events.success('unknownEvent');
+            events.endOfStream();
+          },
+        ),
+      );
+
+      // Unknown events default to togglePlayPause.
+      final events = await service.events.toList();
+
+      expect(events, [MediaButtonEvent.togglePlayPause]);
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(eventChannel, null);
+    });
+  });
+}


### PR DESCRIPTION
Platform channel for media button events (AirPods play/pause) per P034 T1.

Adds MediaButtonPort interface, MediaButtonService (MethodChannel + EventChannel), iOS MediaButtonBridge (MPRemoteCommandCenter), Android MediaButtonBridge (MediaSessionCompat), and 7 unit tests.
