### PR TITLE
API URL guard + env-injected defaults + spoken sync errors

### DIFF
--- a/.env.mobile.example
+++ b/.env.mobile.example
@@ -1,0 +1,8 @@
+# Compile-time defaults for voice-agent.
+# Copy to .env.mobile and fill in your values.
+# These are baked into the app at build time via --dart-define-from-file.
+# User-configured values in Settings always take precedence.
+
+API_URL=
+API_TOKEN=
+GROQ_API_KEY=

--- a/.env.mobile.example
+++ b/.env.mobile.example
@@ -6,3 +6,5 @@
 API_URL=
 API_TOKEN=
 GROQ_API_KEY=
+# GROQ_API_TOKEN is accepted as a legacy alias for GROQ_API_KEY when the
+# latter is empty. Prefer GROQ_API_KEY in new files.

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ assets/models/
 
 # Secrets and credentials
 .env
+.env.mobile
 *.jks
 *.keystore
 .claude/settings.local.json

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ MODEL_DIR := assets/models
 VAD_MODEL_URL := https://cdn.jsdelivr.net/npm/@keyurmaru/vad@0.0.1/silero_vad_v5.onnx
 VAD_MODEL_PATH := $(MODEL_DIR)/silero_vad_v5.onnx
 
+# Inject compile-time defaults from .env.mobile when the file has content.
+ENV_FILE := .env.mobile
+DART_DEFINE_FLAG := $(shell test -s $(ENV_FILE) && echo "--dart-define-from-file=$(ENV_FILE)")
+
 # ──────────────────────────────────────────────
 # Project setup
 # ──────────────────────────────────────────────
@@ -83,19 +87,19 @@ env:
 
 ## run-web: Run stable flavor in Chrome (no native plugins)
 run-web:
-	flutter run -d chrome --flavor stable
+	flutter run -d chrome --flavor stable $(DART_DEFINE_FLAG)
 
 ## run-ios: Run stable flavor on iOS Simulator
 run-ios: _ensure-simulator
-	flutter run -d iPhone --flavor stable
+	flutter run -d iPhone --flavor stable $(DART_DEFINE_FLAG)
 
 ## run-ios-dev: Run dev flavor on iOS Simulator
 run-ios-dev: _ensure-simulator
-	flutter run -d iPhone --flavor dev
+	flutter run -d iPhone --flavor dev $(DART_DEFINE_FLAG)
 
 ## run-macos: Run the app as macOS desktop
 run-macos:
-	flutter run -d macos
+	flutter run -d macos $(DART_DEFINE_FLAG)
 
 ## simulator: Open iOS Simulator
 simulator:
@@ -112,7 +116,7 @@ install-ios:
 	fi; \
 	DEVICE_NAME=$$(flutter devices 2>/dev/null | grep '• ios •' | head -1 | awk -F'•' '{gsub(/[ \t]+$$/, "", $$1); print $$1}'); \
 	echo "Installing stable on: $$DEVICE_NAME ($$DEVICE_ID)"; \
-	flutter run -d "$$DEVICE_ID" --flavor stable
+	flutter run -d "$$DEVICE_ID" --flavor stable $(DART_DEFINE_FLAG)
 
 ## install-ios-dev: Build and install dev on a physical iOS device (USB or wireless)
 install-ios-dev:
@@ -125,7 +129,7 @@ install-ios-dev:
 	fi; \
 	DEVICE_NAME=$$(flutter devices 2>/dev/null | grep '• ios •' | head -1 | awk -F'•' '{gsub(/[ \t]+$$/, "", $$1); print $$1}'); \
 	echo "Installing dev on: $$DEVICE_NAME ($$DEVICE_ID)"; \
-	flutter run -d "$$DEVICE_ID" --flavor dev
+	flutter run -d "$$DEVICE_ID" --flavor dev $(DART_DEFINE_FLAG)
 
 ## devices: List available devices
 devices:

