### PR TITLE
036 — Replay last TTS reply (T1-T5)

### DIFF
--- a/lib/core/local_commands/local_command_matcher.dart
+++ b/lib/core/local_commands/local_command_matcher.dart
@@ -1,0 +1,65 @@
+/// Decision returned by [LocalCommandMatcher.match].
+///
+/// `passthrough` — utterance is not a recognised local command; the
+///   transcript should flow to the backend unchanged.
+/// `replayLast` — utterance matches a replay-last whitelist entry; the
+///   caller should re-speak the last buffered reply and skip the backend.
+sealed class LocalCommandDecision {
+  const LocalCommandDecision();
+}
+
+class LocalCommandPassthrough extends LocalCommandDecision {
+  const LocalCommandPassthrough();
+}
+
+class LocalCommandReplayLast extends LocalCommandDecision {
+  const LocalCommandReplayLast();
+}
+
+/// Whole-utterance whitelist matcher for replay-last commands (P036).
+///
+/// Deliberately conservative: the normalized utterance must be **exactly**
+/// equal to one of the whitelist entries. Any extra content words (e.g.
+/// "powtórz, że X", "Powtórz, żeby coś przerwało.") fall through to the
+/// backend. We prefer false negatives (one extra LLM call) over false
+/// positives (silently swallowing a real chat turn).
+class LocalCommandMatcher {
+  const LocalCommandMatcher();
+
+  /// Whitelist — kept lower-case, normalized form. Add entries only after
+  /// production telemetry justifies them.
+  static const Set<String> _replayLastWhitelist = {
+    'powtórz',
+    'powtórz proszę',
+    'powtórz to',
+    'powtórz jeszcze raz',
+    'jeszcze raz',
+    'repeat',
+    'say again',
+    'say it again',
+  };
+
+  /// Returns the decision for [utterance].
+  LocalCommandDecision match(String utterance) {
+    final normalized = _normalize(utterance);
+    if (normalized.isEmpty) return const LocalCommandPassthrough();
+    if (_replayLastWhitelist.contains(normalized)) {
+      return const LocalCommandReplayLast();
+    }
+    return const LocalCommandPassthrough();
+  }
+
+  /// Normalization (proposal 036, "Local-command matcher"):
+  /// 1. lowercase,
+  /// 2. trim leading/trailing whitespace,
+  /// 3. strip trailing `. , ! ? ; :` punctuation runs,
+  /// 4. collapse internal whitespace runs to a single space.
+  static String _normalize(String input) {
+    var s = input.toLowerCase().trim();
+    // Strip a trailing run of punctuation characters.
+    s = s.replaceAll(RegExp(r'[\.,!\?;:]+$'), '').trim();
+    // Collapse internal whitespace runs.
+    s = s.replaceAll(RegExp(r'\s+'), ' ');
+    return s;
+  }
+}

--- a/lib/core/local_commands/local_command_provider.dart
+++ b/lib/core/local_commands/local_command_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/local_commands/local_command_matcher.dart';
+
+/// Singleton [LocalCommandMatcher] (stateless, P036).
+final localCommandMatcherProvider = Provider<LocalCommandMatcher>((ref) {
+  return const LocalCommandMatcher();
+});

