### PR TITLE
feat(recording): add pause/resume for manual dictation and hands-free listening (P034-T2)

### DIFF
--- a/lib/features/recording/data/recording_service_impl.dart
+++ b/lib/features/recording/data/recording_service_impl.dart
@@ -29,6 +29,7 @@ class RecordingServiceImpl implements RecordingService {
   String? _currentPath;
   Timer? _elapsedTimer;
   DateTime? _startTime;
+  Duration _pausedElapsed = Duration.zero;
   final _elapsedController = StreamController<Duration>.broadcast();
 
   @override
@@ -41,6 +42,7 @@ class RecordingServiceImpl implements RecordingService {
   Future<void> start({required String outputPath}) async {
     _currentPath = outputPath;
     _startTime = DateTime.now();
+    _pausedElapsed = Duration.zero;
 
     await _recorder.start(_config, path: outputPath);
 
@@ -48,7 +50,33 @@ class RecordingServiceImpl implements RecordingService {
       const Duration(milliseconds: 200),
       (_) {
         if (_startTime != null) {
-          _elapsedController.add(DateTime.now().difference(_startTime!));
+          _elapsedController
+              .add(_pausedElapsed + DateTime.now().difference(_startTime!));
+        }
+      },
+    );
+  }
+
+  @override
+  Future<void> pause() async {
+    await _recorder.pause();
+    _elapsedTimer?.cancel();
+    _elapsedTimer = null;
+    if (_startTime != null) {
+      _pausedElapsed += DateTime.now().difference(_startTime!);
+    }
+  }
+
+  @override
+  Future<void> resume() async {
+    await _recorder.resume();
+    _startTime = DateTime.now();
+    _elapsedTimer = Timer.periodic(
+      const Duration(milliseconds: 200),
+      (_) {
+        if (_startTime != null) {
+          _elapsedController
+              .add(_pausedElapsed + DateTime.now().difference(_startTime!));
         }
       },
     );
@@ -57,8 +85,9 @@ class RecordingServiceImpl implements RecordingService {
   @override
   Future<RecordingResult> stop() async {
     final path = await _recorder.stop();
-    final duration =
-        _startTime != null ? DateTime.now().difference(_startTime!) : Duration.zero;
+    final duration = _startTime != null
+        ? _pausedElapsed + DateTime.now().difference(_startTime!)
+        : _pausedElapsed;
 
     _cleanup();
 
@@ -93,6 +122,7 @@ class RecordingServiceImpl implements RecordingService {
     _elapsedTimer = null;
     _startTime = null;
     _currentPath = null;
+    _pausedElapsed = Duration.zero;
     // Do NOT close _elapsedController — it's an app-lifetime singleton.
     // Subscribers stay connected across recording sessions.
     // The stream goes quiet until the next start().

--- a/lib/features/recording/domain/hands_free_session_state.dart
+++ b/lib/features/recording/domain/hands_free_session_state.dart
@@ -43,6 +43,13 @@ class HandsFreeWithBacklog extends HandsFreeSessionState {
   final List<SegmentJob> jobs;
 }
 
+/// User-initiated pause via media button. Engine stopped, backlog preserved.
+class HandsFreeSuspendedByUser extends HandsFreeSessionState {
+  const HandsFreeSuspendedByUser(this.jobs);
+
+  final List<SegmentJob> jobs;
+}
+
 /// Unrecoverable error. Microphone released.
 ///
 /// At most one of [requiresSettings] or [requiresAppSettings] may be true.

--- a/lib/features/recording/domain/recording_service.dart
+++ b/lib/features/recording/domain/recording_service.dart
@@ -9,6 +9,12 @@ abstract class RecordingService {
   Future<RecordingResult> stop();
   Future<void> cancel();
 
+  /// Pauses an active recording. The recorder keeps its file handle open.
+  Future<void> pause();
+
+  /// Resumes a paused recording.
+  Future<void> resume();
+
   /// Broadcast stream that emits every ~200ms while recording.
   /// Completes on stop/cancel/error.
   Stream<Duration> get elapsed;

--- a/lib/features/recording/domain/recording_state.dart
+++ b/lib/features/recording/domain/recording_state.dart
@@ -3,6 +3,7 @@ sealed class RecordingState {
 
   const factory RecordingState.idle() = RecordingIdle;
   const factory RecordingState.recording() = RecordingActive;
+  const factory RecordingState.paused() = RecordingPaused;
   const factory RecordingState.transcribing() = RecordingTranscribing;
   const factory RecordingState.error(
     String message, {
@@ -17,6 +18,10 @@ class RecordingIdle extends RecordingState {
 
 class RecordingActive extends RecordingState {
   const RecordingActive();
+}
+
+class RecordingPaused extends RecordingState {
+  const RecordingPaused();
 }
 
 class RecordingTranscribing extends RecordingState {

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -63,6 +63,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   // ignore: prefer_final_fields — T3 mutates this field
   bool _suspendedForManualRecording = false;
   bool _suspendedForTts = false;
+  bool _suspendedByUser = false;
 
   @override
   bool get isSuspendedForManualRecording => _suspendedForManualRecording;
@@ -92,6 +93,54 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     state = _listeningOrBacklog();
   }
 
+  // ── User-initiated suspension (P034 T2) ─────────────────────────────────
+
+  /// Toggles user-initiated suspension. Called by media button dispatch.
+  /// Returns true if the session is now suspended, false if resumed.
+  Future<bool> toggleUserSuspend() async {
+    if (_suspendedByUser) {
+      await resumeByUser();
+      return false;
+    } else {
+      await suspendByUser();
+      return true;
+    }
+  }
+
+  Future<void> suspendByUser() async {
+    if (_suspendedByUser) return;
+    if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
+
+    // Fast path: engine already stopped by TTS or manual recording.
+    if (_suspendedForTts || _suspendedForManualRecording) {
+      _suspendedByUser = true;
+      state = HandsFreeSuspendedByUser(List<SegmentJob>.unmodifiable(_jobs));
+      return;
+    }
+
+    if (state is HandsFreeCapturing) {
+      await _engine?.interruptCapture();
+    } else {
+      await _engineSub?.cancel();
+      await _engine?.stop();
+    }
+    _engineSub = null;
+    _engine = null;
+    _suspendedByUser = true;
+    state = HandsFreeSuspendedByUser(List<SegmentJob>.unmodifiable(_jobs));
+  }
+
+  Future<void> resumeByUser() async {
+    if (!_suspendedByUser) return;
+    _suspendedByUser = false;
+    if (_suspendedForManualRecording || _suspendedForTts) {
+      state = _listeningOrBacklog();
+      return;
+    }
+    _startEngine(_ref.read(appConfigProvider).vadConfig);
+    state = _listeningOrBacklog();
+  }
+
   /// Restarts the VAD engine with the current [appConfigProvider] VAD config.
   ///
   /// Called when the user changes VAD parameters in Advanced Settings.
@@ -100,6 +149,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   Future<void> reloadVadConfig() async {
     if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
     if (_suspendedForManualRecording) return;
+    if (_suspendedByUser) return;
 
     if (state is HandsFreeCapturing) {
       await _engine?.interruptCapture();
@@ -122,6 +172,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   Future<void> resumeAfterManualRecording() async {
     if (!_suspendedForManualRecording) return;
     _suspendedForManualRecording = false;
+    if (_suspendedByUser) return;
     _startEngine(_ref.read(appConfigProvider).vadConfig);
     state = _listeningOrBacklog();
   }
@@ -151,7 +202,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   Future<void> resumeAfterTts() async {
     if (!_suspendedForTts) return;
     _suspendedForTts = false;
-    if (_suspendedForManualRecording) return;
+    if (_suspendedForManualRecording || _suspendedByUser) return;
     _startEngine(_ref.read(appConfigProvider).vadConfig);
     state = _listeningOrBacklog();
   }
@@ -262,6 +313,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     state = const HandsFreeIdle();
     _jobs.clear();
     _jobCounter = 0;
+    _suspendedByUser = false;
   }
 
   @override

--- a/lib/features/recording/presentation/recording_controller.dart
+++ b/lib/features/recording/presentation/recording_controller.dart
@@ -30,7 +30,8 @@ class RecordingController extends StateNotifier<RecordingState>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.paused && this.state is RecordingActive) {
+    if (state == AppLifecycleState.paused &&
+        (this.state is RecordingActive || this.state is RecordingPaused)) {
       cancelRecording();
     }
   }
@@ -143,6 +144,18 @@ class RecordingController extends StateNotifier<RecordingState>
         state = RecordingState.error('Transcription failed: $e');
       }
     }
+  }
+
+  Future<void> pauseRecording() async {
+    if (state is! RecordingActive) return;
+    await _service.pause();
+    state = const RecordingState.paused();
+  }
+
+  Future<void> resumeRecording() async {
+    if (state is! RecordingPaused) return;
+    await _service.resume();
+    state = const RecordingState.recording();
   }
 
   Future<void> cancelRecording() async {

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/media_button/media_button_port.dart';
+import 'package:voice_agent/core/media_button/media_button_provider.dart';
 import 'package:voice_agent/core/providers/agent_reply_provider.dart';
 import 'package:voice_agent/core/providers/api_url_provider.dart';
 import 'package:voice_agent/core/session_control/session_control_provider.dart';
@@ -23,14 +25,59 @@ class RecordingScreen extends ConsumerStatefulWidget {
 }
 
 class _RecordingScreenState extends ConsumerState<RecordingScreen> {
+  StreamSubscription<MediaButtonEvent>? _mediaButtonSub;
+  MediaButtonPort? _mediaButtonPort;
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         ref.read(handsFreeControllerProvider.notifier).startSession();
+        _activateMediaButton();
       }
     });
+  }
+
+  void _activateMediaButton() {
+    _mediaButtonPort = ref.read(mediaButtonProvider);
+    unawaited(_mediaButtonPort!.activate());
+    _mediaButtonSub = _mediaButtonPort!.events.listen(_onMediaButtonEvent);
+  }
+
+  void _onMediaButtonEvent(MediaButtonEvent event) {
+    if (event != MediaButtonEvent.togglePlayPause) return;
+
+    final recState = ref.read(recordingControllerProvider);
+    final hfState = ref.read(handsFreeControllerProvider);
+    final recCtrl = ref.read(recordingControllerProvider.notifier);
+    final hfCtrl = ref.read(handsFreeControllerProvider.notifier);
+
+    if (recState is RecordingActive) {
+      unawaited(recCtrl.pauseRecording());
+    } else if (recState is RecordingPaused) {
+      unawaited(recCtrl.resumeRecording());
+    } else if (hfState is HandsFreeListening ||
+        hfState is HandsFreeWithBacklog ||
+        hfState is HandsFreeCapturing) {
+      unawaited(hfCtrl.toggleUserSuspend().then((_) {
+        ref.read(toasterProvider).show('Paused');
+        ref.read(hapticServiceProvider).lightImpact();
+      }));
+    } else if (hfState is HandsFreeSuspendedByUser) {
+      unawaited(hfCtrl.toggleUserSuspend().then((_) {
+        ref.read(toasterProvider).show('Resumed');
+        ref.read(hapticServiceProvider).lightImpact();
+      }));
+    }
+    // All other states: no-op
+  }
+
+  @override
+  void dispose() {
+    _mediaButtonSub?.cancel();
+    unawaited(_mediaButtonPort?.deactivate());
+    super.dispose();
   }
 
   @override
@@ -73,6 +120,7 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
     final agentReply = ref.watch(latestAgentReplyProvider);
 
     final isNewConversationDisabled = recState is RecordingActive ||
+        recState is RecordingPaused ||
         recState is RecordingTranscribing ||
         hfState is HandsFreeCapturing ||
         hfState is HandsFreeStopping;
@@ -146,7 +194,10 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
     RecordingController controller,
   ) {
     return switch (state) {
-      RecordingIdle() || RecordingActive() || RecordingTranscribing() =>
+      RecordingIdle() ||
+      RecordingActive() ||
+      RecordingPaused() ||
+      RecordingTranscribing() =>
         const _MicButton(),
       RecordingError(
         :final message,
@@ -282,6 +333,7 @@ class _HandsFreeSection extends StatelessWidget {
         HandsFreeWithBacklog(:final jobs) => jobs,
         HandsFreeCapturing(:final jobs) => jobs,
         HandsFreeStopping(:final jobs) => jobs,
+        HandsFreeSuspendedByUser(:final jobs) => jobs,
         HandsFreeSessionError(:final jobs) => jobs,
         HandsFreeIdle() => const [],
       };
@@ -311,6 +363,7 @@ class _HfStatusStrip extends StatelessWidget {
       HandsFreeCapturing() => const _StatusText('Capturing...'),
       HandsFreeStopping() => const _StatusText('Processing segment...'),
       HandsFreeWithBacklog() => const _StatusText('Listening (jobs pending)...'),
+      HandsFreeSuspendedByUser() => const _StatusText('Listening paused'),
       HandsFreeIdle() => const SizedBox.shrink(),
     };
   }
@@ -424,6 +477,8 @@ class _MicButtonState extends ConsumerState<_MicButton> {
       await recCtrl.startRecording();
     } else if (recState is RecordingActive) {
       await recCtrl.stopAndTranscribe();
+    } else if (recState is RecordingPaused) {
+      await recCtrl.resumeRecording();
     }
     // RecordingTranscribing → no-op
     // RecordingError → handled by error view in _buildRecordingArea
@@ -464,6 +519,7 @@ class _MicButtonState extends ConsumerState<_MicButton> {
     final recState = ref.watch(recordingControllerProvider);
     final hfState = ref.watch(handsFreeControllerProvider);
     final isRecording = recState is RecordingActive;
+    final isPaused = recState is RecordingPaused;
     final isTranscribing = recState is RecordingTranscribing;
     final isHfCapturing = hfState is HandsFreeCapturing;
 
@@ -476,17 +532,21 @@ class _MicButtonState extends ConsumerState<_MicButton> {
 
     final color = isTranscribing
         ? Colors.grey
-        : isRecording && _isPressAndHold
+        : isPaused
             ? Colors.orange
-            : (isRecording || isHfCapturing)
-                ? Colors.red
-                : Colors.green;
+            : isRecording && _isPressAndHold
+                ? Colors.orange
+                : (isRecording || isHfCapturing)
+                    ? Colors.red
+                    : Colors.green;
 
-    final label = isRecording
-        ? (_isPressAndHold ? 'Release to stop' : 'Tap to stop')
-        : isTranscribing
-            ? 'Transcribing...'
-            : 'Tap to record';
+    final label = isPaused
+        ? 'Paused — tap to resume'
+        : isRecording
+            ? (_isPressAndHold ? 'Release to stop' : 'Tap to stop')
+            : isTranscribing
+                ? 'Transcribing...'
+                : 'Tap to record';
 
     return GestureDetector(
       onTap: _onTap,
@@ -512,7 +572,9 @@ class _MicButtonState extends ConsumerState<_MicButton> {
                       strokeWidth: 3,
                     ),
                   )
-                : const Icon(Icons.mic, color: Colors.white, size: 48),
+                : isPaused
+                    ? const Icon(Icons.pause, color: Colors.white, size: 48)
+                    : const Icon(Icons.mic, color: Colors.white, size: 48),
           ),
           const SizedBox(height: 16),
           Text(

--- a/test/app/app_shell_scaffold_test.dart
+++ b/test/app/app_shell_scaffold_test.dart
@@ -25,12 +25,14 @@ import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/agenda/domain/agenda_repository.dart';
 import 'package:voice_agent/features/agenda/presentation/agenda_providers.dart';
+import 'package:voice_agent/core/media_button/media_button_provider.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_session_state.dart';
 import 'package:voice_agent/features/recording/presentation/hands_free_controller.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 
 import '../helpers/stub_background_service.dart';
+import '../helpers/stub_media_button.dart';
 import '../helpers/stub_session_control.dart';
 
 // ── Stub dependencies ─────────────────────────────────────────────────────────
@@ -110,6 +112,7 @@ List<Override> get _baseOverrides => [
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedback()),
   backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+  mediaButtonProvider.overrideWithValue(StubMediaButtonPort()),
   agendaRepositoryProvider.overrideWithValue(_StubAgendaRepository()),
   ...sessionControlTestOverrides,
 ];

--- a/test/features/recording/domain/hands_free_session_state_test.dart
+++ b/test/features/recording/domain/hands_free_session_state_test.dart
@@ -11,6 +11,7 @@ void main() {
       const HandsFreeCapturing([]),
       const HandsFreeStopping([]),
       const HandsFreeWithBacklog([]),
+      const HandsFreeSuspendedByUser([]),
       const HandsFreeSessionError(message: 'oops'),
     ];
 
@@ -27,11 +28,13 @@ void main() {
             break;
           case HandsFreeWithBacklog():
             break;
+          case HandsFreeSuspendedByUser():
+            break;
           case HandsFreeSessionError():
             break;
         }
       }
-      expect(states.length, 6);
+      expect(states.length, 7);
     });
   });
 

--- a/test/features/recording/presentation/hands_free_controller_pause_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_pause_test.dart
@@ -1,0 +1,474 @@
+import 'package:flutter/foundation.dart';
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/background/background_service.dart';
+import 'package:voice_agent/core/background/background_service_provider.dart';
+import 'package:voice_agent/core/config/app_config.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/config/app_config_service.dart';
+import 'package:voice_agent/core/models/sync_queue_item.dart';
+import 'package:voice_agent/core/models/transcript.dart';
+import 'package:voice_agent/core/models/transcript_result.dart';
+import 'package:voice_agent/core/models/transcript_with_status.dart';
+import 'package:voice_agent/core/storage/storage_provider.dart';
+import 'package:voice_agent/core/storage/storage_service.dart';
+import 'package:voice_agent/core/config/vad_config.dart';
+import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
+import 'package:voice_agent/features/recording/domain/hands_free_session_state.dart';
+import 'package:voice_agent/features/recording/domain/recording_result.dart';
+import 'package:voice_agent/features/recording/domain/recording_service.dart';
+import 'package:voice_agent/features/recording/domain/recording_state.dart';
+import 'package:voice_agent/features/recording/domain/stt_service.dart';
+import 'package:voice_agent/core/tts/tts_provider.dart';
+import 'package:voice_agent/core/tts/tts_service.dart';
+import 'package:voice_agent/features/recording/presentation/hands_free_controller.dart';
+import 'package:voice_agent/features/recording/presentation/recording_controller.dart';
+import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
+import 'package:voice_agent/core/audio/audio_feedback_service.dart';
+import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+
+import '../../../helpers/stub_background_service.dart';
+
+// ── FakeHandsFreeEngine ──────────────────────────────────────────────────────
+
+class _FakeHandsFreeEngine implements HandsFreeEngine {
+  bool permissionGranted = true;
+  bool started = false;
+  bool stopped = false;
+  int startCount = 0;
+
+  final _controller = StreamController<HandsFreeEngineEvent>.broadcast();
+
+  void emit(HandsFreeEngineEvent event) => _controller.add(event);
+
+  @override
+  Future<bool> hasPermission() async => permissionGranted;
+
+  @override
+  Stream<HandsFreeEngineEvent> start({required VadConfig config}) {
+    started = true;
+    startCount++;
+    return _controller.stream;
+  }
+
+  @override
+  Future<void> stop() async => stopped = true;
+
+  @override
+  Future<void> interruptCapture() async {}
+
+  @override
+  void dispose() {
+    _controller.close();
+  }
+}
+
+// ── Stubs ────────────────────────────────────────────────────────────────────
+
+class _StubTtsService implements TtsService {
+  @override
+  ValueListenable<bool> get isSpeaking => ValueNotifier(false);
+  @override
+  Future<void> speak(String text, {String? languageCode}) async {}
+  @override
+  Future<void> stop() async {}
+  @override
+  void dispose() {}
+}
+
+class _StubAudioFeedbackService implements AudioFeedbackService {
+  @override
+  Future<void> startProcessingFeedback() async {}
+  @override
+  Future<void> stopLoop() async {}
+  @override
+  Future<void> playSuccess() async {}
+  @override
+  Future<void> playError() async {}
+  @override
+  void dispose() {}
+}
+
+class _FixedConfigService extends AppConfigService {
+  _FixedConfigService(this._config);
+  final AppConfig _config;
+
+  @override
+  Future<AppConfig> load() async => _config;
+}
+
+class _NullRecordingService implements RecordingService {
+  @override
+  Future<bool> requestPermission() async => true;
+  @override
+  Future<void> start({required String outputPath}) async {}
+  @override
+  Future<RecordingResult> stop() async => RecordingResult(
+      filePath: '/tmp/t.wav', duration: Duration.zero, sampleRate: 16000);
+  @override
+  Future<void> pause() async {}
+  @override
+  Future<void> resume() async {}
+  @override
+  Future<void> cancel() async {}
+  @override
+  bool get isRecording => false;
+  @override
+  Stream<Duration> get elapsed => const Stream.empty();
+}
+
+class _NullSttService implements SttService {
+  @override
+  Future<bool> isModelLoaded() async => false;
+  @override
+  Future<void> loadModel() async {}
+  @override
+  Future<TranscriptResult> transcribe(String wavPath,
+          {String? languageCode}) async =>
+      Completer<TranscriptResult>().future; // never completes
+}
+
+class _FakeStorageService implements StorageService {
+  @override
+  Future<String> getDeviceId() async => 'test-device';
+  @override
+  Future<void> saveTranscript(Transcript t) async {}
+  @override
+  Future<Transcript?> getTranscript(String id) async => null;
+  @override
+  Future<List<Transcript>> getTranscripts(
+          {int limit = 50, int offset = 0}) async =>
+      [];
+  @override
+  Future<void> deleteTranscript(String id) async {}
+  @override
+  Future<void> enqueue(String transcriptId) async {}
+  @override
+  Future<List<SyncQueueItem>> getPendingItems() async => [];
+  @override
+  Future<void> markSending(String id) async {}
+  @override
+  Future<void> markSent(String id) async {}
+  @override
+  Future<void> markFailed(String id, String error,
+      {int? overrideAttempts}) async {}
+  @override
+  Future<void> markPendingForRetry(String id) async {}
+  @override
+  Future<void> reactivateForResend(String transcriptId) async {}
+  @override
+  Future<List<TranscriptWithStatus>> getTranscriptsWithStatus(
+          {int limit = 20, int offset = 0}) async =>
+      [];
+  @override
+  Future<int> recoverStaleSending() async => 0;
+  @override
+  Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
+}
+
+// ── Container factory ────────────────────────────────────────────────────────
+
+ProviderContainer _makeContainer({
+  required _FakeHandsFreeEngine engine,
+  String? groqApiKey = 'gsk_test_valid',
+  BackgroundService? backgroundService,
+}) {
+  final container = ProviderContainer(overrides: [
+    handsFreeEngineProvider.overrideWithValue(engine),
+    appConfigServiceProvider.overrideWithValue(
+      _FixedConfigService(AppConfig(groqApiKey: groqApiKey)),
+    ),
+    recordingControllerProvider.overrideWith(
+      (ref) => _IdleRecordingController(ref),
+    ),
+    sttServiceProvider.overrideWithValue(_NullSttService()),
+    storageServiceProvider.overrideWithValue(_FakeStorageService()),
+    ttsServiceProvider.overrideWithValue(_StubTtsService()),
+    audioFeedbackServiceProvider
+        .overrideWithValue(_StubAudioFeedbackService()),
+    backgroundServiceProvider
+        .overrideWithValue(backgroundService ?? StubBackgroundService()),
+  ]);
+  addTearDown(container.dispose);
+  return container;
+}
+
+/// [RecordingController] backed by no-op stubs -- stays in [RecordingState.idle].
+class _IdleRecordingController extends RecordingController {
+  _IdleRecordingController(Ref ref)
+      : super(_NullRecordingService(), _NullSttService(), ref);
+}
+
+HandsFreeController _ctrl(ProviderContainer c) =>
+    c.read(handsFreeControllerProvider.notifier);
+
+HandsFreeSessionState _stateOf(ProviderContainer c) =>
+    c.read(handsFreeControllerProvider);
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  setUpAll(() => WidgetsFlutterBinding.ensureInitialized());
+
+  group('suspendByUser', () {
+    test('from listening transitions to HandsFreeSuspendedByUser', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+      expect(_stateOf(c), isA<HandsFreeListening>());
+
+      await _ctrl(c).suspendByUser();
+
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+    });
+
+    test('is no-op when already suspended by user', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      await _ctrl(c).suspendByUser();
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+
+      // Second call should be no-op
+      await _ctrl(c).suspendByUser();
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+    });
+
+    test('is no-op from HandsFreeIdle', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      // Don't start session — stay idle
+
+      await _ctrl(c).suspendByUser();
+
+      expect(_stateOf(c), isA<HandsFreeIdle>());
+    });
+
+    test('is no-op from HandsFreeSessionError', () async {
+      final engine = _FakeHandsFreeEngine()..permissionGranted = false;
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+
+      await _ctrl(c).suspendByUser();
+
+      expect(_stateOf(c), isA<HandsFreeSessionError>());
+    });
+
+    test('fast path when already suspended for TTS', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      // Suspend for TTS first
+      await _ctrl(c).suspendForTts();
+      // Now suspend by user — should take the fast path
+      await _ctrl(c).suspendByUser();
+
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+    });
+  });
+
+  group('resumeByUser', () {
+    test('from suspended transitions to HandsFreeListening', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      await _ctrl(c).suspendByUser();
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+
+      engine.started = false;
+      await _ctrl(c).resumeByUser();
+
+      expect(_stateOf(c), isA<HandsFreeListening>());
+      expect(engine.started, isTrue, reason: 'engine must restart on resume');
+    });
+
+    test('is no-op when not suspended by user', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      await _ctrl(c).resumeByUser();
+
+      expect(_stateOf(c), isA<HandsFreeListening>());
+    });
+
+    test('does not restart engine if still suspended for TTS', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      await _ctrl(c).suspendForTts();
+      await _ctrl(c).suspendByUser();
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+
+      engine.started = false;
+      engine.startCount = 0;
+      await _ctrl(c).resumeByUser();
+
+      // Engine should NOT start because TTS suspension is still active
+      expect(engine.startCount, 0);
+    });
+
+    test(
+        'does not restart engine if still suspended for manual recording',
+        () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      await _ctrl(c).suspendForManualRecording();
+      await _ctrl(c).suspendByUser();
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+
+      engine.started = false;
+      engine.startCount = 0;
+      await _ctrl(c).resumeByUser();
+
+      // Engine should NOT start because manual recording suspension is still active
+      expect(engine.startCount, 0);
+    });
+  });
+
+  group('toggleUserSuspend', () {
+    test('suspends when not suspended', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      final result = await _ctrl(c).toggleUserSuspend();
+
+      expect(result, isTrue);
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+    });
+
+    test('resumes when already suspended', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      await _ctrl(c).suspendByUser();
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+
+      final result = await _ctrl(c).toggleUserSuspend();
+
+      expect(result, isFalse);
+      expect(_stateOf(c), isA<HandsFreeListening>());
+    });
+  });
+
+  group('suspension priority — resumeAfterTts', () {
+    test('does not restart when _suspendedByUser is true', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      // TTS + user suspend
+      await _ctrl(c).suspendForTts();
+      await _ctrl(c).suspendByUser();
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+
+      engine.started = false;
+      engine.startCount = 0;
+
+      // TTS finishes — but user pause should keep VAD stopped
+      await _ctrl(c).resumeAfterTts();
+
+      expect(engine.startCount, 0,
+          reason: 'user pause takes precedence over TTS resume');
+    });
+  });
+
+  group('suspension priority — resumeAfterManualRecording', () {
+    test('does not restart when _suspendedByUser is true', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      await _ctrl(c).suspendForManualRecording();
+      await _ctrl(c).suspendByUser();
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+
+      engine.started = false;
+      engine.startCount = 0;
+
+      // Manual recording finishes — but user pause should keep VAD stopped
+      await _ctrl(c).resumeAfterManualRecording();
+
+      expect(engine.startCount, 0,
+          reason: 'user pause takes precedence over manual recording resume');
+    });
+  });
+
+  group('reloadVadConfig guard', () {
+    test('is no-op when _suspendedByUser', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      await _ctrl(c).suspendByUser();
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+
+      engine.started = false;
+      engine.startCount = 0;
+
+      await _ctrl(c).reloadVadConfig();
+
+      expect(engine.startCount, 0,
+          reason: 'reloadVadConfig should not restart engine when user paused');
+    });
+  });
+
+  group('stopSession', () {
+    test('clears _suspendedByUser', () async {
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      await _ctrl(c).suspendByUser();
+      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+
+      await _ctrl(c).stopSession();
+
+      expect(_stateOf(c), isA<HandsFreeIdle>());
+
+      // Start again — should work normally (no lingering user pause)
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+
+      expect(_stateOf(c), isA<HandsFreeListening>());
+    });
+  });
+}

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -266,6 +266,10 @@ class _NullRecordingService implements RecordingService {
   Future<RecordingResult> stop() async =>
       RecordingResult(filePath: '/tmp/t.wav', duration: Duration.zero, sampleRate: 16000);
   @override
+  Future<void> pause() async {}
+  @override
+  Future<void> resume() async {}
+  @override
   Future<void> cancel() async {}
   @override
   bool get isRecording => false;
@@ -384,6 +388,7 @@ List<SegmentJob> jobsOf(HandsFreeSessionState s) => switch (s) {
       HandsFreeWithBacklog(:final jobs) => jobs,
       HandsFreeCapturing(:final jobs) => jobs,
       HandsFreeStopping(:final jobs) => jobs,
+      HandsFreeSuspendedByUser(:final jobs) => jobs,
       HandsFreeSessionError(:final jobs) => jobs,
       HandsFreeIdle() => [],
     };

--- a/test/features/recording/presentation/recording_controller_pause_test.dart
+++ b/test/features/recording/presentation/recording_controller_pause_test.dart
@@ -1,0 +1,302 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:voice_agent/core/config/app_config.dart';
+import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/config/app_config_service.dart';
+import 'package:voice_agent/core/models/sync_queue_item.dart';
+import 'package:voice_agent/core/models/transcript.dart';
+import 'package:voice_agent/core/models/transcript_result.dart';
+import 'package:voice_agent/core/models/transcript_with_status.dart';
+import 'package:voice_agent/core/storage/storage_provider.dart';
+import 'package:voice_agent/core/storage/storage_service.dart';
+import 'package:voice_agent/features/recording/domain/recording_result.dart';
+import 'package:voice_agent/features/recording/domain/recording_service.dart';
+import 'package:voice_agent/features/recording/domain/recording_state.dart';
+import 'package:voice_agent/features/recording/domain/stt_service.dart';
+import 'package:voice_agent/features/recording/presentation/recording_controller.dart';
+import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
+import 'package:voice_agent/core/audio/audio_feedback_service.dart';
+import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class _FakeRecordingService implements RecordingService {
+  bool _isRecording = false;
+  String? lastPath;
+  bool permissionGranted = true;
+  int pauseCount = 0;
+  int resumeCount = 0;
+  final _elapsedController = StreamController<Duration>.broadcast();
+
+  @override
+  Future<bool> requestPermission() async => permissionGranted;
+
+  @override
+  Future<void> start({required String outputPath}) async {
+    _isRecording = true;
+    lastPath = outputPath;
+  }
+
+  @override
+  Future<RecordingResult> stop() async {
+    _isRecording = false;
+    return RecordingResult(
+      filePath: lastPath ?? '/tmp/test.wav',
+      duration: const Duration(seconds: 5),
+      sampleRate: 16000,
+    );
+  }
+
+  @override
+  Future<void> pause() async {
+    pauseCount++;
+  }
+
+  @override
+  Future<void> resume() async {
+    resumeCount++;
+  }
+
+  @override
+  Future<void> cancel() async {
+    _isRecording = false;
+  }
+
+  @override
+  Stream<Duration> get elapsed => _elapsedController.stream;
+
+  @override
+  bool get isRecording => _isRecording;
+}
+
+class _FakeSttService implements SttService {
+  @override
+  Future<bool> isModelLoaded() async => true;
+
+  @override
+  Future<void> loadModel() async {}
+
+  @override
+  Future<TranscriptResult> transcribe(
+    String audioFilePath, {
+    String? languageCode,
+  }) async {
+    return const TranscriptResult(
+      text: 'Hello world',
+      segments: [],
+      detectedLanguage: 'en',
+      audioDurationMs: 5000,
+    );
+  }
+}
+
+class _FakeStorageService implements StorageService {
+  final List<Transcript> savedTranscripts = [];
+  final List<String> enqueuedIds = [];
+
+  @override
+  Future<String> getDeviceId() async => 'test-device';
+  @override
+  Future<void> saveTranscript(Transcript t) async => savedTranscripts.add(t);
+  @override
+  Future<Transcript?> getTranscript(String id) async => null;
+  @override
+  Future<List<Transcript>> getTranscripts(
+          {int limit = 50, int offset = 0}) async =>
+      [];
+  @override
+  Future<void> deleteTranscript(String id) async {}
+  @override
+  Future<void> enqueue(String transcriptId) async =>
+      enqueuedIds.add(transcriptId);
+  @override
+  Future<List<SyncQueueItem>> getPendingItems() async => [];
+  @override
+  Future<void> markSending(String id) async {}
+  @override
+  Future<void> markSent(String id) async {}
+  @override
+  Future<void> markFailed(String id, String error,
+      {int? overrideAttempts}) async {}
+  @override
+  Future<void> markPendingForRetry(String id) async {}
+  @override
+  Future<void> reactivateForResend(String transcriptId) async {}
+  @override
+  Future<List<TranscriptWithStatus>> getTranscriptsWithStatus(
+          {int limit = 20, int offset = 0}) async =>
+      [];
+  @override
+  Future<int> recoverStaleSending() async => 0;
+  @override
+  Future<List<SyncQueueItem>> getFailedItems({int? maxAttempts}) async => [];
+}
+
+class _StubAudioFeedbackService implements AudioFeedbackService {
+  @override
+  Future<void> startProcessingFeedback() async {}
+  @override
+  Future<void> stopLoop() async {}
+  @override
+  Future<void> playSuccess() async {}
+  @override
+  Future<void> playError() async {}
+  @override
+  void dispose() {}
+}
+
+class _FixedConfigService extends AppConfigService {
+  _FixedConfigService(this._config);
+  final AppConfig _config;
+
+  @override
+  Future<AppConfig> load() async => _config;
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+ProviderContainer _makeContainer({
+  required _FakeRecordingService fakeService,
+  required _FakeSttService fakeStt,
+  _FakeStorageService? fakeStorage,
+  AppConfig config = const AppConfig(groqApiKey: 'test-key'),
+}) {
+  return ProviderContainer(
+    overrides: [
+      appConfigServiceProvider.overrideWithValue(_FixedConfigService(config)),
+      recordingServiceProvider.overrideWithValue(fakeService),
+      sttServiceProvider.overrideWithValue(fakeStt),
+      storageServiceProvider
+          .overrideWithValue(fakeStorage ?? _FakeStorageService()),
+      audioFeedbackServiceProvider
+          .overrideWithValue(_StubAudioFeedbackService()),
+    ],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeRecordingService fakeService;
+  late _FakeSttService fakeStt;
+  late ProviderContainer container;
+  late RecordingController controller;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    FlutterSecureStorage.setMockInitialValues({});
+    fakeService = _FakeRecordingService();
+    fakeStt = _FakeSttService();
+    container = _makeContainer(fakeService: fakeService, fakeStt: fakeStt);
+    controller = container.read(recordingControllerProvider.notifier);
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  group('pauseRecording', () {
+    test('transitions from RecordingActive to RecordingPaused', () async {
+      // Simulate being in RecordingActive state
+      // ignore: invalid_use_of_protected_member
+      controller.state = const RecordingState.recording();
+      expect(controller.state, isA<RecordingActive>());
+
+      await controller.pauseRecording();
+
+      expect(controller.state, isA<RecordingPaused>());
+      expect(fakeService.pauseCount, 1);
+    });
+
+    test('is no-op when not RecordingActive', () async {
+      // From idle
+      await controller.pauseRecording();
+      expect(controller.state, isA<RecordingIdle>());
+      expect(fakeService.pauseCount, 0);
+    });
+
+    test('is no-op from RecordingPaused (already paused)', () async {
+      // ignore: invalid_use_of_protected_member
+      controller.state = const RecordingState.recording();
+      await controller.pauseRecording();
+      expect(controller.state, isA<RecordingPaused>());
+
+      // Pause again — should not double-pause
+      await controller.pauseRecording();
+      expect(controller.state, isA<RecordingPaused>());
+      expect(fakeService.pauseCount, 1);
+    });
+  });
+
+  group('resumeRecording', () {
+    test('transitions from RecordingPaused to RecordingActive', () async {
+      // ignore: invalid_use_of_protected_member
+      controller.state = const RecordingState.recording();
+      await controller.pauseRecording();
+      expect(controller.state, isA<RecordingPaused>());
+
+      await controller.resumeRecording();
+
+      expect(controller.state, isA<RecordingActive>());
+      expect(fakeService.resumeCount, 1);
+    });
+
+    test('is no-op when not RecordingPaused', () async {
+      // From idle
+      await controller.resumeRecording();
+      expect(controller.state, isA<RecordingIdle>());
+      expect(fakeService.resumeCount, 0);
+    });
+
+    test('is no-op from RecordingActive (not paused)', () async {
+      // ignore: invalid_use_of_protected_member
+      controller.state = const RecordingState.recording();
+      await controller.resumeRecording();
+      expect(controller.state, isA<RecordingActive>());
+      expect(fakeService.resumeCount, 0);
+    });
+  });
+
+  group('app lifecycle', () {
+    test('cancels from RecordingPaused state', () async {
+      // ignore: invalid_use_of_protected_member
+      controller.state = const RecordingState.recording();
+      await controller.pauseRecording();
+      expect(controller.state, isA<RecordingPaused>());
+
+      controller.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future.delayed(Duration.zero);
+
+      expect(controller.state, isA<RecordingIdle>());
+    });
+
+    test('cancels from RecordingActive state', () async {
+      // ignore: invalid_use_of_protected_member
+      controller.state = const RecordingState.recording();
+      expect(controller.state, isA<RecordingActive>());
+
+      controller.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future.delayed(Duration.zero);
+
+      expect(controller.state, isA<RecordingIdle>());
+    });
+
+    test('does not cancel from RecordingIdle', () async {
+      controller.didChangeAppLifecycleState(AppLifecycleState.paused);
+      expect(controller.state, isA<RecordingIdle>());
+    });
+  });
+}

--- a/test/features/recording/presentation/recording_controller_test.dart
+++ b/test/features/recording/presentation/recording_controller_test.dart
@@ -55,6 +55,12 @@ class FakeRecordingService implements RecordingService {
   }
 
   @override
+  Future<void> pause() async {}
+
+  @override
+  Future<void> resume() async {}
+
+  @override
   Future<void> cancel() async {
     _isRecording = false;
   }
@@ -404,6 +410,7 @@ void main() {
     const states = <RecordingState>[
       RecordingIdle(),
       RecordingActive(),
+      RecordingPaused(),
       RecordingTranscribing(),
       RecordingError('test error'),
     ];
@@ -414,12 +421,14 @@ void main() {
           break;
         case RecordingActive():
           break;
+        case RecordingPaused():
+          break;
         case RecordingTranscribing():
           break;
         case RecordingError():
           break;
       }
     }
-    expect(states.length, 4);
+    expect(states.length, 5);
   });
 }

