### PR TITLE
fix(ios/audio): switch to .playback during TTS so AirPods button works

### DIFF
--- a/ios/Runner/AudioSessionBridge.swift
+++ b/ios/Runner/AudioSessionBridge.swift
@@ -27,9 +27,66 @@ class AudioSessionBridge {
         }
     }
 
+    /// Saved category when transitioning into TTS playback. Used by
+    /// restoreAudioSession() to flip back to whatever the app had set
+    /// before TTS started. Nil means "no saved state — caller must
+    /// explicitly pick a category".
+    private var savedCategoryBeforeTtsPlayback: AVAudioSession.Category?
+    private var savedCategoryOptionsBeforeTtsPlayback: AVAudioSession.CategoryOptions?
+
     private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let session = AVAudioSession.sharedInstance()
         switch call.method {
+        case "setPlayback":
+            // P034 follow-up: during TTS playback, switch to .playback (no
+            // microphone). With .playAndRecord active, iOS treats the
+            // session as a "call/voice" mode and rejects hardware media
+            // button presses — user hears the iOS rejection sound when
+            // pressing AirPods. Switching to .playback during TTS makes
+            // iOS route the press as media play/pause normally.
+            // Saves the prior category so restoreAudioSession can flip back.
+            do {
+                NSLog("[AudioSessionDbg] setPlayback requested (current=\(session.category.rawValue))")
+                self.savedCategoryBeforeTtsPlayback = session.category
+                self.savedCategoryOptionsBeforeTtsPlayback = session.categoryOptions
+                try session.setCategory(.playback, mode: .spokenAudio, options: [])
+                try session.setActive(true)
+                NSLog("[AudioSessionDbg] setPlayback applied — category=\(session.category.rawValue) options=\(session.categoryOptions.rawValue)")
+                result(nil)
+            } catch {
+                NSLog("[AudioSessionDbg] setPlayback FAILED: \(error.localizedDescription)")
+                result(FlutterError(
+                    code: "AUDIO_SESSION_ERROR",
+                    message: "Failed to set playback: \(error.localizedDescription)",
+                    details: nil
+                ))
+            }
+        case "restoreAudioSession":
+            // Restore the category captured by the most recent setPlayback
+            // call. If none was captured (caller never set playback or
+            // restore was already called), this is a no-op.
+            do {
+                guard let savedCategory = self.savedCategoryBeforeTtsPlayback else {
+                    NSLog("[AudioSessionDbg] restoreAudioSession called but nothing was saved — no-op")
+                    result(nil)
+                    return
+                }
+                let savedOptions = self.savedCategoryOptionsBeforeTtsPlayback ?? []
+                NSLog("[AudioSessionDbg] restoreAudioSession requested (target=\(savedCategory.rawValue) options=\(savedOptions.rawValue))")
+                try session.setCategory(savedCategory, mode: .default, options: savedOptions)
+                try session.setActive(true)
+                self.savedCategoryBeforeTtsPlayback = nil
+                self.savedCategoryOptionsBeforeTtsPlayback = nil
+                NSLog("[AudioSessionDbg] restoreAudioSession applied — category=\(session.category.rawValue) options=\(session.categoryOptions.rawValue)")
+                result(nil)
+            } catch {
+                NSLog("[AudioSessionDbg] restoreAudioSession FAILED: \(error.localizedDescription)")
+                result(FlutterError(
+                    code: "AUDIO_SESSION_ERROR",
+                    message: "Failed to restore: \(error.localizedDescription)",
+                    details: nil
+                ))
+            }
         case "setPlayAndRecord":
             do {
                 NSLog("[AudioSessionDbg] setPlayAndRecord requested")

--- a/ios/Runner/MediaButtonBridge.swift
+++ b/ios/Runner/MediaButtonBridge.swift
@@ -73,19 +73,25 @@ class MediaButtonBridge: NSObject, FlutterStreamHandler {
         // togglePlayPause is the canonical case; play/pause are how iOS
         // disambiguates when nowPlayingInfo's playbackRate is 0.0 vs 1.0.
         // Register the same target on all three so we never miss the press.
-        let toggleHandler: (MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus = { [weak self] _ in
-            let hasSink = (self?.eventSink != nil)
-            NSLog("[MediaButtonDbg] togglePlayPause TARGET FIRED hasEventSink=\(hasSink)")
-            logAudioSession("targetFired")
-            self?.eventSink?("togglePlayPause")
-            return .success
+        let makeHandler: (String) -> ((MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus) = { source in
+            return { [weak self] _ in
+                let hasSink = (self?.eventSink != nil)
+                NSLog("[MediaButtonDbg] \(source) TARGET FIRED hasEventSink=\(hasSink)")
+                logAudioSession("targetFired:\(source)")
+                self?.eventSink?("togglePlayPause")
+                return .success
+            }
         }
         center.togglePlayPauseCommand.isEnabled = true
-        center.togglePlayPauseCommand.addTarget(handler: toggleHandler)
+        center.togglePlayPauseCommand.addTarget(handler: makeHandler("togglePlayPause"))
         center.playCommand.isEnabled = true
-        center.playCommand.addTarget(handler: toggleHandler)
+        center.playCommand.addTarget(handler: makeHandler("play"))
         center.pauseCommand.isEnabled = true
-        center.pauseCommand.addTarget(handler: toggleHandler)
+        center.pauseCommand.addTarget(handler: makeHandler("pause"))
+
+        // Diagnostic: confirm registration stuck.
+        NSLog("[MediaButtonDbg] toggle.enabled=\(center.togglePlayPauseCommand.isEnabled) play.enabled=\(center.playCommand.isEnabled) pause.enabled=\(center.pauseCommand.isEnabled)")
+        startStatePolling()
 
         // Now-playing info must signal "actively playing" so iOS treats this
         // app as the foreground media participant. Setting playbackRate=1.0
@@ -101,7 +107,27 @@ class MediaButtonBridge: NSObject, FlutterStreamHandler {
         NSLog("[MediaButtonDbg] activateRemoteCommands DONE (3 targets, nowPlayingInfo with rate=1)")
     }
 
+    // Diagnostic: every 2s log audio session + nowPlayingInfo state so we
+    // can see what iOS sees when the user presses the headset button. The
+    // poll auto-stops when deactivateRemoteCommands runs.
+    private var statePollTimer: Timer?
+    private func startStatePolling() {
+        stopStatePolling()
+        statePollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
+            let s = AVAudioSession.sharedInstance()
+            let info = MPNowPlayingInfoCenter.default().nowPlayingInfo
+            let rate = info?[MPNowPlayingInfoPropertyPlaybackRate] ?? "nil"
+            let title = info?[MPMediaItemPropertyTitle] ?? "nil"
+            NSLog("[MediaButtonDbg] poll category=\(s.category.rawValue) options=\(s.categoryOptions.rawValue) other=\(s.isOtherAudioPlaying) npRate=\(rate) npTitle=\(title)")
+        }
+    }
+    private func stopStatePolling() {
+        statePollTimer?.invalidate()
+        statePollTimer = nil
+    }
+
     private func deactivateRemoteCommands() {
+        stopStatePolling()
         NSLog("[MediaButtonDbg] deactivateRemoteCommands called")
         let center = MPRemoteCommandCenter.shared()
         center.togglePlayPauseCommand.isEnabled = false

--- a/lib/core/tts/flutter_tts_service.dart
+++ b/lib/core/tts/flutter_tts_service.dart
@@ -2,14 +2,20 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 import 'package:voice_agent/core/tts/ssml_lang_splitter.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 
 class FlutterTtsService implements TtsService {
-  FlutterTtsService({FlutterTts? tts, bool? isIOS})
-      : _tts = tts ?? FlutterTts(),
-        _isIOS = isIOS ?? Platform.isIOS {
+  FlutterTtsService({
+    FlutterTts? tts,
+    bool? isIOS,
+    MethodChannel? audioSessionChannel,
+  })  : _tts = tts ?? FlutterTts(),
+        _isIOS = isIOS ?? Platform.isIOS,
+        _audioSession = audioSessionChannel ??
+            const MethodChannel('com.voiceagent/audio_session') {
     _tts.setStartHandler(_onStart);
     _tts.setCompletionHandler(_onCompletion);
     _tts.setCancelHandler(_onCancel);
@@ -28,11 +34,8 @@ class FlutterTtsService implements TtsService {
       _tts.setSharedInstance(true);
       // ignore: discarded_futures
       _tts.setIosAudioCategory(
-        IosTextToSpeechAudioCategory.playAndRecord,
-        [
-          IosTextToSpeechAudioCategoryOptions.defaultToSpeaker,
-          IosTextToSpeechAudioCategoryOptions.allowBluetooth,
-        ],
+        IosTextToSpeechAudioCategory.playback,
+        [],
         IosTextToSpeechAudioMode.defaultMode,
       );
     }
@@ -40,7 +43,36 @@ class FlutterTtsService implements TtsService {
 
   final FlutterTts _tts;
   final bool _isIOS;
+  final MethodChannel _audioSession;
   final ValueNotifier<bool> _speaking = ValueNotifier(false);
+
+  /// P034 follow-up: switch the iOS audio session to .playback for the
+  /// duration of TTS so that hardware media-button presses (AirPods
+  /// click) reach our MPRemoteCommand handlers. With .playAndRecord
+  /// active iOS treats the session as call-like and rejects play/pause
+  /// hardware presses (audible "boop" rejection sound). Calls are
+  /// best-effort: failures don't abort speech.
+  Future<void> _acquirePlaybackFocus() async {
+    if (!_isIOS) return;
+    try {
+      await _audioSession.invokeMethod<void>('setPlayback');
+    } on PlatformException catch (e) {
+      debugPrint('[TtsDbg] setPlayback failed: ${e.message}');
+    } on MissingPluginException {
+      // Bridge not registered (tests etc.) — proceed without focus switch.
+    }
+  }
+
+  Future<void> _releasePlaybackFocus() async {
+    if (!_isIOS) return;
+    try {
+      await _audioSession.invokeMethod<void>('restoreAudioSession');
+    } on PlatformException catch (e) {
+      debugPrint('[TtsDbg] restoreAudioSession failed: ${e.message}');
+    } on MissingPluginException {
+      // Bridge not registered — no state to restore.
+    }
+  }
 
   @override
   ValueListenable<bool> get isSpeaking => _speaking;
@@ -58,6 +90,11 @@ class FlutterTtsService implements TtsService {
   Future<void> speak(String text, {String? languageCode}) async {
     final segments = SsmlLangSplitter.split(text);
     if (segments.isEmpty) return;
+
+    // P034 follow-up: acquire .playback session BEFORE the first speak so
+    // hardware media buttons route to MPRemoteCommand during the entire
+    // utterance. Released on completion / cancel / error / stop().
+    await _acquirePlaybackFocus();
 
     // Single segment with no explicit language override: follow the original
     // path exactly (zero behavior change for untagged replies).
@@ -127,6 +164,8 @@ class FlutterTtsService implements TtsService {
     if (queue == null) {
       // No active queue — single-utterance path or already cleared.
       _speaking.value = false;
+      // ignore: discarded_futures
+      _releasePlaybackFocus();
       return;
     }
 
@@ -140,6 +179,8 @@ class FlutterTtsService implements TtsService {
     } else {
       // Queue drained.
       _activeQueue = null;
+      // ignore: discarded_futures
+      _releasePlaybackFocus();
       if (!queue.doneCompleter.isCompleted) {
         queue.doneCompleter.complete();
       }
@@ -155,6 +196,8 @@ class FlutterTtsService implements TtsService {
       queue.doneCompleter.complete();
     }
     _speaking.value = false;
+    // ignore: discarded_futures
+    _releasePlaybackFocus();
   }
 
   void _onError(dynamic error) {
@@ -165,6 +208,8 @@ class FlutterTtsService implements TtsService {
       queue.doneCompleter.complete();
     }
     _speaking.value = false;
+    // ignore: discarded_futures
+    _releasePlaybackFocus();
   }
 
   @override
@@ -185,6 +230,10 @@ class FlutterTtsService implements TtsService {
 
     // (4) Ensure _speaking is false.
     if (_speaking.value) _speaking.value = false;
+
+    // (5) Release the .playback session so .playAndRecord (or whatever
+    // was active before TTS) is restored.
+    await _releasePlaybackFocus();
     debugPrint('[TtsDbg] stop() done speaking=${_speaking.value}');
   }
 

--- a/test/core/tts/flutter_tts_service_test.dart
+++ b/test/core/tts/flutter_tts_service_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
-import 'dart:ui';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 import 'package:voice_agent/core/tts/flutter_tts_service.dart';
@@ -103,6 +103,15 @@ class _MockFlutterTts implements FlutterTts {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 void main() {
+  // FlutterTtsService.speak invokes a MethodChannel for audio-session
+  // focus switching (P034 follow-up). The test binding must be ready
+  // before any platform-channel call. The handler returns null so the
+  // call is a no-op in tests.
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const audioSessionChannel = MethodChannel('com.voiceagent/audio_session');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(audioSessionChannel, (call) async => null);
+
   group('FlutterTtsService', () {
     test('speak() with explicit languageCode calls setLanguage with that code',
         () async {


### PR DESCRIPTION
Root cause: .playAndRecord audio session category is treated as call/voice mode by iOS — hardware media-button presses (AirPods click) are rejected with the iOS 'boop' rejection sound. Control Center pause works (different routing) but hardware press does not.

Fix: AudioSessionBridge gains setPlayback / restoreAudioSession methods that flip the session to .playback for the duration of TTS speech. FlutterTtsService acquires playback focus before speak() and releases on completion / cancel / error / stop().