--- a/lib/core/session_control/session_id_coordinator.dart
+++ b/lib/core/session_control/session_id_coordinator.dart
@@ -6,6 +6,16 @@
 class SessionIdCoordinator {
   String? _currentConversationId;
 
+  /// Listeners notified after [resetSession] runs. Used by P036's TTS
+  /// reply buffer to clear itself without importing a feature module.
+  final List<void Function()> _resetListeners = [];
+
+  /// Listeners notified when [adoptConversationId] changes the current
+  /// conversation tag (i.e. `newId != currentConversationId`). Used by
+  /// P036's TTS reply buffer to clear when the backend rotates the
+  /// conversation without an explicit `reset_session` signal.
+  final List<void Function(String newId)> _conversationChangeListeners = [];
+
   /// The current conversation ID, or null when a fresh conversation
   /// will be opened on the next send.
   String? get currentConversationId => _currentConversationId;
@@ -14,11 +24,39 @@ class SessionIdCoordinator {
   /// allows the backend to open a fresh conversation.
   Future<void> resetSession() async {
     _currentConversationId = null;
+    for (final listener in List.of(_resetListeners)) {
+      listener();
+    }
   }
 
   /// Adopts a conversation ID returned by the backend after a
   /// successful reply so subsequent sends keep the same local tag.
+  ///
+  /// If [id] differs from the previously-held ID, registered
+  /// conversation-change listeners are fired (P036).
   void adoptConversationId(String id) {
+    final changed = id != _currentConversationId;
     _currentConversationId = id;
+    if (changed) {
+      for (final listener in List.of(_conversationChangeListeners)) {
+        listener(id);
+      }
+    }
+  }
+
+  /// Registers a listener for [resetSession]. Returns a disposer that
+  /// removes the listener when called.
+  void Function() addResetListener(void Function() listener) {
+    _resetListeners.add(listener);
+    return () => _resetListeners.remove(listener);
+  }
+
+  /// Registers a listener fired whenever [adoptConversationId] changes
+  /// the current ID. Returns a disposer that removes the listener.
+  void Function() addConversationChangeListener(
+    void Function(String newId) listener,
+  ) {
+    _conversationChangeListeners.add(listener);
+    return () => _conversationChangeListeners.remove(listener);
   }
 }

--- a/lib/core/tts/buffering_tts_service.dart
+++ b/lib/core/tts/buffering_tts_service.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/foundation.dart';
+import 'package:voice_agent/core/tts/tts_reply_buffer.dart';
+import 'package:voice_agent/core/tts/tts_service.dart';
+
+/// Decorator over [TtsService] that records the `(text, languageCode)` of
+/// every successful `speak()` call into a [TtsReplyBuffer] (proposal 036).
+///
+/// Only successful (non-throwing) `speak` calls write to the buffer. Calls
+/// to `stop()` and `dispose()` do not. By design only the agent-reply
+/// `TtsService` instance is wrapped — error/feedback speak callsites must
+/// not feed the replay buffer.
+class BufferingTtsService implements TtsService {
+  BufferingTtsService({
+    required TtsService inner,
+    required TtsReplyBuffer buffer,
+  })  : _inner = inner,
+        _buffer = buffer;
+
+  final TtsService _inner;
+  final TtsReplyBuffer _buffer;
+
+  @override
+  ValueListenable<bool> get isSpeaking => _inner.isSpeaking;
+
+  @override
+  Future<void> speak(String text, {String? languageCode}) async {
+    await _inner.speak(text, languageCode: languageCode);
+    // Only reached if the inner call did not throw.
+    _buffer.record(text, languageCode: languageCode);
+  }
+
+  @override
+  Future<void> stop() => _inner.stop();
+
+  @override
+  void dispose() => _inner.dispose();
+}

--- a/lib/core/tts/tts_provider.dart
+++ b/lib/core/tts/tts_provider.dart
@@ -1,11 +1,32 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/session_control/session_control_provider.dart';
 import 'package:voice_agent/core/tts/flutter_tts_service.dart';
+import 'package:voice_agent/core/tts/tts_reply_buffer.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 
 final ttsServiceProvider = Provider<TtsService>((ref) {
   final tts = FlutterTtsService();
   ref.onDispose(tts.dispose);
   return tts;
+});
+
+/// P036: holds the most recent successful agent reply for replay-last.
+/// Cleared on session reset and on conversation_id rotation.
+final ttsReplyBufferProvider = Provider<TtsReplyBuffer>((ref) {
+  final buffer = InMemoryTtsReplyBuffer();
+
+  // Clear on session reset (P029 reset_session signal path).
+  final coordinator = ref.watch(sessionIdCoordinatorProvider);
+  final disposeReset = coordinator.addResetListener(buffer.clear);
+  // Clear when the backend rotates conversation_id without an explicit
+  // reset_session signal.
+  final disposeChange = coordinator.addConversationChangeListener(
+    (_) => buffer.clear(),
+  );
+  ref.onDispose(disposeReset);
+  ref.onDispose(disposeChange);
+
+  return buffer;
 });
 
 /// Whether TTS is currently playing audio. Used by hands-free controller

--- a/lib/core/tts/tts_reply_buffer.dart
+++ b/lib/core/tts/tts_reply_buffer.dart
@@ -1,0 +1,68 @@
+/// Holds the most recently spoken successful agent reply for client-side
+/// replay (proposal 036).
+///
+/// The buffer is intentionally tiny: at v1 the buffer holds **one** entry —
+/// the last successful reply, with the language code that was passed to TTS.
+/// On replay we re-feed `(text, languageCode)` to the same `TtsService` that
+/// originally spoke it, so the platform engine produces equivalent speech
+/// without an LLM round-trip.
+///
+/// The buffer lives in `core/` (it has no platform deps) and is wired in
+/// `core/tts/tts_provider.dart`. Only the agent-reply path
+/// (`SyncWorker._handleReply`) writes to it via `BufferingTtsService`;
+/// error/feedback `speak` calls deliberately bypass it.
+class TtsReplyEntry {
+  const TtsReplyEntry({required this.text, this.languageCode});
+
+  final String text;
+  final String? languageCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TtsReplyEntry &&
+          other.text == text &&
+          other.languageCode == languageCode;
+
+  @override
+  int get hashCode => Object.hash(text, languageCode);
+
+  @override
+  String toString() =>
+      'TtsReplyEntry(text: $text, languageCode: $languageCode)';
+}
+
+/// Port for the TTS replay buffer. Implementations are responsible for
+/// storage; the decorator (`BufferingTtsService`) and the consumer
+/// (`SyncWorker`) only depend on this interface.
+abstract class TtsReplyBuffer {
+  /// Records `(text, languageCode)` as the most recent successful reply.
+  void record(String text, {String? languageCode});
+
+  /// Returns the most recent entry, or `null` if the buffer is empty.
+  TtsReplyEntry? last();
+
+  /// Empties the buffer.
+  void clear();
+}
+
+/// Default in-memory implementation. Holds the single most recent entry.
+///
+/// Per proposal 036, v1 is `n = 1` — at most one entry. LRU semantics are
+/// trivially satisfied: `record()` always replaces the previous entry.
+class InMemoryTtsReplyBuffer implements TtsReplyBuffer {
+  TtsReplyEntry? _entry;
+
+  @override
+  void record(String text, {String? languageCode}) {
+    _entry = TtsReplyEntry(text: text, languageCode: languageCode);
+  }
+
+  @override
+  TtsReplyEntry? last() => _entry;
+
+  @override
+  void clear() {
+    _entry = null;
+  }
+}

--- a/lib/features/api_sync/sync_provider.dart
+++ b/lib/features/api_sync/sync_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
+import 'package:voice_agent/core/local_commands/local_command_provider.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
 import 'package:voice_agent/core/providers/agent_reply_provider.dart';
 import 'package:voice_agent/core/providers/api_client_provider.dart';
@@ -37,6 +38,10 @@ final syncWorkerProvider = Provider<SyncWorker>((ref) {
         ref.read(appForegroundedProvider) || ref.read(sessionActiveProvider),
     sessionControlDispatcher: ref.watch(sessionControlDispatcherProvider),
     sessionIdCoordinator: ref.watch(sessionIdCoordinatorProvider),
+    localCommandMatcher: ref.watch(localCommandMatcherProvider),
+    ttsReplyBuffer: ref.watch(ttsReplyBufferProvider),
+    toaster: ref.watch(toasterProvider),
+    hapticService: ref.watch(hapticServiceProvider),
     onAgentReply: (reply) {
       ref.read(latestAgentReplyProvider.notifier).state = reply;
     },

--- a/lib/features/api_sync/sync_worker.dart
+++ b/lib/features/api_sync/sync_worker.dart
@@ -2,12 +2,16 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:voice_agent/core/audio/audio_feedback_service.dart';
+import 'package:voice_agent/core/local_commands/local_command_matcher.dart';
 import 'package:voice_agent/core/network/api_client.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/session_control/haptic_service.dart';
 import 'package:voice_agent/core/session_control/session_control_dispatcher.dart';
 import 'package:voice_agent/core/session_control/session_control_signal.dart';
 import 'package:voice_agent/core/session_control/session_id_coordinator.dart';
+import 'package:voice_agent/core/session_control/toaster.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
+import 'package:voice_agent/core/tts/tts_reply_buffer.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/api_sync/api_config.dart';
 
@@ -25,6 +29,10 @@ class SyncWorker {
     required this.shouldProcessQueue,
     required this.sessionControlDispatcher,
     required this.sessionIdCoordinator,
+    required this.localCommandMatcher,
+    required this.ttsReplyBuffer,
+    required this.toaster,
+    required this.hapticService,
     this.onAgentReply,
   });
 
@@ -42,6 +50,19 @@ class SyncWorker {
 
   final SessionControlDispatcher sessionControlDispatcher;
   final SessionIdCoordinator sessionIdCoordinator;
+
+  /// P036: local-command matcher run before backend dispatch.
+  final LocalCommandMatcher localCommandMatcher;
+
+  /// P036: holds the most recent successful agent reply for replay.
+  final TtsReplyBuffer ttsReplyBuffer;
+
+  /// P036: shows the "Powtarzam ostatnią odpowiedź" /
+  /// "Brak wcześniejszej odpowiedzi" feedback toasts.
+  final Toaster toaster;
+
+  /// P036: light haptic tick on every replay decision.
+  final HapticService hapticService;
 
   final void Function(String reply)? onAgentReply;
 
@@ -153,6 +174,23 @@ class SyncWorker {
         return;
       }
 
+      // P036: pre-flight local-command match. A whitelisted replay-last
+      // utterance with a non-empty buffer skips the backend round-trip and
+      // re-speaks the previous reply locally. Any other case (passthrough or
+      // empty buffer) falls through to the existing backend path.
+      final decision = localCommandMatcher.match(transcript.text);
+      if (decision is LocalCommandReplayLast) {
+        final buffered = ttsReplyBuffer.last();
+        if (buffered != null) {
+          await _replayLast(item.id, buffered);
+          return;
+        }
+        // Empty buffer: surface feedback then fall through to the backend
+        // so the user still gets *some* response.
+        toaster.show('Brak wcześniejszej odpowiedzi');
+        unawaited(hapticService.lightImpact());
+      }
+
       final result = await apiClient.post(
         transcript,
         url: url,
@@ -191,6 +229,32 @@ class SyncWorker {
     }
   }
 
+  /// P036: re-speak the buffered reply and treat the queue item as locally
+  /// consumed (same effect as `markSent` for queue purposes). No backend
+  /// call, no LLM, no `onAgentReply` callback — the reply has already been
+  /// surfaced once, this is a re-speak.
+  Future<void> _replayLast(String queueItemId, TtsReplyEntry buffered) async {
+    toaster.show('Powtarzam ostatnią odpowiedź');
+    unawaited(hapticService.lightImpact());
+
+    // Mirror the stop→speak ordering used in `_handleReply`.
+    if (getTtsEnabled()) {
+      try {
+        await ttsService.stop();
+        await ttsService.speak(
+          buffered.text,
+          languageCode: buffered.languageCode,
+        );
+      } catch (_) {
+        // Best-effort — replay must not poison the queue.
+      }
+    }
+
+    // Treat the local utterance as consumed. Do not POST, do not mark
+    // failed/pending — drop the queue row.
+    await storageService.markSent(queueItemId);
+  }
+
   Future<void> _speakError(String message) async {
     if (!getTtsEnabled()) return;
     try {
@@ -220,6 +284,10 @@ class SyncWorker {
       if (getTtsEnabled()) {
         await ttsService.stop();
         await ttsService.speak(message, languageCode: language);
+        // P036: record successful agent-reply speak into the replay
+        // buffer. Only this code path feeds the buffer — `_speakError`
+        // and any other future speak callsite must NOT.
+        ttsReplyBuffer.record(message, languageCode: language);
       }
       onAgentReply?.call(message);
 

--- a/test/core/local_commands/local_command_matcher_test.dart
+++ b/test/core/local_commands/local_command_matcher_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/local_commands/local_command_matcher.dart';
+
+void main() {
+  const matcher = LocalCommandMatcher();
+
+  group('LocalCommandMatcher — replayLast whitelist', () {
+    const whitelist = [
+      'powtórz',
+      'powtórz proszę',
+      'powtórz to',
+      'powtórz jeszcze raz',
+      'jeszcze raz',
+      'repeat',
+      'say again',
+      'say it again',
+    ];
+
+    for (final entry in whitelist) {
+      test('exact "$entry" → replayLast', () {
+        expect(matcher.match(entry), isA<LocalCommandReplayLast>());
+      });
+
+      test('uppercased "$entry" → replayLast', () {
+        expect(
+          matcher.match(entry.toUpperCase()),
+          isA<LocalCommandReplayLast>(),
+        );
+      });
+
+      test('trailing punctuation "$entry." → replayLast', () {
+        expect(matcher.match('$entry.'), isA<LocalCommandReplayLast>());
+      });
+
+      test('surrounding whitespace " $entry " → replayLast', () {
+        expect(matcher.match('  $entry  '), isA<LocalCommandReplayLast>());
+      });
+    }
+
+    test('mixed punctuation "Powtórz!?" → replayLast', () {
+      expect(matcher.match('Powtórz!?'), isA<LocalCommandReplayLast>());
+    });
+
+    test('internal whitespace collapse "say  again" → replayLast', () {
+      expect(matcher.match('say  again'), isA<LocalCommandReplayLast>());
+    });
+  });
+
+  group('LocalCommandMatcher — passthrough', () {
+    // The originating production phrase that must NOT trigger replay.
+    test(
+        '"Powtórz, żeby coś przerwało." (origin [42]) → passthrough',
+        () {
+      expect(
+        matcher.match('Powtórz, żeby coś przerwało.'),
+        isA<LocalCommandPassthrough>(),
+      );
+    });
+
+    test('"Powtórz ostatnią wygenerowaną wiadomość." → passthrough', () {
+      expect(
+        matcher.match('Powtórz ostatnią wygenerowaną wiadomość.'),
+        isA<LocalCommandPassthrough>(),
+      );
+    });
+
+    test('"powtórz, że X" → passthrough', () {
+      expect(
+        matcher.match('powtórz, że X'),
+        isA<LocalCommandPassthrough>(),
+      );
+    });
+
+    test('"Repeat please tell me more" → passthrough', () {
+      expect(
+        matcher.match('Repeat please tell me more'),
+        isA<LocalCommandPassthrough>(),
+      );
+    });
+
+    test('empty string → passthrough', () {
+      expect(matcher.match(''), isA<LocalCommandPassthrough>());
+    });
+
+    test('whitespace-only "   " → passthrough', () {
+      expect(matcher.match('   '), isA<LocalCommandPassthrough>());
+    });
+
+    test('pure punctuation "..." → passthrough', () {
+      expect(matcher.match('...'), isA<LocalCommandPassthrough>());
+    });
+
+    test('substring inside larger sentence → passthrough', () {
+      expect(
+        matcher.match('Please repeat the answer'),
+        isA<LocalCommandPassthrough>(),
+      );
+    });
+
+    test('replayLast prefix with more words → passthrough', () {
+      expect(
+        matcher.match('powtórz to wszystko'),
+        isA<LocalCommandPassthrough>(),
+      );
+    });
+  });
+}

--- a/test/core/tts/buffering_tts_service_test.dart
+++ b/test/core/tts/buffering_tts_service_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/tts/buffering_tts_service.dart';
+import 'package:voice_agent/core/tts/tts_reply_buffer.dart';
+import 'package:voice_agent/core/tts/tts_service.dart';
+
+class _SpyTts implements TtsService {
+  final List<String> log = [];
+  bool throwOnSpeak = false;
+  final ValueNotifier<bool> _speaking = ValueNotifier(false);
+
+  @override
+  ValueListenable<bool> get isSpeaking => _speaking;
+
+  @override
+  Future<void> speak(String text, {String? languageCode}) async {
+    log.add('speak:$text:$languageCode');
+    if (throwOnSpeak) throw StateError('boom');
+  }
+
+  @override
+  Future<void> stop() async {
+    log.add('stop');
+  }
+
+  @override
+  void dispose() {
+    log.add('dispose');
+  }
+}
+
+void main() {
+  group('BufferingTtsService', () {
+    late _SpyTts inner;
+    late InMemoryTtsReplyBuffer buffer;
+    late BufferingTtsService service;
+
+    setUp(() {
+      inner = _SpyTts();
+      buffer = InMemoryTtsReplyBuffer();
+      service = BufferingTtsService(inner: inner, buffer: buffer);
+    });
+
+    test('successful speak forwards to inner and records in buffer', () async {
+      await service.speak('hello', languageCode: 'en');
+
+      expect(inner.log, ['speak:hello:en']);
+      expect(
+        buffer.last(),
+        const TtsReplyEntry(text: 'hello', languageCode: 'en'),
+      );
+    });
+
+    test('speak without languageCode records null languageCode', () async {
+      await service.speak('plain');
+      expect(buffer.last(), const TtsReplyEntry(text: 'plain'));
+    });
+
+    test('thrown speak does NOT record in buffer', () async {
+      inner.throwOnSpeak = true;
+      await expectLater(
+        () => service.speak('boom', languageCode: 'en'),
+        throwsStateError,
+      );
+      expect(buffer.last(), isNull);
+    });
+
+    test('stop() does not record', () async {
+      await service.stop();
+      expect(inner.log, ['stop']);
+      expect(buffer.last(), isNull);
+    });
+
+    test('dispose() does not record', () {
+      service.dispose();
+      expect(inner.log, ['dispose']);
+      expect(buffer.last(), isNull);
+    });
+
+    test('isSpeaking is delegated to inner', () {
+      expect(service.isSpeaking, same(inner.isSpeaking));
+    });
+
+    test('successive successful speaks overwrite (n=1 LRU)', () async {
+      await service.speak('first', languageCode: 'pl');
+      await service.speak('second', languageCode: 'en');
+      expect(
+        buffer.last(),
+        const TtsReplyEntry(text: 'second', languageCode: 'en'),
+      );
+    });
+  });
+}

--- a/test/core/tts/tts_reply_buffer_test.dart
+++ b/test/core/tts/tts_reply_buffer_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/tts/tts_reply_buffer.dart';
+
+void main() {
+  group('InMemoryTtsReplyBuffer', () {
+    test('last() on empty buffer returns null', () {
+      final buffer = InMemoryTtsReplyBuffer();
+      expect(buffer.last(), isNull);
+    });
+
+    test('record() then last() returns the recorded entry', () {
+      final buffer = InMemoryTtsReplyBuffer();
+      buffer.record('hello', languageCode: 'en');
+      expect(
+        buffer.last(),
+        const TtsReplyEntry(text: 'hello', languageCode: 'en'),
+      );
+    });
+
+    test('record() with no languageCode is preserved as null', () {
+      final buffer = InMemoryTtsReplyBuffer();
+      buffer.record('hi');
+      expect(buffer.last(), const TtsReplyEntry(text: 'hi'));
+    });
+
+    test('successive records overwrite (n=1 LRU)', () {
+      final buffer = InMemoryTtsReplyBuffer();
+      buffer.record('first', languageCode: 'pl');
+      buffer.record('second', languageCode: 'en');
+      expect(
+        buffer.last(),
+        const TtsReplyEntry(text: 'second', languageCode: 'en'),
+      );
+    });
+
+    test('clear() empties the buffer', () {
+      final buffer = InMemoryTtsReplyBuffer();
+      buffer.record('hello', languageCode: 'en');
+      buffer.clear();
+      expect(buffer.last(), isNull);
+    });
+
+    test('clear() on empty buffer is a no-op', () {
+      final buffer = InMemoryTtsReplyBuffer();
+      buffer.clear();
+      expect(buffer.last(), isNull);
+    });
+  });
+
+  group('TtsReplyEntry equality', () {
+    test('equal when text and languageCode match', () {
+      expect(
+        const TtsReplyEntry(text: 'a', languageCode: 'en'),
+        const TtsReplyEntry(text: 'a', languageCode: 'en'),
+      );
+    });
+
+    test('different text → not equal', () {
+      expect(
+        const TtsReplyEntry(text: 'a', languageCode: 'en'),
+        isNot(const TtsReplyEntry(text: 'b', languageCode: 'en')),
+      );
+    });
+
+    test('different languageCode → not equal', () {
+      expect(
+        const TtsReplyEntry(text: 'a', languageCode: 'en'),
+        isNot(const TtsReplyEntry(text: 'a', languageCode: 'pl')),
+      );
+    });
+  });
+}

--- a/test/features/api_sync/sync_worker_test.dart
+++ b/test/features/api_sync/sync_worker_test.dart
@@ -7,6 +7,7 @@ import 'package:voice_agent/core/models/sync_queue_item.dart';
 import 'package:voice_agent/core/models/sync_status.dart';
 import 'package:voice_agent/core/models/transcript.dart';
 import 'package:voice_agent/core/models/transcript_with_status.dart';
+import 'package:voice_agent/core/local_commands/local_command_matcher.dart';
 import 'package:voice_agent/core/network/api_client.dart';
 import 'package:voice_agent/core/audio/audio_feedback_service.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
@@ -17,6 +18,7 @@ import 'package:voice_agent/core/session_control/session_control_signal.dart';
 import 'package:voice_agent/core/session_control/session_id_coordinator.dart';
 import 'package:voice_agent/core/session_control/toaster.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
+import 'package:voice_agent/core/tts/tts_reply_buffer.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/api_sync/api_config.dart';
 import 'package:voice_agent/features/api_sync/sync_worker.dart';
@@ -276,6 +278,10 @@ void main() {
   late bool ttsEnabled;
   late _RecordingDispatcher dispatcher;
   late SessionIdCoordinator sessionIdCoordinator;
+  late LocalCommandMatcher localCommandMatcher;
+  late InMemoryTtsReplyBuffer ttsReplyBuffer;
+  late _FakeToaster toaster;
+  late _FakeHapticService hapticService;
   late SyncWorker worker;
 
   final transcript = Transcript(
@@ -294,6 +300,10 @@ void main() {
     ttsEnabled = true;
     dispatcher = _RecordingDispatcher();
     sessionIdCoordinator = SessionIdCoordinator();
+    localCommandMatcher = const LocalCommandMatcher();
+    ttsReplyBuffer = InMemoryTtsReplyBuffer();
+    toaster = _FakeToaster();
+    hapticService = _FakeHapticService();
     worker = SyncWorker(
       storageService: storage,
       apiClient: apiClient,
@@ -305,6 +315,10 @@ void main() {
       shouldProcessQueue: () => true,
       sessionControlDispatcher: dispatcher,
       sessionIdCoordinator: sessionIdCoordinator,
+      localCommandMatcher: localCommandMatcher,
+      ttsReplyBuffer: ttsReplyBuffer,
+      toaster: toaster,
+      hapticService: hapticService,
     );
   });
 
@@ -394,6 +408,10 @@ void main() {
         shouldProcessQueue: () => true,
         sessionControlDispatcher: dispatcher,
         sessionIdCoordinator: sessionIdCoordinator,
+      localCommandMatcher: localCommandMatcher,
+      ttsReplyBuffer: ttsReplyBuffer,
+      toaster: toaster,
+      hapticService: hapticService,
       );
 
       await storage.saveTranscript(transcript);
@@ -559,6 +577,10 @@ void main() {
         shouldProcessQueue: () => true,
         sessionControlDispatcher: dispatcher,
         sessionIdCoordinator: sessionIdCoordinator,
+      localCommandMatcher: localCommandMatcher,
+      ttsReplyBuffer: ttsReplyBuffer,
+      toaster: toaster,
+      hapticService: hapticService,
         onAgentReply: (reply) => receivedReply = reply,
       );
 
@@ -587,6 +609,10 @@ void main() {
         shouldProcessQueue: () => true,
         sessionControlDispatcher: dispatcher,
         sessionIdCoordinator: sessionIdCoordinator,
+      localCommandMatcher: localCommandMatcher,
+      ttsReplyBuffer: ttsReplyBuffer,
+      toaster: toaster,
+      hapticService: hapticService,
         onAgentReply: (reply) => receivedReply = reply,
       );
 
@@ -615,6 +641,10 @@ void main() {
         shouldProcessQueue: () => true,
         sessionControlDispatcher: dispatcher,
         sessionIdCoordinator: sessionIdCoordinator,
+      localCommandMatcher: localCommandMatcher,
+      ttsReplyBuffer: ttsReplyBuffer,
+      toaster: toaster,
+      hapticService: hapticService,
         onAgentReply: (reply) => receivedReply = reply,
       );
 
@@ -642,6 +672,10 @@ void main() {
         shouldProcessQueue: () => true,
         sessionControlDispatcher: dispatcher,
         sessionIdCoordinator: sessionIdCoordinator,
+      localCommandMatcher: localCommandMatcher,
+      ttsReplyBuffer: ttsReplyBuffer,
+      toaster: toaster,
+      hapticService: hapticService,
         onAgentReply: (reply) => receivedReply = reply,
       );
 
@@ -792,6 +826,10 @@ void main() {
         shouldProcessQueue: predicate,
         sessionControlDispatcher: dispatcher,
         sessionIdCoordinator: sessionIdCoordinator,
+      localCommandMatcher: localCommandMatcher,
+      ttsReplyBuffer: ttsReplyBuffer,
+      toaster: toaster,
+      hapticService: hapticService,
       );
     }
 
@@ -866,6 +904,10 @@ void main() {
         shouldProcessQueue: () => canProcess,
         sessionControlDispatcher: dispatcher,
         sessionIdCoordinator: sessionIdCoordinator,
+      localCommandMatcher: localCommandMatcher,
+      ttsReplyBuffer: ttsReplyBuffer,
+      toaster: toaster,
+      hapticService: hapticService,
       );
 
       await storage.saveTranscript(transcript);
@@ -973,6 +1015,10 @@ void main() {
         shouldProcessQueue: () => true,
         sessionControlDispatcher: dispatcher,
         sessionIdCoordinator: sessionIdCoordinator,
+      localCommandMatcher: localCommandMatcher,
+      ttsReplyBuffer: ttsReplyBuffer,
+      toaster: toaster,
+      hapticService: hapticService,
         onAgentReply: (reply) => capturedReply = reply,
       );
 
@@ -1121,6 +1167,10 @@ void main() {
         shouldProcessQueue: () => true,
         sessionControlDispatcher: orderDispatcher,
         sessionIdCoordinator: sessionIdCoordinator,
+      localCommandMatcher: localCommandMatcher,
+      ttsReplyBuffer: ttsReplyBuffer,
+      toaster: toaster,
+      hapticService: hapticService,
       );
 
       await storage.saveTranscript(transcript);
@@ -1138,4 +1188,368 @@ void main() {
       expect(orderDispatcher.dispatched, hasLength(1));
     });
   });
+
+  group('P036 replay-last (LocalCommandMatcher + TtsReplyBuffer)', () {
+    Future<void> seedReplyAndDrain() async {
+      // Seed: a normal agent reply that primes the buffer.
+      final seedTranscript = Transcript(
+        id: 'tx-seed',
+        text: 'What is the weather?',
+        language: 'en',
+        deviceId: 'dev',
+        createdAt: 500,
+      );
+      await storage.saveTranscript(seedTranscript);
+      await storage.enqueue('tx-seed');
+      apiClient.nextBody = '{"message":"It is sunny","language":"en"}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 100));
+      worker.stop();
+
+      // Reset apiClient body and tts log between drains.
+      apiClient.nextBody = null;
+      apiClient.nextResult = const ApiSuccess();
+    }
+
+    test(
+      'whitelisted utterance + non-empty buffer → no apiClient.post, '
+      'tts.stop then tts.speak with buffered (text, languageCode), '
+      'queue item dropped, toast + haptic',
+      () async {
+        // Pre-populate buffer directly (simulates a previous successful reply).
+        ttsReplyBuffer.record('It is sunny', languageCode: 'en');
+
+        // Track post-calls via a counting fake.
+        final replayApi = _CountingApiClient();
+        worker = SyncWorker(
+          storageService: storage,
+          apiClient: replayApi,
+          apiConfig:
+              const ApiConfig(url: 'https://example.com/api', token: 'tok'),
+          connectivityService: connectivity,
+          ttsService: tts,
+          getTtsEnabled: () => ttsEnabled,
+          audioFeedbackService: _StubAudioFeedbackService(),
+          shouldProcessQueue: () => true,
+          sessionControlDispatcher: dispatcher,
+          sessionIdCoordinator: sessionIdCoordinator,
+          localCommandMatcher: localCommandMatcher,
+          ttsReplyBuffer: ttsReplyBuffer,
+          toaster: toaster,
+          hapticService: hapticService,
+        );
+
+        // Enqueue the user replay command.
+        final replayTranscript = Transcript(
+          id: 'tx-replay',
+          text: 'powtórz',
+          language: 'pl',
+          deviceId: 'dev',
+          createdAt: 1000,
+        );
+        await storage.saveTranscript(replayTranscript);
+        await storage.enqueue('tx-replay');
+
+        worker.start();
+        await Future.delayed(const Duration(milliseconds: 100));
+        worker.stop();
+
+        // No backend call.
+        expect(replayApi.postCalls, 0);
+        // TTS replay produced stop then speak with buffered values.
+        expect(tts.log, contains('stop'));
+        expect(tts.log, contains('speak:It is sunny:en'));
+        // Queue item dropped (treated as consumed via markSent).
+        expect(storage.queueItems.where((i) => i.id == 'q-0'), isEmpty);
+        // Toast + haptic.
+        expect(toaster.messages, contains('Powtarzam ostatnią odpowiedź'));
+        expect(hapticService.calls, greaterThanOrEqualTo(1));
+      },
+    );
+
+    test(
+      'whitelisted utterance + empty buffer → toast shown, falls through to '
+      'apiClient.post (backend round-trip preserved)',
+      () async {
+        expect(ttsReplyBuffer.last(), isNull);
+
+        final replayApi = _CountingApiClient();
+        replayApi.nextBody = '{"message":"ok","language":"en"}';
+        worker = SyncWorker(
+          storageService: storage,
+          apiClient: replayApi,
+          apiConfig:
+              const ApiConfig(url: 'https://example.com/api', token: 'tok'),
+          connectivityService: connectivity,
+          ttsService: tts,
+          getTtsEnabled: () => ttsEnabled,
+          audioFeedbackService: _StubAudioFeedbackService(),
+          shouldProcessQueue: () => true,
+          sessionControlDispatcher: dispatcher,
+          sessionIdCoordinator: sessionIdCoordinator,
+          localCommandMatcher: localCommandMatcher,
+          ttsReplyBuffer: ttsReplyBuffer,
+          toaster: toaster,
+          hapticService: hapticService,
+        );
+
+        final replayTranscript = Transcript(
+          id: 'tx-empty-replay',
+          text: 'powtórz',
+          language: 'pl',
+          deviceId: 'dev',
+          createdAt: 1000,
+        );
+        await storage.saveTranscript(replayTranscript);
+        await storage.enqueue('tx-empty-replay');
+
+        worker.start();
+        await Future.delayed(const Duration(milliseconds: 100));
+        worker.stop();
+
+        expect(toaster.messages, contains('Brak wcześniejszej odpowiedzi'));
+        // Backend WAS called (passthrough on empty buffer).
+        expect(replayApi.postCalls, 1);
+      },
+    );
+
+    test(
+      'non-whitelisted utterance → matcher passes through, _handleReply runs '
+      'unchanged and feeds the buffer with the new reply',
+      () async {
+        await seedReplyAndDrain();
+        // After seed drain, buffer should hold the seed reply.
+        expect(
+          ttsReplyBuffer.last(),
+          const TtsReplyEntry(text: 'It is sunny', languageCode: 'en'),
+        );
+      },
+    );
+
+    test(
+      '"Powtórz, żeby coś przerwało." (origin phrase) does NOT trigger replay '
+      '— full backend round-trip',
+      () async {
+        ttsReplyBuffer.record('previous reply', languageCode: 'pl');
+        final replayApi = _CountingApiClient();
+        replayApi.nextBody = '{"message":"backend","language":"pl"}';
+        worker = SyncWorker(
+          storageService: storage,
+          apiClient: replayApi,
+          apiConfig:
+              const ApiConfig(url: 'https://example.com/api', token: 'tok'),
+          connectivityService: connectivity,
+          ttsService: tts,
+          getTtsEnabled: () => ttsEnabled,
+          audioFeedbackService: _StubAudioFeedbackService(),
+          shouldProcessQueue: () => true,
+          sessionControlDispatcher: dispatcher,
+          sessionIdCoordinator: sessionIdCoordinator,
+          localCommandMatcher: localCommandMatcher,
+          ttsReplyBuffer: ttsReplyBuffer,
+          toaster: toaster,
+          hapticService: hapticService,
+        );
+
+        final originTranscript = Transcript(
+          id: 'tx-origin',
+          text: 'Powtórz, żeby coś przerwało.',
+          language: 'pl',
+          deviceId: 'dev',
+          createdAt: 1000,
+        );
+        await storage.saveTranscript(originTranscript);
+        await storage.enqueue('tx-origin');
+
+        worker.start();
+        await Future.delayed(const Duration(milliseconds: 100));
+        worker.stop();
+
+        // Backend WAS called — origin phrase must not trigger local replay.
+        expect(replayApi.postCalls, 1);
+        // No replay toast.
+        expect(
+          toaster.messages,
+          isNot(contains('Powtarzam ostatnią odpowiedź')),
+        );
+      },
+    );
+  });
+
+  group('P036 _speakError does NOT feed buffer', () {
+    test(
+      'permanent failure speaks error but buffer remains empty',
+      () async {
+        await storage.saveTranscript(transcript);
+        await storage.enqueue('tx-1');
+        apiClient.nextResult = const ApiPermanentFailure(
+          statusCode: 400,
+          message: 'Bad request',
+        );
+
+        expect(ttsReplyBuffer.last(), isNull);
+
+        worker.start();
+        await Future.delayed(const Duration(milliseconds: 100));
+        worker.stop();
+
+        // _speakError ran (TTS fired with the error message).
+        expect(
+          tts.log.any((e) => e.startsWith('speak:Bad request:')),
+          isTrue,
+        );
+        // CRITICAL: buffer must NOT be populated by error speak.
+        expect(ttsReplyBuffer.last(), isNull);
+      },
+    );
+
+    test(
+      'transient failure speaks error but buffer remains empty',
+      () async {
+        await storage.saveTranscript(transcript);
+        await storage.enqueue('tx-1');
+        apiClient.nextResult =
+            const ApiTransientFailure(reason: 'Connection timeout');
+
+        worker.start();
+        await Future.delayed(const Duration(milliseconds: 100));
+        worker.stop();
+
+        expect(
+          tts.log.any((e) => e.startsWith('speak:Connection timeout:')),
+          isTrue,
+        );
+        expect(ttsReplyBuffer.last(), isNull);
+      },
+    );
+
+    test(
+      'after a successful reply primes the buffer, a subsequent error speak '
+      'does NOT overwrite the buffer',
+      () async {
+        // Prime the buffer via an actual successful reply path.
+        ttsReplyBuffer.record('first reply', languageCode: 'en');
+        await storage.saveTranscript(transcript);
+        await storage.enqueue('tx-1');
+        apiClient.nextResult =
+            const ApiTransientFailure(reason: 'oops');
+
+        worker.start();
+        await Future.delayed(const Duration(milliseconds: 100));
+        worker.stop();
+
+        // Buffer untouched by error path.
+        expect(
+          ttsReplyBuffer.last(),
+          const TtsReplyEntry(text: 'first reply', languageCode: 'en'),
+        );
+      },
+    );
+  });
+
+  group('P036 buffer-clear hooks (SessionIdCoordinator)', () {
+    test('resetSession() invokes registered listener', () async {
+      final coord = SessionIdCoordinator();
+      var calls = 0;
+      coord.addResetListener(() => calls++);
+      await coord.resetSession();
+      expect(calls, 1);
+    });
+
+    test('addResetListener disposer removes the listener', () async {
+      final coord = SessionIdCoordinator();
+      var calls = 0;
+      final dispose = coord.addResetListener(() => calls++);
+      dispose();
+      await coord.resetSession();
+      expect(calls, 0);
+    });
+
+    test(
+      'adoptConversationId(differentId) fires conversation-change listener',
+      () {
+        final coord = SessionIdCoordinator();
+        coord.adoptConversationId('conv-1');
+        var lastNotified = '';
+        coord.addConversationChangeListener((id) => lastNotified = id);
+        coord.adoptConversationId('conv-2');
+        expect(lastNotified, 'conv-2');
+      },
+    );
+
+    test(
+      'adoptConversationId(sameId) does NOT fire conversation-change listener',
+      () {
+        final coord = SessionIdCoordinator();
+        coord.adoptConversationId('conv-1');
+        var calls = 0;
+        coord.addConversationChangeListener((_) => calls++);
+        coord.adoptConversationId('conv-1');
+        expect(calls, 0);
+      },
+    );
+
+    test(
+      'first adopt from null fires conversation-change listener (id changed)',
+      () {
+        final coord = SessionIdCoordinator();
+        var calls = 0;
+        coord.addConversationChangeListener((_) => calls++);
+        coord.adoptConversationId('conv-1');
+        expect(calls, 1);
+      },
+    );
+
+    test('integration: buffer cleared on resetSession via wired listener', () {
+      final coord = SessionIdCoordinator();
+      final buffer = InMemoryTtsReplyBuffer();
+      coord.addResetListener(buffer.clear);
+
+      buffer.record('hello', languageCode: 'en');
+      expect(buffer.last(), isNotNull);
+
+      coord.resetSession();
+      expect(buffer.last(), isNull);
+    });
+
+    test(
+      'integration: buffer cleared on adoptConversationId(different) but '
+      'NOT on adoptConversationId(same)',
+      () {
+        final coord = SessionIdCoordinator();
+        final buffer = InMemoryTtsReplyBuffer();
+        coord.addConversationChangeListener((_) => buffer.clear());
+
+        coord.adoptConversationId('conv-1');
+        buffer.record('first', languageCode: 'en');
+
+        // Same id — should NOT clear.
+        coord.adoptConversationId('conv-1');
+        expect(buffer.last(), isNotNull);
+
+        // Different id — should clear.
+        coord.adoptConversationId('conv-2');
+        expect(buffer.last(), isNull);
+      },
+    );
+  });
+}
+
+/// Counts `post` calls so we can assert the local-replay path skips backend.
+class _CountingApiClient extends ApiClient {
+  int postCalls = 0;
+  ApiResult nextResult = const ApiSuccess();
+  String? nextBody;
+
+  @override
+  Future<ApiResult> post(
+    Transcript transcript, {
+    required String url,
+    String? token,
+  }) async {
+    postCalls++;
+    if (nextResult is ApiSuccess) return ApiSuccess(body: nextBody);
+    return nextResult;
+  }
 }


### PR DESCRIPTION
## Summary

Implements proposal [036 — Replay Last TTS Reply](docs/proposals/036-replay-last-tts.md). Bundles T1-T5 in one PR (tightly coupled core port + decorator + matcher + wiring + lifetime; total diff well under the 600-LOC threshold from the implementation guidelines).

When the user says one of a small whitelist of replay phrases (e.g. "powtórz", "repeat", "say again"), the app re-speaks the previous agent reply from an in-memory buffer — no backend round-trip, no LLM call.

### What changed

- **T1 — `core/tts/`**: new `TtsReplyBuffer` port + `InMemoryTtsReplyBuffer` (n=1, single most-recent entry; LRU is trivial at n=1). New `BufferingTtsService` decorator that captures `(text, languageCode)` on every successful `speak()`.
- **T2 — `core/local_commands/`**: new `LocalCommandMatcher` with whole-utterance whitelist (`powtórz`, `powtórz proszę`, `powtórz to`, `powtórz jeszcze raz`, `jeszcze raz`, `repeat`, `say again`, `say it again`). Normalizes lowercase + trim + trailing-punctuation strip + whitespace collapse. Sealed `LocalCommandDecision` (`passthrough` / `replayLast`).
- **T3 — `features/api_sync/sync_worker.dart`**: `_drain()` runs the matcher BEFORE `apiClient.post`. On `replayLast` + non-empty buffer it shows toast "Powtarzam ostatnią odpowiedź", fires haptic, stops then re-speaks the buffered entry, drops the queue item via `markSent` (no backend, no LLM, no `onAgentReply` callback). On `replayLast` + empty buffer it shows "Brak wcześniejszej odpowiedzi" and falls through to the backend so the user still gets a response.
- **Capture site**: only `_handleReply` records into the buffer, AFTER a successful `ttsService.speak`. `_speakError` deliberately does NOT feed the buffer — verified by tests.
- **T4 — `core/session_control/session_id_coordinator.dart`**: new `addResetListener` and `addConversationChangeListener` hooks (disposer pattern). `ttsReplyBufferProvider` subscribes to both: clears on `resetSession()` and on `adoptConversationId()` when the new id differs. Not cleared on `stop_recording`. Not persisted across app restarts.
- **T5 — `test/features/api_sync/sync_worker_test.dart`**: integration tests cover whitelist match with non-empty buffer skips backend; empty-buffer toast + passthrough; origin phrase does NOT trigger replay; `_speakError` does NOT feed buffer (three scenarios).

### Hard rules respected

- Dependency rule: `core/tts` and `core/local_commands` live in `core/`; `features/api_sync` consumes from core only. No cross-feature imports.
- Originating production phrase "Powtórz, żeby coś przerwało." passthrough is asserted by an explicit unit test in `local_command_matcher_test.dart` and by an integration test in `sync_worker_test.dart`.
- `<lang>` tag handling from P030 preserved: buffer stores `(text, languageCode)`; replay re-feeds these into the same `TtsService.speak`, so the `SsmlLangSplitter` runs again on replay.
- Only `_handleReply` feeds the buffer (verified by 3 `_speakError` tests).
- `make verify` green: 937 tests passing, `flutter analyze` clean.

## Test plan

- [x] `flutter analyze` — clean.
- [x] `flutter test` — 937 pass / 0 fail.
- [x] New unit tests (`tts_reply_buffer_test.dart`, `buffering_tts_service_test.dart`, `local_command_matcher_test.dart`) cover write/read/clear, decorator capture-only-on-success, whitelist hits across casings/punctuation/whitespace, all required passthrough cases.
- [x] Origin phrase "Powtórz, żeby coś przerwało." asserted as passthrough in both matcher unit tests and SyncWorker integration tests.
- [x] `_speakError` non-feeding verified for permanent + transient + buffer-prime scenarios.
- [x] Buffer-clear hooks verified for `resetSession`, `adoptConversationId(same)` (no clear), `adoptConversationId(different)` (clear), and disposer.
- [ ] Manual device verification (per proposal): foreground + locked-screen replay on iOS and Android; verify no network traffic during replay; verify origin phrase still hits backend.

Refs: docs/proposals/036-replay-last-tts.md, depends on P029 + P030 (both Implemented).