--- a/test/features/recording/presentation/recording_screen_hands_free_test.dart
+++ b/test/features/recording/presentation/recording_screen_hands_free_test.dart
@@ -27,10 +27,12 @@ import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
 import 'package:voice_agent/core/audio/audio_feedback_service.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
+import 'package:voice_agent/core/media_button/media_button_provider.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../../helpers/stub_background_service.dart';
+import '../../../helpers/stub_media_button.dart';
 import '../../../helpers/stub_session_control.dart';
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────
@@ -80,6 +82,8 @@ class _NoOpRecordingService implements RecordingService {
   @override Future<void> start({required String outputPath}) async {}
   @override Future<RecordingResult> stop() async => RecordingResult(
       filePath: '/tmp/x.wav', duration: Duration.zero, sampleRate: 16000);
+  @override Future<void> pause() async {}
+  @override Future<void> resume() async {}
   @override Future<void> cancel() async {}
   @override Stream<Duration> get elapsed => const Stream.empty();
   @override bool get isRecording => false;
@@ -137,6 +141,7 @@ List<Override> baseOverrides(FakeHfEngine engine) => [
       ttsServiceProvider.overrideWithValue(_StubTtsService()),
       audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
       backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+      mediaButtonProvider.overrideWithValue(StubMediaButtonPort()),
       ...sessionControlTestOverrides,
     ];
 

--- a/test/features/recording/presentation/recording_screen_mic_button_test.dart
+++ b/test/features/recording/presentation/recording_screen_mic_button_test.dart
@@ -28,11 +28,13 @@ import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
 import 'package:voice_agent/core/audio/audio_feedback_service.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
+import 'package:voice_agent/core/media_button/media_button_provider.dart';
 import 'package:voice_agent/features/recording/presentation/recording_controller.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../../helpers/stub_background_service.dart';
+import '../../../helpers/stub_media_button.dart';
 import '../../../helpers/stub_session_control.dart';
 
 // ── Stubs ────────────────────────────────────────────────────────────────────
@@ -83,6 +85,8 @@ class _NoOpRecordingService implements RecordingService {
   @override Future<void> start({required String outputPath}) async {}
   @override Future<RecordingResult> stop() async =>
       RecordingResult(filePath: '/tmp/x.wav', duration: Duration.zero, sampleRate: 16000);
+  @override Future<void> pause() async {}
+  @override Future<void> resume() async {}
   @override Future<void> cancel() async {}
   @override Stream<Duration> get elapsed => const Stream.empty();
   @override bool get isRecording => false;
@@ -157,6 +161,7 @@ List<Override> get _baseOverrides => [
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
   backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+  mediaButtonProvider.overrideWithValue(StubMediaButtonPort()),
   ...sessionControlTestOverrides,
 ];
 
@@ -192,6 +197,7 @@ Future<_SpyTtsService> _pumpAppWithSpyTts(WidgetTester tester) async {
         ttsServiceProvider.overrideWithValue(spy),
         audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
         backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+        mediaButtonProvider.overrideWithValue(StubMediaButtonPort()),
         ...sessionControlTestOverrides,
       ],
       child: const App(),

--- a/test/features/recording/presentation/recording_screen_new_conversation_test.dart
+++ b/test/features/recording/presentation/recording_screen_new_conversation_test.dart
@@ -29,11 +29,13 @@ import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
 import 'package:voice_agent/features/recording/domain/recording_result.dart';
+import 'package:voice_agent/core/media_button/media_button_provider.dart';
 import 'package:voice_agent/features/recording/domain/recording_service.dart';
 import 'package:voice_agent/features/recording/domain/stt_service.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 
 import '../../../helpers/stub_background_service.dart';
+import '../../../helpers/stub_media_button.dart';
 
 // ── Stubs ────────────────────────────────────────────────────────────────────
 
@@ -154,6 +156,10 @@ class _NoOpRecordingService implements RecordingService {
   Future<RecordingResult> stop() async => RecordingResult(
       filePath: '/tmp/x.wav', duration: Duration.zero, sampleRate: 16000);
   @override
+  Future<void> pause() async {}
+  @override
+  Future<void> resume() async {}
+  @override
   Future<void> cancel() async {}
   @override
   Stream<Duration> get elapsed => const Stream.empty();
@@ -226,6 +232,7 @@ List<Override> _baseOverrides({
       audioFeedbackServiceProvider
           .overrideWithValue(_StubAudioFeedbackService()),
       backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+      mediaButtonProvider.overrideWithValue(StubMediaButtonPort()),
       sessionIdCoordinatorProvider
           .overrideWithValue(coordinator ?? SessionIdCoordinator()),
       toasterProvider.overrideWithValue(

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -28,11 +28,13 @@ import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
 import 'package:voice_agent/core/audio/audio_feedback_service.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
+import 'package:voice_agent/core/media_button/media_button_provider.dart';
 import 'package:voice_agent/features/recording/presentation/recording_controller.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 import 'package:voice_agent/core/background/background_service_provider.dart';
 
 import '../../../helpers/stub_background_service.dart';
+import '../../../helpers/stub_media_button.dart';
 import '../../../helpers/stub_session_control.dart';
 
 class _StubStorage implements StorageService {
@@ -99,6 +101,7 @@ List<Override> get _baseOverrides => [
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
   backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+  mediaButtonProvider.overrideWithValue(StubMediaButtonPort()),
   ...sessionControlTestOverrides,
 ];
 
@@ -309,6 +312,10 @@ class _NoOpRecordingService implements RecordingService {
         duration: Duration.zero,
         sampleRate: 16000,
       );
+  @override
+  Future<void> pause() async {}
+  @override
+  Future<void> resume() async {}
   @override
   Future<void> cancel() async {}
   @override

--- a/test/features/settings/advanced_settings_screen_test.dart
+++ b/test/features/settings/advanced_settings_screen_test.dart
@@ -24,8 +24,10 @@ import 'package:voice_agent/features/recording/domain/recording_service.dart';
 import 'package:voice_agent/features/recording/domain/stt_service.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 import 'package:voice_agent/core/background/background_service_provider.dart';
+import 'package:voice_agent/core/media_button/media_button_provider.dart';
 
 import '../../helpers/stub_background_service.dart';
+import '../../helpers/stub_media_button.dart';
 import '../../helpers/stub_session_control.dart';
 import 'package:voice_agent/features/settings/advanced_settings_screen.dart';
 
@@ -68,6 +70,8 @@ class _NoOpRecordingService implements RecordingService {
   @override Future<void> start({required String outputPath}) async {}
   @override Future<RecordingResult> stop() async =>
       RecordingResult(filePath: '/tmp/x.wav', duration: Duration.zero, sampleRate: 16000);
+  @override Future<void> pause() async {}
+  @override Future<void> resume() async {}
   @override Future<void> cancel() async {}
   @override Stream<Duration> get elapsed => const Stream.empty();
   @override bool get isRecording => false;
@@ -107,6 +111,7 @@ List<Override> _baseOverrides({AppConfigService? configService}) => [
   if (configService != null)
     appConfigServiceProvider.overrideWithValue(configService),
   backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+  mediaButtonProvider.overrideWithValue(StubMediaButtonPort()),
   ...sessionControlTestOverrides,
 ];
 

--- a/test/helpers/stub_media_button.dart
+++ b/test/helpers/stub_media_button.dart
@@ -1,0 +1,22 @@
+import 'dart:async';
+
+import 'package:voice_agent/core/media_button/media_button_port.dart';
+
+/// No-op [MediaButtonPort] for tests. Never emits events.
+class StubMediaButtonPort implements MediaButtonPort {
+  final _controller = StreamController<MediaButtonEvent>.broadcast();
+
+  @override
+  Stream<MediaButtonEvent> get events => _controller.stream;
+
+  @override
+  Future<void> activate() async {}
+
+  @override
+  Future<void> deactivate() async {}
+
+  /// Emits an event for testing.
+  void emit(MediaButtonEvent event) => _controller.add(event);
+
+  void dispose() => _controller.close();
+}


### PR DESCRIPTION
Adds pause/resume for both manual dictation and hands-free listening, wired to the media button service from T1.

- RecordingPaused state + pause()/resume() on RecordingService
- HandsFreeSuspendedByUser state + toggleUserSuspend() with suspension priority
- Media button dispatch in RecordingScreen
- 24 new tests (9 recording controller + 15 hands-free controller)
