### PR TITLE
debug(media-button): instrument AirPods → TTS path for live diagnosis

### DIFF
--- a/ios/Runner/AudioSessionBridge.swift
+++ b/ios/Runner/AudioSessionBridge.swift
@@ -32,14 +32,17 @@ class AudioSessionBridge {
         switch call.method {
         case "setPlayAndRecord":
             do {
+                NSLog("[AudioSessionDbg] setPlayAndRecord requested")
                 try session.setCategory(
                     .playAndRecord,
                     mode: .default,
                     options: [.defaultToSpeaker, .allowBluetooth, .mixWithOthers]
                 )
                 try session.setActive(true)
+                NSLog("[AudioSessionDbg] setPlayAndRecord applied — category=\(session.category.rawValue) options=\(session.categoryOptions.rawValue) active=true")
                 result(nil)
             } catch {
+                NSLog("[AudioSessionDbg] setPlayAndRecord FAILED: \(error.localizedDescription)")
                 result(FlutterError(
                     code: "AUDIO_SESSION_ERROR",
                     message: "Failed to set playAndRecord: \(error.localizedDescription)",
@@ -48,11 +51,13 @@ class AudioSessionBridge {
             }
         case "setAmbient":
             do {
+                NSLog("[AudioSessionDbg] setAmbient requested")
                 try session.setCategory(
                     .ambient,
                     mode: .default,
                     options: [.mixWithOthers]
                 )
+                NSLog("[AudioSessionDbg] setAmbient applied — category=\(session.category.rawValue) options=\(session.categoryOptions.rawValue)")
                 result(nil)
             } catch {
                 result(FlutterError(

--- a/ios/Runner/MediaButtonBridge.swift
+++ b/ios/Runner/MediaButtonBridge.swift
@@ -1,5 +1,11 @@
+import AVFoundation
 import Flutter
 import MediaPlayer
+
+private func logAudioSession(_ tag: String) {
+    let s = AVAudioSession.sharedInstance()
+    NSLog("[MediaButtonDbg] \(tag) category=\(s.category.rawValue) options=\(s.categoryOptions.rawValue) mode=\(s.mode.rawValue) otherAudioPlaying=\(s.isOtherAudioPlaying)")
+}
 
 /// Bridges iOS media remote-command events (e.g. AirPods play/pause)
 /// to Dart via platform channels.
@@ -58,9 +64,14 @@ class MediaButtonBridge: NSObject, FlutterStreamHandler {
     // MARK: - Remote command management
 
     private func activateRemoteCommands() {
+        NSLog("[MediaButtonDbg] activateRemoteCommands called")
+        logAudioSession("activate")
         let center = MPRemoteCommandCenter.shared()
         center.togglePlayPauseCommand.isEnabled = true
         center.togglePlayPauseCommand.addTarget { [weak self] _ in
+            let hasSink = (self?.eventSink != nil)
+            NSLog("[MediaButtonDbg] togglePlayPause TARGET FIRED hasEventSink=\(hasSink)")
+            logAudioSession("targetFired")
             self?.eventSink?("togglePlayPause")
             return .success
         }
@@ -70,9 +81,11 @@ class MediaButtonBridge: NSObject, FlutterStreamHandler {
         MPNowPlayingInfoCenter.default().nowPlayingInfo = [
             MPMediaItemPropertyTitle: "Voice Agent"
         ]
+        NSLog("[MediaButtonDbg] activateRemoteCommands DONE (target registered, nowPlayingInfo set)")
     }
 
     private func deactivateRemoteCommands() {
+        NSLog("[MediaButtonDbg] deactivateRemoteCommands called")
         let center = MPRemoteCommandCenter.shared()
         center.togglePlayPauseCommand.isEnabled = false
         center.togglePlayPauseCommand.removeTarget(nil)
@@ -86,11 +99,13 @@ class MediaButtonBridge: NSObject, FlutterStreamHandler {
         withArguments arguments: Any?,
         eventSink events: @escaping FlutterEventSink
     ) -> FlutterError? {
+        NSLog("[MediaButtonDbg] onListen — eventSink attached")
         eventSink = events
         return nil
     }
 
     func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        NSLog("[MediaButtonDbg] onCancel — eventSink DETACHED")
         eventSink = nil
         return nil
     }

--- a/lib/core/media_button/media_button_service.dart
+++ b/lib/core/media_button/media_button_service.dart
@@ -1,5 +1,6 @@
 import 'dart:developer' as developer;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'package:voice_agent/core/media_button/media_button_port.dart';
@@ -23,22 +24,29 @@ class MediaButtonService implements MediaButtonPort {
 
   @override
   Stream<MediaButtonEvent> get events {
-    return _eventChannel.receiveBroadcastStream().map((dynamic event) {
-      if (event == 'togglePlayPause') {
-        return MediaButtonEvent.togglePlayPause;
-      }
-      developer.log(
-        'Unknown media button event: $event',
-        name: 'MediaButtonService',
-      );
-      return MediaButtonEvent.togglePlayPause;
-    });
+    return _eventChannel
+        .receiveBroadcastStream()
+        .map<MediaButtonEvent?>((dynamic event) {
+          debugPrint('[MediaButtonDbg] raw event from native: $event');
+          if (event == 'togglePlayPause') {
+            return MediaButtonEvent.togglePlayPause;
+          }
+          developer.log(
+            'Unknown media button event: $event',
+            name: 'MediaButtonService',
+          );
+          return null;
+        })
+        .where((e) => e != null)
+        .cast<MediaButtonEvent>();
   }
 
   @override
   Future<void> activate() async {
+    debugPrint('[MediaButtonDbg] Dart→native activate() invoked');
     try {
       await _methodChannel.invokeMethod<void>('activate');
+      debugPrint('[MediaButtonDbg] Dart→native activate() returned');
     } catch (e) {
       developer.log(
         'Failed to activate media button: $e',
@@ -49,6 +57,7 @@ class MediaButtonService implements MediaButtonPort {
 
   @override
   Future<void> deactivate() async {
+    debugPrint('[MediaButtonDbg] Dart→native deactivate() invoked');
     try {
       await _methodChannel.invokeMethod<void>('deactivate');
     } catch (e) {

--- a/lib/core/tts/flutter_tts_service.dart
+++ b/lib/core/tts/flutter_tts_service.dart
@@ -95,10 +95,12 @@ class FlutterTtsService implements TtsService {
   // ── Handler callbacks ───────────────────────────────────────────────────
 
   void _onStart() {
+    debugPrint('[TtsDbg] _onStart speakingWas=${_speaking.value}');
     if (!_speaking.value) _speaking.value = true;
   }
 
   void _onCompletion() {
+    debugPrint('[TtsDbg] _onCompletion activeQueue=${_activeQueue != null} speaking=${_speaking.value}');
     final queue = _activeQueue;
     if (queue == null) {
       // No active queue — single-utterance path or already cleared.
@@ -124,6 +126,7 @@ class FlutterTtsService implements TtsService {
   }
 
   void _onCancel() {
+    debugPrint('[TtsDbg] _onCancel speakingWas=${_speaking.value}');
     final queue = _activeQueue;
     _activeQueue = null;
     if (queue != null && !queue.doneCompleter.isCompleted) {
@@ -133,6 +136,7 @@ class FlutterTtsService implements TtsService {
   }
 
   void _onError(dynamic error) {
+    debugPrint('[TtsDbg] _onError error=$error speakingWas=${_speaking.value}');
     final queue = _activeQueue;
     _activeQueue = null;
     if (queue != null && !queue.doneCompleter.isCompleted) {
@@ -143,12 +147,14 @@ class FlutterTtsService implements TtsService {
 
   @override
   Future<void> stop() async {
+    debugPrint('[TtsDbg] stop() called speaking=${_speaking.value} hasActiveQueue=${_activeQueue != null}');
     // (1) Clear the queue so any racing completion handler sees null.
     final queue = _activeQueue;
     _activeQueue = null;
 
     // (2) Wait for the native-side cancel to complete.
     await _tts.stop();
+    debugPrint('[TtsDbg] stop() native _tts.stop() returned');
 
     // (3) Complete any pending doneCompleter.
     if (queue != null && !queue.doneCompleter.isCompleted) {
@@ -157,6 +163,7 @@ class FlutterTtsService implements TtsService {
 
     // (4) Ensure _speaking is false.
     if (_speaking.value) _speaking.value = false;
+    debugPrint('[TtsDbg] stop() done speaking=${_speaking.value}');
   }
 
   @override

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -46,9 +46,19 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
   }
 
   void _onMediaButtonEvent(MediaButtonEvent event) {
+    final ttsPlaying = ref.read(ttsPlayingProvider);
+    final ttsIsSpeakingDirect = ref.read(ttsServiceProvider).isSpeaking.value;
+    final recStateSnap = ref.read(recordingControllerProvider);
+    final hfStateSnap = ref.read(handsFreeControllerProvider);
+    debugPrint(
+      '[MediaButtonDbg] _onMediaButtonEvent event=$event '
+      'ttsPlayingProvider=$ttsPlaying ttsIsSpeaking.value=$ttsIsSpeakingDirect '
+      'recState=${recStateSnap.runtimeType} hfState=${hfStateSnap.runtimeType}',
+    );
     if (event != MediaButtonEvent.togglePlayPause) return;
 
-    if (ref.read(ttsPlayingProvider)) {
+    if (ttsPlaying) {
+      debugPrint('[MediaButtonDbg] branch=stopTts');
       unawaited(ref.read(ttsServiceProvider).stop());
       return;
     }
@@ -59,23 +69,28 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
     final hfCtrl = ref.read(handsFreeControllerProvider.notifier);
 
     if (recState is RecordingActive) {
+      debugPrint('[MediaButtonDbg] branch=pauseRecording');
       unawaited(recCtrl.pauseRecording());
     } else if (recState is RecordingPaused) {
+      debugPrint('[MediaButtonDbg] branch=resumeRecording');
       unawaited(recCtrl.resumeRecording());
     } else if (hfState is HandsFreeListening ||
         hfState is HandsFreeWithBacklog ||
         hfState is HandsFreeCapturing) {
+      debugPrint('[MediaButtonDbg] branch=hfSuspend');
       unawaited(hfCtrl.toggleUserSuspend().then((_) {
         ref.read(toasterProvider).show('Paused');
         ref.read(hapticServiceProvider).lightImpact();
       }));
     } else if (hfState is HandsFreeSuspendedByUser) {
+      debugPrint('[MediaButtonDbg] branch=hfResume');
       unawaited(hfCtrl.toggleUserSuspend().then((_) {
         ref.read(toasterProvider).show('Resumed');
         ref.read(hapticServiceProvider).lightImpact();
       }));
+    } else {
+      debugPrint('[MediaButtonDbg] branch=noop');
     }
-    // All other states: no-op
   }
 
   @override

--- a/test/core/media_button/media_button_service_test.dart
+++ b/test/core/media_button/media_button_service_test.dart
@@ -120,10 +120,10 @@ void main() {
         ),
       );
 
-      // Unknown events default to togglePlayPause.
+      // Unknown events are dropped (no spurious togglePlayPause).
       final events = await service.events.toList();
 
-      expect(events, [MediaButtonEvent.togglePlayPause]);
+      expect(events, isEmpty);
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockStreamHandler(eventChannel, null);


### PR DESCRIPTION
## Summary

Adds **temporary debug instrumentation** for live diagnosis of the AirPods button → TTS interrupt flow. Logs every hop (iOS remote-command target, audio session category, EventChannel sink, Dart stream, `_onMediaButtonEvent` branches, TTS handlers).

Filter logs by `MediaButtonDbg` / `AudioSessionDbg` / `TtsDbg`.

⚠️ **This branch is being merged to `main` to enable testing multiple bugfix branches against a single instrumented build.** Revert PR follows after live debug concludes.

## Changes

- `ios/Runner/MediaButtonBridge.swift` — `NSLog` at `activate`/`deactivate`, `togglePlayPauseCommand` target fire, `onListen`/`onCancel`. Dumps `AVAudioSession` category/options/`isOtherAudioPlaying` at each hop.
- `ios/Runner/AudioSessionBridge.swift` — `NSLog` on `setPlayAndRecord` / `setAmbient` showing applied category and options.
- `lib/core/media_button/media_button_service.dart` — `debugPrint` at activate/deactivate + raw native event. **Also fixes latent bug**: unknown native events were coerced to `togglePlayPause`; now dropped via `where`+`cast`.
- `lib/features/recording/presentation/recording_screen.dart` — `_onMediaButtonEvent` logs incoming event + `ttsPlayingProvider` vs `ttsService.isSpeaking.value` + `recState`/`hfState` + selected branch.
- `lib/core/tts/flutter_tts_service.dart` — `debugPrint` in `_onStart` / `_onCompletion` / `_onCancel` / `_onError` / `stop()`.
- `test/core/media_button/media_button_service_test.dart` — updated to expect dropped unknown events instead of legacy coerce-to-toggle.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/core/media_button/` — 7/7 pass with new behavior
- [x] Full test suite: 850 pass, 7 fail (pre-existing on `b9c83c5`, all in `recording_screen_new_conversation_test.dart`, **not** from this branch)
- [ ] On-device: run, click AirPods (a) before TTS (b) during TTS (c) after TTS, capture Console.app + `flutter run` logs
- [ ] Decide root-cause path from collected logs; open follow-up fix PR
- [ ] Revert this PR once live debug concludes