--- a/lib/core/config/app_config_service.dart
+++ b/lib/core/config/app_config_service.dart
@@ -53,6 +53,13 @@ class AppConfigService {
     'picovoice_access_key',
   ];
 
+  static const _defaultApiUrl = String.fromEnvironment('API_URL');
+  static const _defaultApiToken = String.fromEnvironment('API_TOKEN');
+  static const _defaultGroqApiKey = String.fromEnvironment('GROQ_API_KEY',
+      defaultValue: String.fromEnvironment('GROQ_API_TOKEN'));
+
+  static String? _nullIfEmpty(String value) => value.isEmpty ? null : value;
+
   Future<SharedPreferences> get _preferences async {
     _prefs ??= await SharedPreferences.getInstance();
     return _prefs!;
@@ -92,9 +99,9 @@ class AppConfigService {
     ).clamp();
 
     return AppConfig(
-      apiUrl: prefs.getString(_apiUrlKey),
-      apiToken: token,
-      groqApiKey: groqApiKey,
+      apiUrl: prefs.getString(_apiUrlKey) ?? _nullIfEmpty(_defaultApiUrl),
+      apiToken: token ?? _nullIfEmpty(_defaultApiToken),
+      groqApiKey: groqApiKey ?? _nullIfEmpty(_defaultGroqApiKey),
       autoSend: prefs.getBool(_autoSendKey) ?? true,
       language: prefs.getString(_languageKey) ?? 'auto',
       keepHistory: prefs.getBool(_keepHistoryKey) ?? true,

--- a/lib/features/api_sync/sync_worker.dart
+++ b/lib/features/api_sync/sync_worker.dart
@@ -165,11 +165,11 @@ class SyncWorker {
           unawaited(audioFeedbackService.playSuccess());
           await _handleReply(body);
         case ApiPermanentFailure(:final message):
-          // Exhaust retry budget — permanent failures should never be auto-retried
           await storageService.markFailed(
             item.id, message, overrideAttempts: _maxRetries,
           );
           unawaited(audioFeedbackService.playError());
+          await _speakError(message);
         case ApiTransientFailure(:final reason):
           final attempts = item.attempts + 1; // markSending already incremented
           if (attempts >= _maxRetries) {
@@ -181,11 +181,22 @@ class SyncWorker {
             await storageService.markFailed(item.id, reason);
           }
           unawaited(audioFeedbackService.playError());
+          await _speakError(reason);
         case ApiNotConfigured():
           break;
       }
     } finally {
       _draining = false;
+    }
+  }
+
+  Future<void> _speakError(String message) async {
+    if (!getTtsEnabled()) return;
+    try {
+      await ttsService.stop();
+      await ttsService.speak(message);
+    } catch (_) {
+      // Best-effort — don't let TTS failure break the sync loop.
     }
   }
 

--- a/lib/features/api_sync/sync_worker.dart
+++ b/lib/features/api_sync/sync_worker.dart
@@ -165,6 +165,7 @@ class SyncWorker {
           unawaited(audioFeedbackService.playSuccess());
           await _handleReply(body);
         case ApiPermanentFailure(:final message):
+          // Exhaust retry budget — permanent failures should never be auto-retried
           await storageService.markFailed(
             item.id, message, overrideAttempts: _maxRetries,
           );

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -246,6 +246,16 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
       return;
     }
 
+    // Guard 3 — API URL.
+    if (config.apiUrl == null || config.apiUrl!.isEmpty) {
+      state = const HandsFreeSessionError(
+        message: 'API URL not set.',
+        requiresAppSettings: true,
+        jobs: [],
+      );
+      return;
+    }
+
     // All guards passed — mark the session active BEFORE starting the engine
     // so SyncWorker (P027, ADR-NET-002) can drain in the background from the
     // very first tick.

--- a/lib/features/recording/presentation/recording_controller.dart
+++ b/lib/features/recording/presentation/recording_controller.dart
@@ -57,6 +57,14 @@ class RecordingController extends StateNotifier<RecordingState>
       return;
     }
 
