### PR TITLE
fix(recording): stop TTS on AirPods button press

### DIFF
--- a/lib/core/tts/flutter_tts_service.dart
+++ b/lib/core/tts/flutter_tts_service.dart
@@ -172,13 +172,30 @@ class FlutterTtsService implements TtsService {
     _speaking.dispose();
   }
 
+  static final _langNameToCode = <String, String>{
+    'afrikaans': 'af', 'arabic': 'ar', 'armenian': 'hy', 'azerbaijani': 'az',
+    'belarusian': 'be', 'bosnian': 'bs', 'bulgarian': 'bg', 'catalan': 'ca',
+    'chinese': 'zh', 'croatian': 'hr', 'czech': 'cs', 'danish': 'da',
+    'dutch': 'nl', 'english': 'en', 'estonian': 'et', 'finnish': 'fi',
+    'french': 'fr', 'galician': 'gl', 'german': 'de', 'greek': 'el',
+    'hebrew': 'he', 'hindi': 'hi', 'hungarian': 'hu', 'icelandic': 'is',
+    'indonesian': 'id', 'italian': 'it', 'japanese': 'ja', 'kannada': 'kn',
+    'kazakh': 'kk', 'korean': 'ko', 'latvian': 'lv', 'lithuanian': 'lt',
+    'macedonian': 'mk', 'malay': 'ms', 'marathi': 'mr', 'maori': 'mi',
+    'nepali': 'ne', 'norwegian': 'no', 'persian': 'fa', 'polish': 'pl',
+    'portuguese': 'pt', 'romanian': 'ro', 'russian': 'ru', 'serbian': 'sr',
+    'slovak': 'sk', 'slovenian': 'sl', 'spanish': 'es', 'swahili': 'sw',
+    'swedish': 'sv', 'tagalog': 'tl', 'tamil': 'ta', 'thai': 'th',
+    'turkish': 'tr', 'ukrainian': 'uk', 'urdu': 'ur', 'vietnamese': 'vi',
+    'welsh': 'cy',
+  };
+
   String _resolveLanguage(String? code) {
     if (code == null || code == 'auto') {
-      // Use full device locale (e.g. "pl_PL") so AVSpeechSynthesizer on iOS
-      // can select the correct voice. Never pass bare two-letter code for auto.
       return Platform.localeName;
     }
-    // Explicit code (e.g. "pl", "en") — passed as-is; best-effort on iOS.
+    final normalized = _langNameToCode[code.toLowerCase()];
+    if (normalized != null) return normalized;
     return code;
   }
 

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -48,6 +48,11 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
   void _onMediaButtonEvent(MediaButtonEvent event) {
     if (event != MediaButtonEvent.togglePlayPause) return;
 
+    if (ref.read(ttsPlayingProvider)) {
+      unawaited(ref.read(ttsServiceProvider).stop());
+      return;
+    }
+
     final recState = ref.read(recordingControllerProvider);
     final hfState = ref.read(handsFreeControllerProvider);
     final recCtrl = ref.read(recordingControllerProvider.notifier);


### PR DESCRIPTION
## Summary
- Stop TTS playback when AirPods play/pause button is pressed during agent speech
- Normalize language names (e.g. "polish") to ISO 639-1 codes in TTS _resolveLanguage, fixing voice selection when Groq returns full names

## Test plan
- [ ] Start a conversation that triggers agent TTS reply
- [ ] While TTS is playing, press AirPods play/pause button — verify TTS stops immediately
- [ ] Verify recording start/stop via AirPods still works when TTS is not playing
- [ ] Verify hands-free suspend/resume via AirPods still works
- [ ] Verify TTS speaks with correct voice when Groq returns full language name (e.g. "polish")
