### PR TITLE
fix(test): override handsFreeControlPortProvider in new-conversation fixture

### DIFF
--- a/test/features/recording/presentation/recording_screen_new_conversation_test.dart
+++ b/test/features/recording/presentation/recording_screen_new_conversation_test.dart
@@ -19,6 +19,7 @@ import 'package:voice_agent/core/models/transcript_with_status.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
 import 'package:voice_agent/core/providers/api_url_provider.dart';
 import 'package:voice_agent/features/api_sync/sync_provider.dart';
+import 'package:voice_agent/core/session_control/hands_free_control_port.dart';
 import 'package:voice_agent/core/session_control/haptic_service.dart';
 import 'package:voice_agent/core/session_control/session_control_provider.dart';
 import 'package:voice_agent/core/session_control/session_id_coordinator.dart';
@@ -235,11 +236,21 @@ List<Override> _baseOverrides({
       mediaButtonProvider.overrideWithValue(StubMediaButtonPort()),
       sessionIdCoordinatorProvider
           .overrideWithValue(coordinator ?? SessionIdCoordinator()),
+      handsFreeControlPortProvider
+          .overrideWithValue(_StubHandsFreeControlPort()),
       toasterProvider.overrideWithValue(
           toaster ?? _SpyToaster()),
       hapticServiceProvider
           .overrideWithValue(hapticService ?? _SpyHapticService()),
     ];
+
+class _StubHandsFreeControlPort implements HandsFreeControlPort {
+  @override
+  bool get isSuspendedForManualRecording => false;
+
+  @override
+  Future<void> stopSession() async {}
+}
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes 7 pre-existing failures in `recording_screen_new_conversation_test.dart` flagged in #262.

`handsFreeControlPortProvider` throws `UnimplementedError` by default and must be overridden in any `ProviderScope` that pumps `AppShellScaffold` — main.dart does this, but the new-conversation test fixture missed it (likely added when P029 wired the provider in but P032 added the test before/without coordinating).

Fix: add a local `_StubHandsFreeControlPort` (parallels the existing `_FakeHandsFreeControlPort` in `session_control_dispatcher_test.dart` but minimal) and register the override in `_baseOverrides`.

```
+import 'package:voice_agent/core/session_control/hands_free_control_port.dart';
+
+      handsFreeControlPortProvider
+          .overrideWithValue(_StubHandsFreeControlPort()),
+
+class _StubHandsFreeControlPort implements HandsFreeControlPort {
+  @override
+  bool get isSuspendedForManualRecording => false;
+  @override
+  Future<void> stopSession() async {}
+}
```

## Verification

```
flutter test test/features/recording/presentation/recording_screen_new_conversation_test.dart
00:00 +7: All tests passed!

make verify
00:16 +864: All tests passed!
```

`make verify` is now green on `main` (864 tests, 0 failures).