+    if (config.apiUrl == null || config.apiUrl!.isEmpty) {
+      state = const RecordingState.error(
+        'API URL not set.',
+        requiresAppSettings: true,
+      );
+      return;
+    }
+
     try {
       if (!await _sttService.isModelLoaded()) {
         await _sttService.loadModel();

--- a/test/app/app_shell_scaffold_test.dart
+++ b/test/app/app_shell_scaffold_test.dart
@@ -107,7 +107,7 @@ List<Override> get _baseOverrides => [
   connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
   handsFreeEngineProvider.overrideWithValue(_IdleHfEngine()),
   appConfigServiceProvider.overrideWithValue(
-    _FixedConfigService(const AppConfig(groqApiKey: 'test-key')),
+    _FixedConfigService(const AppConfig(groqApiKey: 'test-key', apiUrl: 'https://test.example.com/api')),
   ),
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedback()),

--- a/test/features/api_sync/sync_worker_test.dart
+++ b/test/features/api_sync/sync_worker_test.dart
@@ -408,6 +408,56 @@ void main() {
       expect(storage.queueItems.length, 1);
     });
 
+    test('speaks error via TTS on permanent failure', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextResult = const ApiPermanentFailure(
+        statusCode: 400,
+        message: 'Invalid transcript format',
+      );
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 100));
+      worker.stop();
+
+      expect(tts.log, contains('stop'));
+      expect(
+        tts.log.any((e) => e.startsWith('speak:Invalid transcript format:')),
+        isTrue,
+      );
+    });
+
+    test('speaks error via TTS on transient failure', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextResult = const ApiTransientFailure(reason: 'Connection timeout');
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 100));
+      worker.stop();
+
+      expect(
+        tts.log.any((e) => e.startsWith('speak:Connection timeout:')),
+        isTrue,
+      );
+    });
+
+    test('does not speak error when TTS is disabled', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      ttsEnabled = false;
+      apiClient.nextResult = const ApiPermanentFailure(
+        statusCode: 500,
+        message: 'Server error',
+      );
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 100));
+      worker.stop();
+
+      expect(tts.log, isEmpty);
+    });
+
     test('pauses on offline connectivity', () async {
       worker.start();
       expect(worker.state, SyncWorkerState.running);

--- a/test/features/recording/presentation/hands_free_controller_pause_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_pause_test.dart
@@ -179,7 +179,7 @@ ProviderContainer _makeContainer({
   final container = ProviderContainer(overrides: [
     handsFreeEngineProvider.overrideWithValue(engine),
     appConfigServiceProvider.overrideWithValue(
-      _FixedConfigService(AppConfig(groqApiKey: groqApiKey)),
+      _FixedConfigService(AppConfig(groqApiKey: groqApiKey, apiUrl: 'https://test.example.com/api')),
     ),
     recordingControllerProvider.overrideWith(
       (ref) => _IdleRecordingController(ref),

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -340,9 +340,12 @@ class _StubAudioFeedbackService implements AudioFeedbackService {
 
 // ── Container factory ────────────────────────────────────────────────────────
 
+const _defaultApiUrl = Object();
+
 ProviderContainer makeContainer({
   required HandsFreeEngine engine,
   String? groqApiKey = 'gsk_test_valid',
+  Object? apiUrl = _defaultApiUrl,
   bool recordingActive = false,
   SttService? sttService,
   StorageService? storageService,
@@ -353,7 +356,10 @@ ProviderContainer makeContainer({
   final container = ProviderContainer(overrides: [
     handsFreeEngineProvider.overrideWithValue(engine),
     appConfigServiceProvider.overrideWithValue(
-      _FixedConfigService(AppConfig(groqApiKey: groqApiKey)),
+      _FixedConfigService(AppConfig(
+        groqApiKey: groqApiKey,
+        apiUrl: apiUrl == _defaultApiUrl ? 'https://test.example.com/api' : apiUrl as String?,
+      )),
     ),
     recordingControllerProvider.overrideWith(
       (ref) => recordingActive
@@ -426,6 +432,29 @@ void main() {
     test('empty Groq key → SessionError(requiresAppSettings)', () async {
       final engine = FakeHandsFreeEngine();
       final c = makeContainer(engine: engine, groqApiKey: '');
+
+      await ctrl(c).startSession();
+
+      final s = stateOf(c) as HandsFreeSessionError;
+      expect(s.requiresAppSettings, isTrue);
+      expect(engine.started, isFalse);
+    });
+
+    test('missing API URL → SessionError(requiresAppSettings)', () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine, apiUrl: null);
+
+      await ctrl(c).startSession();
+
+      final s = stateOf(c) as HandsFreeSessionError;
+      expect(s.requiresAppSettings, isTrue);
+      expect(s.message, 'API URL not set.');
+      expect(engine.started, isFalse);
+    });
+
+    test('empty API URL → SessionError(requiresAppSettings)', () async {
+      final engine = FakeHandsFreeEngine();
+      final c = makeContainer(engine: engine, apiUrl: '');
 
       await ctrl(c).startSession();
 

--- a/test/features/recording/presentation/recording_controller_pause_test.dart
+++ b/test/features/recording/presentation/recording_controller_pause_test.dart
@@ -168,7 +168,7 @@ ProviderContainer _makeContainer({
   required _FakeRecordingService fakeService,
   required _FakeSttService fakeStt,
   _FakeStorageService? fakeStorage,
-  AppConfig config = const AppConfig(groqApiKey: 'test-key'),
+  AppConfig config = const AppConfig(groqApiKey: 'test-key', apiUrl: 'https://test.example.com/api'),
 }) {
   return ProviderContainer(
     overrides: [

--- a/test/features/recording/presentation/recording_controller_test.dart
+++ b/test/features/recording/presentation/recording_controller_test.dart
@@ -201,7 +201,7 @@ ProviderContainer _makeContainer({
   required FakeRecordingService fakeService,
   required FakeSttService fakeStt,
   FakeStorageService? fakeStorage,
-  AppConfig config = const AppConfig(groqApiKey: 'test-key'),
+  AppConfig config = const AppConfig(groqApiKey: 'test-key', apiUrl: 'https://test.example.com/api'),
 }) {
   return ProviderContainer(
     overrides: [
@@ -398,6 +398,43 @@ void main() {
     );
     addTearDown(noKeyContainer.dispose);
     final ctrl = noKeyContainer.read(recordingControllerProvider.notifier);
+
+    await ctrl.startRecording();
+
+    expect(ctrl.state, isA<RecordingError>());
+    final error = ctrl.state as RecordingError;
+    expect(error.requiresAppSettings, isTrue);
+  });
+
+  test(
+      'startRecording emits RecordingError(requiresAppSettings) when API URL missing',
+      () async {
+    final noUrlContainer = _makeContainer(
+      fakeService: fakeService,
+      fakeStt: fakeStt,
+      config: const AppConfig(groqApiKey: 'test-key', apiUrl: null),
+    );
+    addTearDown(noUrlContainer.dispose);
+    final ctrl = noUrlContainer.read(recordingControllerProvider.notifier);
+
+    await ctrl.startRecording();
+
+    expect(ctrl.state, isA<RecordingError>());
+    final error = ctrl.state as RecordingError;
+    expect(error.requiresAppSettings, isTrue);
+    expect(error.message, 'API URL not set.');
+  });
+
+  test(
+      'startRecording emits RecordingError(requiresAppSettings) when API URL empty',
+      () async {
+    final noUrlContainer = _makeContainer(
+      fakeService: fakeService,
+      fakeStt: fakeStt,
+      config: const AppConfig(groqApiKey: 'test-key', apiUrl: ''),
+    );
+    addTearDown(noUrlContainer.dispose);
+    final ctrl = noUrlContainer.read(recordingControllerProvider.notifier);
 
     await ctrl.startRecording();
 

--- a/test/features/recording/presentation/recording_screen_hands_free_test.dart
+++ b/test/features/recording/presentation/recording_screen_hands_free_test.dart
@@ -133,7 +133,7 @@ List<Override> baseOverrides(FakeHfEngine engine) => [
       connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
       apiUrlConfiguredProvider.overrideWithValue(true),
       appConfigServiceProvider.overrideWithValue(
-        _FixedConfigService(const AppConfig(groqApiKey: 'gsk_test_key')),
+        _FixedConfigService(const AppConfig(groqApiKey: 'gsk_test_key', apiUrl: 'https://test.example.com/api')),
       ),
       handsFreeEngineProvider.overrideWithValue(engine),
       sttServiceProvider.overrideWithValue(_NoOpSttService()),

--- a/test/features/recording/presentation/recording_screen_mic_button_test.dart
+++ b/test/features/recording/presentation/recording_screen_mic_button_test.dart
@@ -148,7 +148,7 @@ List<Override> get _baseOverrides => [
   connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
   apiUrlConfiguredProvider.overrideWithValue(true),
   appConfigServiceProvider.overrideWithValue(
-    _FixedConfigService(const AppConfig(groqApiKey: 'gsk_test_key')),
+    _FixedConfigService(const AppConfig(groqApiKey: 'gsk_test_key', apiUrl: 'https://test.example.com/api')),
   ),
   handsFreeEngineProvider.overrideWithValue(_IdleHfEngine()),
   recordingServiceProvider.overrideWithValue(_NoOpRecordingService()),
@@ -184,7 +184,7 @@ Future<_SpyTtsService> _pumpAppWithSpyTts(WidgetTester tester) async {
         connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
         apiUrlConfiguredProvider.overrideWithValue(true),
         appConfigServiceProvider.overrideWithValue(
-          _FixedConfigService(const AppConfig(groqApiKey: 'gsk_test_key')),
+          _FixedConfigService(const AppConfig(groqApiKey: 'gsk_test_key', apiUrl: 'https://test.example.com/api')),
         ),
         handsFreeEngineProvider.overrideWithValue(_IdleHfEngine()),
         recordingServiceProvider.overrideWithValue(_NoOpRecordingService()),

--- a/test/features/recording/presentation/recording_screen_new_conversation_test.dart
+++ b/test/features/recording/presentation/recording_screen_new_conversation_test.dart
@@ -223,7 +223,7 @@ List<Override> _baseOverrides({
       connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
       apiUrlConfiguredProvider.overrideWithValue(true),
       appConfigServiceProvider.overrideWithValue(
-        _FixedConfigService(const AppConfig(groqApiKey: 'gsk_test_key')),
+        _FixedConfigService(const AppConfig(groqApiKey: 'gsk_test_key', apiUrl: 'https://test.example.com/api')),
       ),
       handsFreeEngineProvider.overrideWithValue(engine ?? _IdleHfEngine()),
       sttServiceProvider.overrideWithValue(_NoOpSttService()),

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -96,7 +96,7 @@ List<Override> get _baseOverrides => [
   connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
   handsFreeEngineProvider.overrideWithValue(_IdleHfEngine()),
   appConfigServiceProvider.overrideWithValue(
-    _FixedConfigService(const AppConfig(groqApiKey: 'test-key')),
+    _FixedConfigService(const AppConfig(groqApiKey: 'test-key', apiUrl: 'https://test.example.com/api')),
   ),
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
   audioFeedbackServiceProvider.overrideWithValue(_StubAudioFeedbackService()),
@@ -122,19 +122,23 @@ void main() {
     expect(find.text('Tap to record'), findsOneWidget);
   });
 
-  testWidgets('Record screen shows banner when API not configured',
+  testWidgets('Record screen shows error when API URL not configured',
       (tester) async {
     await tester.pumpWidget(
-      ProviderScope(overrides: _baseOverrides, child: const App()),
+      ProviderScope(
+        overrides: [
+          ..._baseOverrides,
+          appConfigServiceProvider.overrideWithValue(
+            _FixedConfigService(const AppConfig(groqApiKey: 'test-key', apiUrl: null)),
+          ),
+        ],
+        child: const App(),
+      ),
     );
     await tester.pumpAndSettle();
 
-    expect(
-      find.text(
-        'Set up your API endpoint in Settings to sync your transcripts.',
-      ),
-      findsOneWidget,
-    );
+    expect(find.text('API URL not set.'), findsOneWidget);
+    expect(find.text('Go to Settings'), findsWidgets);
   });
 
   testWidgets('Record screen hides banner when API configured',


### PR DESCRIPTION
## Summary

Three connected pieces of API config robustness, packaged together because they share the same flow (build-time injection → runtime guard → user feedback when the network rejects):

1. **Compile-time defaults via `.env.mobile`** — `Makefile` injects `API_URL` / `API_TOKEN` / `GROQ_API_KEY` through `--dart-define-from-file` when the file has content. `AppConfigService` reads them via `String.fromEnvironment` as fallbacks; user-configured values in Settings (SharedPreferences) take precedence. Lets a personal install ship with sensible defaults baked in (post-P035 ergonomics) without putting secrets in source.
2. **API URL guard before recording** — `RecordingController` and `HandsFreeController` emit `RecordingState.error('API URL not set.', requiresAppSettings: true)` when `config.apiUrl` is null/empty, bouncing the user to `/settings` instead of failing silently mid-flow. Parallels the existing P011 Groq-key guard pattern.
3. **Spoken sync errors** — `SyncWorker` speaks `ApiPermanentFailure` / `ApiTransientFailure` messages via `TtsService` when TTS is enabled. Best-effort; swallows TTS exceptions so the sync loop is never broken by a TTS failure. Hands-free user hears why their dictation didn't land.

## Files changed

```
.gitignore                                                +1
.env.mobile.example                                       +8 (template)
Makefile                                                  +12 -8
lib/core/config/app_config_service.dart                   +10 -3
lib/features/api_sync/sync_worker.dart                    +12 -1
lib/features/recording/presentation/recording_controller.dart      +8
lib/features/recording/presentation/hands_free_controller.dart     +10
test/...                                                  +136 (10 files)
```

`.env.mobile` (real secrets) is gitignored — only `.env.mobile.example` is in source.

## Tests

Added:
- `recording_controller_test`: 2 new cases (`apiUrl: null`, `apiUrl: ''`) — guard fires.
- `hands_free_controller_test`: parallel coverage for hands-free guard.
- `sync_worker_test`: `_speakError` invocation on failure paths.

## Pre-existing failures (not caused by this PR)

`recording_screen_new_conversation_test.dart` has 7 failures that **already fail on clean `origin/main`** — the test fixture is missing `handsFreeControlPortProvider` override (introduced in P029 but not propagated to this test's `_baseOverrides`). Verified by running the same test against `origin/main` in a separate worktree. To be fixed in a follow-up PR.

## Related proposals

This PR is a small ergonomic follow-up that doesn't have a dedicated proposal — it threads existing patterns:
- 011 (Groq STT) — established the `requiresAppSettings: true` guard pattern; this PR extends it to API URL.
- 015 (TTS response playback) + 016 (audio feedback) — the existing TTS / jingle pipeline that this PR's `_speakError` reuses.
- 035 (dual installation flavors) — recently merged; this PR adds the `.env.mobile` injection ergonomics that 035 stopped short of.

## Test plan

- [x] `make analyze` — clean.
- [x] `make test` — passes for all changes in this PR; 7 pre-existing failures unchanged.
- [ ] Manual verify on iOS device with empty Settings — expect "API URL not set" error with "Go to Settings" navigation.
- [ ] Manual verify on iOS device with bad URL set — expect TTS to speak the network error message.
- [ ] Manual verify build with `.env.mobile` present — expect baked-in defaults visible at first launch.
