### PR TITLE
fix(tts/ios): share AVAudioSession with app + drop .mixWithOthers

### DIFF
--- a/lib/core/tts/flutter_tts_service.dart
+++ b/lib/core/tts/flutter_tts_service.dart
@@ -14,6 +14,28 @@ class FlutterTtsService implements TtsService {
     _tts.setCompletionHandler(_onCompletion);
     _tts.setCancelHandler(_onCancel);
     _tts.setErrorHandler(_onError);
+    if (_isIOS) {
+      // P034 follow-up: tell flutter_tts to honour the app-managed
+      // AVAudioSession (set by AudioSessionBridge to .playAndRecord
+      // without .mixWithOthers). Without this, the plugin sets its own
+      // category (.playback with .mixWithOthers by default) which
+      // prevents the app from claiming exclusive media focus →
+      // hardware media-button events (AirPods togglePlayPause) never
+      // route to MediaButtonBridge.MPRemoteCommandCenter target.
+      // Awaited via fire-and-forget — these are setup calls and
+      // failure is non-fatal (tests stub the FlutterTts engine).
+      // ignore: discarded_futures
+      _tts.setSharedInstance(true);
+      // ignore: discarded_futures
+      _tts.setIosAudioCategory(
+        IosTextToSpeechAudioCategory.playAndRecord,
+        [
+          IosTextToSpeechAudioCategoryOptions.defaultToSpeaker,
+          IosTextToSpeechAudioCategoryOptions.allowBluetooth,
+        ],
+        IosTextToSpeechAudioMode.defaultMode,
+      );
+    }
   }
 
   final FlutterTts _tts;

--- a/test/core/tts/flutter_tts_service_test.dart
+++ b/test/core/tts/flutter_tts_service_test.dart
@@ -93,8 +93,11 @@ class _MockFlutterTts implements FlutterTts {
   }
 
   // Unused FlutterTts members — not needed for these tests.
+  // Default to a settled Future so future-typed setters (e.g.
+  // setSharedInstance, setIosAudioCategory) don't throw a TypeError
+  // when the constructor fires them on iOS.
   @override
-  dynamic noSuchMethod(Invocation invocation) => null;
+  dynamic noSuchMethod(Invocation invocation) => Future<dynamic>.value(null);
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to PR #266. flutter_tts plugin manages its own AVAudioSession by default — sets .playback with .mixWithOthers — overriding the AudioSessionBridge fix while TTS speaks. App still doesn't claim exclusive media focus during playback → AirPods media-button event routes to the prior 'now playing' app, never to MediaButtonBridge.

Fix: tell flutter_tts to setSharedInstance(true) and setIosAudioCategory to .playAndRecord with [.defaultToSpeaker, .allowBluetooth] (NO .mixWithOthers) — matches AudioSessionBridge config so both paths agree.

User report: 'nadal nie mogę przerwać odtwarzania wiadomości' after PR #266 dev install.