### PR TITLE
P037 T3+T4+T6+T8 — engagement core (tap-to-engage refactor)

### DIFF
--- a/ios/Runner/AudioSessionBridge.swift
+++ b/ios/Runner/AudioSessionBridge.swift
@@ -150,6 +150,29 @@ class AudioSessionBridge {
                     details: nil
                 ))
             }
+        case "setPlaybackOnly":
+            // P037 v2: when leaving the engaged listening state, switch to
+            // .playback (NOT .ambient). With .playback, the app remains the
+            // active media participant, so AirPods media-button presses are
+            // routed to MPRemoteCommandCenter targets in the app — required
+            // for tap-to-engage. Mirrors `setPlayback` but does NOT save the
+            // prior category: this is the new resting state, not a temporary
+            // detour around TTS.
+            do {
+                NSLog("[AudioSessionDbg] setPlaybackOnly requested (current=\(session.category.rawValue))")
+                try? session.setActive(false, options: [.notifyOthersOnDeactivation])
+                try session.setCategory(.playback, mode: .spokenAudio, options: [])
+                try session.setActive(true)
+                NSLog("[AudioSessionDbg] setPlaybackOnly applied — category=\(session.category.rawValue) mode=\(session.mode.rawValue) options=\(session.categoryOptions.rawValue)")
+                result(nil)
+            } catch {
+                NSLog("[AudioSessionDbg] setPlaybackOnly FAILED: \(error.localizedDescription)")
+                result(FlutterError(
+                    code: "AUDIO_SESSION_ERROR",
+                    message: "Failed to set playbackOnly: \(error.localizedDescription)",
+                    details: nil
+                ))
+            }
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -1,3 +1,20 @@
+/// Target audio session category to apply when [BackgroundService.stopService]
+/// tears down the engaged listening state.
+///
+/// - [playback]: switch to `.playback` (no mic). The app remains the active
+///   media participant so AirPods media-button presses are routed to its
+///   `MPRemoteCommandCenter` targets. P037 v2 default: required for the
+///   tap-to-engage flow because the AirPods short-click must reach the app
+///   when it is in the resting (idle) state.
+/// - [ambient]: legacy behaviour; switch to `.ambient`. Yields media-button
+///   routing to the foreground "now playing" app and stops occupying the
+///   audio output unit. Kept for backward compatibility with callers that
+///   want the pre-P037 quiet-yield semantics.
+enum AudioSessionTarget {
+  playback,
+  ambient,
+}
+
 /// Abstract interface for background service management.
 ///
 /// Manages the platform-specific keepalive mechanism that prevents the OS from
@@ -6,7 +23,18 @@
 /// an active audio session.
 abstract class BackgroundService {
   Future<void> startService();
-  Future<void> stopService();
+
+  /// Stop the foreground service / audio session keepalive.
+  ///
+  /// [target] selects the post-stop iOS audio session category. Defaults to
+  /// [AudioSessionTarget.playback] (P037 v2): the app keeps owning the media
+  /// participant slot so AirPods buttons still reach
+  /// `MPRemoteCommandCenter`. Pass [AudioSessionTarget.ambient] for the
+  /// legacy "fully yield" behaviour.
+  Future<void> stopService({
+    AudioSessionTarget target = AudioSessionTarget.playback,
+  });
+
   Future<void> updateNotification({required String title, required String body});
   bool get isRunning;
 }

--- a/lib/core/background/flutter_foreground_task_service.dart
+++ b/lib/core/background/flutter_foreground_task_service.dart
@@ -77,7 +77,9 @@ class FlutterForegroundTaskService implements BackgroundService {
   }
 
   @override
-  Future<void> stopService() async {
+  Future<void> stopService({
+    AudioSessionTarget target = AudioSessionTarget.playback,
+  }) async {
     if (!_running) return;
 
     if (Platform.isAndroid) {
@@ -85,8 +87,18 @@ class FlutterForegroundTaskService implements BackgroundService {
     }
 
     if (Platform.isIOS) {
+      // P037 v2: by default, when leaving the engaged listening state we
+      // switch to `.playback` (not `.ambient`). The app keeps the media
+      // participant slot so AirPods short-click reaches its
+      // MPRemoteCommandCenter targets — required for tap-to-engage.
+      // Callers that want the pre-P037 "fully yield to other apps" behaviour
+      // can opt into [AudioSessionTarget.ambient].
+      final method = switch (target) {
+        AudioSessionTarget.playback => 'setPlaybackOnly',
+        AudioSessionTarget.ambient => 'setAmbient',
+      };
       try {
-        await _audioSessionChannel.invokeMethod('setAmbient');
+        await _audioSessionChannel.invokeMethod(method);
       } on PlatformException {
         // Audio session revert failed — non-critical
       } on MissingPluginException {

--- a/lib/features/recording/domain/engagement_controller.dart
+++ b/lib/features/recording/domain/engagement_controller.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'package:voice_agent/features/recording/domain/engagement_state.dart';
+
+/// Auto-disengage timeout for the [EngagementController]. Hard-coded per
+/// the P037 v2 task list (T6) — exposed via [AppConfig] later.
+const Duration kListeningEngagementTimeout = Duration(seconds: 30);
+
+/// State machine for the P037 v2 tap-to-engage listening lifecycle (T3).
+///
+/// Owns:
+///   • the [EngagementState] (`Idle / Listening / Capturing / Error`),
+///   • the 30 s auto-disengage timer (T6),
+///   • notifications to interested observers via [stream].
+///
+/// Lives in `features/recording/domain/` because it is a state machine
+/// over the recording lifecycle and depends only on Dart core types
+/// (no platform packages, no Riverpod).
+///
+/// The audio-session bridging that flips between `.playback` and
+/// `.playAndRecord` is performed by the owning controller in
+/// presentation/, which calls into `BackgroundService` from `core/`.
+/// Keeping that bridge outside the state machine preserves the layering
+/// rule (domain depends on no platform code) and lets the controller
+/// orchestrate side effects synchronously around state transitions.
+class EngagementController {
+  EngagementController({Duration? timeout})
+      : _timeout = timeout ?? kListeningEngagementTimeout;
+
+  final Duration _timeout;
+  final _controller = StreamController<EngagementState>.broadcast();
+
+  EngagementState _state = const EngagementIdle();
+  Timer? _timer;
+  bool _disposed = false;
+
+  /// Current engagement state.
+  EngagementState get state => _state;
+
+  /// Stream of engagement state changes.
+  Stream<EngagementState> get stream => _controller.stream;
+
+  /// Open an engagement: Idle → Listening. Starts the auto-disengage
+  /// timer. Idempotent when already engaged.
+  void engage() {
+    _ensureNotDisposed();
+    if (_state is EngagementListening || _state is EngagementCapturing) return;
+    _cancelTimer();
+    _setState(const EngagementListening());
+    _timer = Timer(_timeout, tickTimeout);
+  }
+
+  /// Mark VAD start-of-speech: Listening → Capturing. Cancels the
+  /// auto-disengage timer (the segment will end naturally on VAD
+  /// end-of-speech). No-op if not in Listening.
+  void markCaptureStarted() {
+    _ensureNotDisposed();
+    if (_state is! EngagementListening) return;
+    _cancelTimer();
+    _setState(const EngagementCapturing());
+  }
+
+  /// Close the current engagement: any non-Idle → Idle. Cancels the
+  /// auto-disengage timer. Idempotent when already idle.
+  void disengage() {
+    _ensureNotDisposed();
+    if (_state is EngagementIdle) return;
+    _cancelTimer();
+    _setState(const EngagementIdle());
+  }
+
+  /// Auto-disengage trigger fired by the 30 s timer. Public so tests
+  /// (and future synchronous-fake callers) can drive the transition
+  /// without waiting for real time. Equivalent to [disengage] when in
+  /// Listening; no-op otherwise.
+  void tickTimeout() {
+    _ensureNotDisposed();
+    if (_state is! EngagementListening) return;
+    _cancelTimer();
+    _setState(const EngagementIdle());
+  }
+
+  /// Mark an unrecoverable engagement-layer error. Cancels the timer.
+  void markError(String message) {
+    _ensureNotDisposed();
+    _cancelTimer();
+    _setState(EngagementError(message));
+  }
+
+  /// Release timer + stream resources. Safe to call multiple times.
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    _cancelTimer();
+    await _controller.close();
+  }
+
+  // ── internals ────────────────────────────────────────────────────────
+
+  void _setState(EngagementState next) {
+    _state = next;
+    if (!_controller.isClosed) {
+      _controller.add(next);
+    }
+  }
+
+  void _cancelTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  void _ensureNotDisposed() {
+    assert(!_disposed, 'EngagementController used after dispose()');
+  }
+}

--- a/lib/features/recording/domain/engagement_state.dart
+++ b/lib/features/recording/domain/engagement_state.dart
@@ -1,0 +1,45 @@
+/// Runtime state of the tap-to-engage listening machine introduced by
+/// P037 v2 (Candidate B). The engagement machine is the high-level
+/// "are we currently capturing speech for one turn or not?" model that
+/// drives audio-session category transitions and the 30 s auto-disengage
+/// timer.
+///
+/// Layered above this, [HandsFreeSessionState] still carries the segment
+/// job list so the UI can render in-flight transcription/persistence work.
+sealed class EngagementState {
+  const EngagementState();
+}
+
+/// Resting state. Audio session is `.playback`; mic is not engaged. The
+/// app remains the active media participant so AirPods short-click is
+/// routed via `MPRemoteCommandCenter`.
+class EngagementIdle extends EngagementState {
+  const EngagementIdle();
+}
+
+/// Engagement opened. Audio session is `.playAndRecord`, VAD is running,
+/// the 30 s auto-disengage timer is active. Transitions to
+/// [EngagementCapturing] on VAD start-of-speech (which cancels the timer)
+/// or back to [EngagementIdle] on `disengage()` / `tickTimeout()`.
+class EngagementListening extends EngagementState {
+  const EngagementListening();
+}
+
+/// VAD detected start-of-speech and is accumulating an utterance. The
+/// 30 s timer was cancelled at start-of-speech. Transitions back to
+/// [EngagementIdle] on `disengage()` (typically called when the engine
+/// reports the segment is ready and the controller decides to close the
+/// turn).
+class EngagementCapturing extends EngagementState {
+  const EngagementCapturing();
+}
+
+/// Unrecoverable engagement error. Mirrors [HandsFreeSessionError] at the
+/// engagement layer. The owning [HandsFreeController] surfaces the
+/// detailed error message via [HandsFreeSessionError]; this variant is
+/// only used to gate transitions inside [EngagementController].
+class EngagementError extends EngagementState {
+  const EngagementError(this.message);
+
+  final String message;
+}

--- a/lib/features/recording/domain/hands_free_session_state.dart
+++ b/lib/features/recording/domain/hands_free_session_state.dart
@@ -1,10 +1,32 @@
 import 'package:voice_agent/features/recording/domain/segment_job.dart';
 
+/// Sub-phase of [HandsFreeListening], mirroring [EngagementState]
+/// from the P037 v2 tap-to-engage refactor.
+///
+/// In the v2 one-shot model the session is either Idle or Listening at
+/// the public/UI level. The internal phase is tracked here so the UI can
+/// continue rendering distinct status text ("Listening...", "Capturing...",
+/// "Processing segment...") without resurrecting the old per-phase
+/// session-state classes.
+enum HandsFreeListeningPhase {
+  /// VAD running, no speech detected.
+  listening,
+
+  /// VAD detected start-of-speech; segment accumulating.
+  capturing,
+
+  /// Hangover or maxSegmentMs triggered; WAV being written asynchronously.
+  stopping,
+}
+
 /// Runtime state of a hands-free recording session.
 ///
-/// All active variants carry a [jobs] list so the UI can render the segment
-/// list without a separate provider. [HandsFreeIdle] carries no jobs because
-/// the session is not running.
+/// P037 v2 collapsed the previous fine-grained variants
+/// (`HandsFreeListening` / `HandsFreeWithBacklog` / `HandsFreeCapturing`
+/// / `HandsFreeStopping` / `HandsFreeSuspendedByUser`) into a single
+/// [HandsFreeListening] case carrying a [HandsFreeListeningPhase]
+/// indicator and the segment job list. [HandsFreeIdle] and
+/// [HandsFreeSessionError] are unchanged.
 sealed class HandsFreeSessionState {
   const HandsFreeSessionState();
 }
@@ -14,40 +36,17 @@ class HandsFreeIdle extends HandsFreeSessionState {
   const HandsFreeIdle();
 }
 
-/// VAD running; no speech detected; no job backlog.
-/// Cooldown (if active) is invisible — session stays Listening during cooldown.
+/// Session is engaged. The [phase] indicates the engine sub-state
+/// (listening / capturing / stopping); [jobs] carries the in-flight
+/// transcription/persistence backlog.
 class HandsFreeListening extends HandsFreeSessionState {
-  const HandsFreeListening(this.jobs);
+  const HandsFreeListening(
+    this.jobs, {
+    this.phase = HandsFreeListeningPhase.listening,
+  });
 
   final List<SegmentJob> jobs;
-}
-
-/// Speech frames accumulating in segment buffer.
-class HandsFreeCapturing extends HandsFreeSessionState {
-  const HandsFreeCapturing(this.jobs);
-
-  final List<SegmentJob> jobs;
-}
-
-/// Hangover or maxSegmentMs triggered; WAV being written asynchronously.
-class HandsFreeStopping extends HandsFreeSessionState {
-  const HandsFreeStopping(this.jobs);
-
-  final List<SegmentJob> jobs;
-}
-
-/// Listening; one or more STT jobs are pending or in-flight.
-class HandsFreeWithBacklog extends HandsFreeSessionState {
-  const HandsFreeWithBacklog(this.jobs);
-
-  final List<SegmentJob> jobs;
-}
-
-/// User-initiated pause via media button. Engine stopped, backlog preserved.
-class HandsFreeSuspendedByUser extends HandsFreeSessionState {
-  const HandsFreeSuspendedByUser(this.jobs);
-
-  final List<SegmentJob> jobs;
+  final HandsFreeListeningPhase phase;
 }
 
 /// Unrecoverable error. Microphone released.

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
+import 'package:voice_agent/core/background/background_service.dart';
 import 'package:voice_agent/core/background/background_service_provider.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/providers/session_active_provider.dart';
@@ -13,32 +14,46 @@ import 'package:voice_agent/core/models/transcript.dart';
 import 'package:voice_agent/core/session_control/hands_free_control_port.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/tts/tts_provider.dart';
+import 'package:voice_agent/features/recording/domain/engagement_controller.dart';
+import 'package:voice_agent/features/recording/domain/engagement_state.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_session_state.dart';
 import 'package:voice_agent/features/recording/domain/segment_job.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 
-/// T3a + T3b: session lifecycle and job processing for hands-free mode.
+/// Hands-free session controller (P037 v2 — tap-to-engage refactor, T4).
 ///
-/// T3a responsibilities (merged):
-///   • session-start guard (permission → Groq key → active-recording check)
-///   • [HandsFreeEngineEvent] → [HandsFreeSessionState] mapping
-///   • background lifecycle via [WidgetsBindingObserver]
-///   • stopSession() with in-flight job drain
+/// Wraps an [EngagementController] (T3) which owns the high-level
+/// `Idle / Listening / Capturing / Error` lifecycle and the 30 s
+/// auto-disengage timer (T6). This controller still owns:
+///   • session-start guard (permission → Groq key → API URL)
+///   • engine event mapping → [HandsFreeListeningPhase] sub-state
+///   • job queue + serial STT slot + persist+enqueue with rollback
+///   • foreground-service lifecycle (audio session category transitions)
 ///
-/// T3b additions:
-///   • STT serial slot — jobs processed one at a time
-///   • Bounded job queue (max [_maxJobs] non-terminal jobs)
-///   • [StorageService.saveTranscript] + [enqueue] with rollback on enqueue failure
-///   • WAV cleanup for rejections and session stop
+/// In the v2 one-shot model the publicly exposed states collapse to
+/// [HandsFreeIdle] / [HandsFreeListening] / [HandsFreeSessionError].
+/// The pre-v2 `WithBacklog`, `Capturing`, `Stopping`, and
+/// `SuspendedByUser` distinctions live as fields on
+/// [HandsFreeListening.phase] (capturing / stopping) or are simply gone
+/// (`SuspendedByUser` was a continuous-listening artefact and disappears
+/// in the one-shot model: a "user pause" maps to closing the engagement).
+///
+/// T7 (UI wiring of AirPods short-click → [engage]) is intentionally out
+/// of scope for this PR. The legacy session-start path
+/// ([startSession]) preserves the old "auto-start when the screen mounts"
+/// behaviour by internally calling [engage] so existing UI keeps working.
 class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     with WidgetsBindingObserver
     implements HandsFreeControlPort {
-  HandsFreeController(this._ref) : super(const HandsFreeIdle()) {
+  HandsFreeController(this._ref, {EngagementController? engagement})
+      : _engagement = engagement ?? EngagementController(),
+        super(const HandsFreeIdle()) {
     WidgetsBinding.instance.addObserver(this);
   }
 
   final Ref _ref;
+  final EngagementController _engagement;
 
   HandsFreeEngine? _engine;
   StreamSubscription<HandsFreeEngineEvent>? _engineSub;
@@ -56,69 +71,47 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   // All segment jobs are chained onto this future so they run sequentially.
   Future<void>? _sttSlot;
 
-  // ── Manual-recording suspension (T3: full implementation) ────────────────
-  // In T2 the stubs allow `ref.listen` in RecordingScreen to compile without
-  // producing side-effects. T3 fills in the real logic.
+  // Tracks the most recent engine sub-phase so [_listeningOrBacklog] can
+  // reflect capture/stopping in the collapsed [HandsFreeListening] state.
+  HandsFreeListeningPhase _phase = HandsFreeListeningPhase.listening;
 
-  // ignore: prefer_final_fields — T3 mutates this field
+  // Manual-recording suspension: the [HandsFreeControlPort] still exposes
+  // [isSuspendedForManualRecording] for [SessionControlDispatcher]. In the
+  // one-shot v2 model "suspended for manual recording" simply means the
+  // engagement was closed; the flag persists across the closure so the
+  // dispatcher knows to skip [stopSession].
   bool _suspendedForManualRecording = false;
-  bool _suspendedForTts = false;
+
+  // User-initiated suspension (P034 carry-over). In the v2 one-shot model
+  // the public state collapses to [HandsFreeIdle] when paused, but we
+  // still track *why* it was paused so that auto-resume paths
+  // ([resumeAfterTts] / [resumeAfterManualRecording]) honour the user's
+  // explicit pause intent and do NOT silently re-engage.
   bool _suspendedByUser = false;
 
   @override
   bool get isSuspendedForManualRecording => _suspendedForManualRecording;
 
+  /// Engagement-layer state (testability hook). Exposes the underlying
+  /// [EngagementController] state without leaking the controller itself.
+  EngagementState get engagementState => _engagement.state;
+
+  // ── Public API: legacy compatibility surface ─────────────────────────────
+
   /// Interrupts the active VAD segment and releases the microphone so that
   /// manual recording can start. The job backlog is preserved.
   ///
-  /// Returns when the microphone has been released and [RecordingController]
-  /// may call [startRecording].
+  /// In the v2 one-shot model this collapses to "close the engagement and
+  /// remember that we're in manual-recording mode so [resumeAfter*] knows
+  /// to re-engage". Mid-capture, the in-flight segment is discarded via
+  /// [HandsFreeEngine.interruptCapture] so the mic releases promptly.
   Future<void> suspendForManualRecording() async {
-    if (state is HandsFreeCapturing) {
-      await _engine?.interruptCapture(); // discards current segment
-    } else if (state is HandsFreeListening ||
-        state is HandsFreeWithBacklog ||
-        state is HandsFreeStopping) {
-      // HandsFreeStopping: stop() blocks on _wavWriteCompleter (~100–500ms).
-      // The segment is worth keeping — accept the latency.
-      await _engineSub?.cancel();
-      await _engine?.stop();
-    } else {
-      // HandsFreeIdle or HandsFreeSessionError — nothing to release.
+    if (state is HandsFreeIdle || state is HandsFreeSessionError) {
       return;
     }
-    _engineSub = null;
-    _engine = null;
-    _suspendedForManualRecording = true;
-    state = _listeningOrBacklog();
-  }
-
-  // ── User-initiated suspension (P034 T2) ─────────────────────────────────
-
-  /// Toggles user-initiated suspension. Called by media button dispatch.
-  /// Returns true if the session is now suspended, false if resumed.
-  Future<bool> toggleUserSuspend() async {
-    if (_suspendedByUser) {
-      await resumeByUser();
-      return false;
-    } else {
-      await suspendByUser();
-      return true;
-    }
-  }
-
-  Future<void> suspendByUser() async {
-    if (_suspendedByUser) return;
-    if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
-
-    // Fast path: engine already stopped by TTS or manual recording.
-    if (_suspendedForTts || _suspendedForManualRecording) {
-      _suspendedByUser = true;
-      state = HandsFreeSuspendedByUser(List<SegmentJob>.unmodifiable(_jobs));
-      return;
-    }
-
-    if (state is HandsFreeCapturing) {
+    if (state is HandsFreeListening &&
+        (state as HandsFreeListening).phase ==
+            HandsFreeListeningPhase.capturing) {
       await _engine?.interruptCapture();
     } else {
       await _engineSub?.cancel();
@@ -126,83 +119,109 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     }
     _engineSub = null;
     _engine = null;
+    _engagement.disengage();
+    _suspendedForManualRecording = true;
+    state = const HandsFreeIdle();
+  }
+
+  /// Toggles user-initiated suspension. Called by media button dispatch.
+  /// Returns true if the session is now suspended, false if resumed.
+  ///
+  /// In v2 this maps to engage/disengage on the underlying engagement.
+  Future<bool> toggleUserSuspend() async {
+    if (_suspendedByUser) {
+      await resumeByUser();
+      return false;
+    }
+    await suspendByUser();
+    return true;
+  }
+
+  Future<void> suspendByUser() async {
+    if (_suspendedByUser) return;
+
+    // Fast path: engine already idle from TTS or manual-recording suspend
+    // — just flip the flag so resume*() honours the user's pause intent.
+    if (state is HandsFreeIdle &&
+        (_suspendedForTts || _suspendedForManualRecording)) {
+      _suspendedByUser = true;
+      return;
+    }
+
+    if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
     _suspendedByUser = true;
-    state = HandsFreeSuspendedByUser(List<SegmentJob>.unmodifiable(_jobs));
+    await _closeEngagement(toAmbientFor: AudioSessionTarget.playback);
+    state = const HandsFreeIdle();
   }
 
   Future<void> resumeByUser() async {
     if (!_suspendedByUser) return;
     _suspendedByUser = false;
-    if (_suspendedForManualRecording || _suspendedForTts) {
-      state = _listeningOrBacklog();
-      return;
-    }
-    _startEngine(_ref.read(appConfigProvider).vadConfig);
-    state = _listeningOrBacklog();
+    if (_suspendedForManualRecording) return;
+    if (_suspendedForTts) return;
+    _resumeEngagement();
   }
 
   /// Restarts the VAD engine with the current [appConfigProvider] VAD config.
   ///
   /// Called when the user changes VAD parameters in Advanced Settings.
-  /// No-op when idle, in error, or suspended for manual recording (the new
-  /// config will be picked up automatically by [resumeAfterManualRecording]).
   Future<void> reloadVadConfig() async {
     if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
     if (_suspendedForManualRecording) return;
     if (_suspendedByUser) return;
 
-    if (state is HandsFreeCapturing) {
-      await _engine?.interruptCapture();
-    } else {
-      await _engineSub?.cancel();
-      _engineSub = null;
-      await _engine?.stop();
-    }
-    _engine = null;
+    await _engineSub?.cancel();
     _engineSub = null;
+    await _engine?.stop();
+    _engine = null;
     if (!mounted) return;
 
     _startEngine(_ref.read(appConfigProvider).vadConfig);
+    _phase = HandsFreeListeningPhase.listening;
     state = _listeningOrBacklog();
   }
 
   /// Restarts the VAD engine after manual recording completes.
-  ///
-  /// Does NOT clear [_jobs] or [_jobCounter] — the backlog is preserved.
   Future<void> resumeAfterManualRecording() async {
     if (!_suspendedForManualRecording) return;
     _suspendedForManualRecording = false;
     if (_suspendedByUser) return;
-    _startEngine(_ref.read(appConfigProvider).vadConfig);
-    state = _listeningOrBacklog();
+    _resumeEngagement();
   }
 
-
-  // ── TTS suspension ──────────────────────────────────────────────────────
+  // Tracks whether the most recent engagement closure was due to a TTS
+  // suspend; only that path should auto-resume when TTS ends.
+  bool _suspendedForTts = false;
 
   /// Pauses the VAD engine while TTS is playing to prevent the mic from
-  /// picking up speaker output.
+  /// picking up speaker output. In the v2 one-shot model this collapses
+  /// to closing the engagement; [resumeAfterTts] re-engages.
   Future<void> suspendForTts() async {
-    if (_suspendedForTts || _suspendedForManualRecording) return;
+    if (_suspendedForTts) return;
+    if (_suspendedForManualRecording) return;
     if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
-
-    if (state is HandsFreeCapturing) {
-      await _engine?.interruptCapture();
-    } else {
-      await _engineSub?.cancel();
-      await _engine?.stop();
-    }
-    _engineSub = null;
-    _engine = null;
     _suspendedForTts = true;
-    state = _listeningOrBacklog();
+    await _closeEngagement(toAmbientFor: AudioSessionTarget.playback);
+    state = const HandsFreeIdle();
   }
 
-  /// Restarts the VAD engine after TTS finishes playing.
+  /// Re-engages after TTS finishes playing.
   Future<void> resumeAfterTts() async {
     if (!_suspendedForTts) return;
     _suspendedForTts = false;
-    if (_suspendedForManualRecording || _suspendedByUser) return;
+    if (_suspendedForManualRecording) return;
+    if (_suspendedByUser) return;
+    _resumeEngagement();
+  }
+
+  /// Re-opens an engagement after a soft-suspend (TTS / manual recording /
+  /// user pause). Skips the [startSession] start-up guards because they
+  /// were already validated on the first start; the session is just being
+  /// re-engaged. Mirrors the pre-v2 inline `_startEngine` + state assign.
+  void _resumeEngagement() {
+    if (state is! HandsFreeIdle) return;
+    _engagement.engage();
+    _phase = HandsFreeListeningPhase.listening;
     _startEngine(_ref.read(appConfigProvider).vadConfig);
     state = _listeningOrBacklog();
   }
@@ -216,8 +235,12 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     // stopped by stopSession() / _terminateWithError()) keeps the process alive.
   }
 
-  // ── Public API ────────────────────────────────────────────────────────────
+  // ── Public API: lifecycle ─────────────────────────────────────────────────
 
+  /// Open an engagement: run the start-up guards, flip the audio session
+  /// to `.playAndRecord` and start the VAD engine. Invoked by the
+  /// existing UI auto-start path; T7 will later wire AirPods short-click
+  /// here directly.
   Future<void> startSession() async {
     if (state is! HandsFreeIdle && state is! HandsFreeSessionError) return;
 
@@ -271,9 +294,16 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
       body: 'Recording session active',
     ));
 
-    _jobs.clear();
-    _jobCounter = 0;
+    if (_jobs.isEmpty) {
+      _jobCounter = 0;
+    }
+    _phase = HandsFreeListeningPhase.listening;
+    _engagement.engage();
     _startEngine(_ref.read(appConfigProvider).vadConfig);
+    // State is left as-is — the controller transitions into a concrete
+    // [HandsFreeListening] (with the right phase) when the first engine
+    // event arrives. This matches the pre-v2 contract and keeps the
+    // session-start side effects behaviour-equivalent.
   }
 
   // ── Helpers — engine lifecycle ────────────────────────────────────────────
@@ -298,10 +328,14 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     // background while we tear down (P027, ADR-NET-002).
     _ref.read(sessionActiveProvider.notifier).state = false;
 
-    // Stop foreground service before engine teardown; on iOS this reverts the
-    // audio session category from playAndRecord back to ambient before the
-    // next (possibly unrelated) capture begins.
+    // P037 v2: stopService now defaults to AudioSessionTarget.playback so
+    // the app keeps the media-participant slot and AirPods buttons remain
+    // routed to its MPRemoteCommandCenter targets. The legacy ambient
+    // behaviour is still available via the new parameter for callers that
+    // want to fully yield.
     await _ref.read(backgroundServiceProvider).stopService();
+
+    _engagement.disengage();
 
     await _engineSub?.cancel();
     _engineSub = null;
@@ -323,12 +357,35 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     state = const HandsFreeIdle();
     _jobs.clear();
     _jobCounter = 0;
+    _suspendedForManualRecording = false;
     _suspendedByUser = false;
+    _suspendedForTts = false;
+    _phase = HandsFreeListeningPhase.listening;
+  }
+
+  /// Tear down the engine + audio session without draining the job queue
+  /// or clearing the [_suspendedForManualRecording] flag. Used by the
+  /// "soft pause" paths ([suspendForTts], [suspendForManualRecording],
+  /// [suspendByUser]) where we want to come back to listening shortly.
+  Future<void> _closeEngagement({
+    required AudioSessionTarget toAmbientFor,
+  }) async {
+    _ref.read(sessionActiveProvider.notifier).state = false;
+    await _ref
+        .read(backgroundServiceProvider)
+        .stopService(target: toAmbientFor);
+    _engagement.disengage();
+    await _engineSub?.cancel();
+    _engineSub = null;
+    await _engine?.stop();
+    _engine = null;
+    _phase = HandsFreeListeningPhase.listening;
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    unawaited(_engagement.dispose());
     // Clean up WAV files for any remaining unprocessed jobs.
     for (final job in _jobs) {
       unawaited(_cleanupWav(job.wavPath));
@@ -343,14 +400,19 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   void _onEngineEvent(HandsFreeEngineEvent event) {
     switch (event) {
       case EngineListening():
+        _phase = HandsFreeListeningPhase.listening;
         state = _listeningOrBacklog();
 
       case EngineCapturing():
         unawaited(_ref.read(ttsServiceProvider).stop());
-        state = HandsFreeCapturing(List<SegmentJob>.unmodifiable(_jobs));
+        _phase = HandsFreeListeningPhase.capturing;
+        // Inform the engagement layer so the 30 s timer is cancelled.
+        _engagement.markCaptureStarted();
+        state = _listeningOrBacklog();
 
       case EngineStopping():
-        state = HandsFreeStopping(List<SegmentJob>.unmodifiable(_jobs));
+        _phase = HandsFreeListeningPhase.stopping;
+        state = _listeningOrBacklog();
 
       case EngineSegmentReady(wavPath: final path):
         _onSegmentReady(path);
@@ -504,14 +566,13 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
 
   // ── Helpers ──────────────────────────────────────────────────────────────
 
-  /// Returns [HandsFreeListening] or [HandsFreeWithBacklog] based on jobs.
+  /// Returns a [HandsFreeListening] state with the current jobs and
+  /// engine-driven [_phase]. Replaces the pre-v2 split between
+  /// `HandsFreeListening` and `HandsFreeWithBacklog` (the distinction is
+  /// recovered by inspecting `jobs` if needed).
   HandsFreeSessionState _listeningOrBacklog() {
-    final active = _jobs.any((j) =>
-        j.state is Transcribing ||
-        j.state is Persisting ||
-        j.state is QueuedForTranscription);
     final jobs = List<SegmentJob>.unmodifiable(_jobs);
-    return active ? HandsFreeWithBacklog(jobs) : HandsFreeListening(jobs);
+    return HandsFreeListening(jobs, phase: _phase);
   }
 
   void _terminateWithError(
@@ -522,6 +583,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     // immediately (P027, ADR-NET-002).
     _ref.read(sessionActiveProvider.notifier).state = false;
     unawaited(_ref.read(backgroundServiceProvider).stopService());
+    _engagement.markError(message);
     unawaited(_engineSub?.cancel());
     _engineSub = null;
     unawaited(_engine?.stop());

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -77,15 +77,13 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
     } else if (recState is RecordingPaused) {
       debugPrint('[MediaButtonDbg] branch=resumeRecording');
       unawaited(recCtrl.resumeRecording());
-    } else if (hfState is HandsFreeListening ||
-        hfState is HandsFreeWithBacklog ||
-        hfState is HandsFreeCapturing) {
+    } else if (hfState is HandsFreeListening) {
       debugPrint('[MediaButtonDbg] branch=hfSuspend');
       unawaited(hfCtrl.toggleUserSuspend().then((_) {
         ref.read(toasterProvider).show('Paused');
         ref.read(hapticServiceProvider).lightImpact();
       }));
-    } else if (hfState is HandsFreeSuspendedByUser) {
+    } else if (hfState is HandsFreeIdle) {
       debugPrint('[MediaButtonDbg] branch=hfResume');
       unawaited(hfCtrl.toggleUserSuspend().then((_) {
         ref.read(toasterProvider).show('Resumed');
@@ -121,7 +119,8 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
 
     // Clear agent reply when hands-free starts capturing
     ref.listen<HandsFreeSessionState>(handsFreeControllerProvider, (prev, next) {
-      if (next is HandsFreeCapturing) {
+      if (next is HandsFreeListening &&
+          next.phase == HandsFreeListeningPhase.capturing) {
         ref.read(latestAgentReplyProvider.notifier).state = null;
       }
     });
@@ -144,11 +143,7 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
     // already real output).
     ref.listen<HandsFreeSessionState>(handsFreeControllerProvider, (prev, next) {
       final ttsPlaying = ref.read(ttsPlayingProvider);
-      final shouldKeepAlive = !ttsPlaying &&
-          (next is HandsFreeListening ||
-              next is HandsFreeWithBacklog ||
-              next is HandsFreeCapturing ||
-              next is HandsFreeSuspendedByUser);
+      final shouldKeepAlive = !ttsPlaying && next is HandsFreeListening;
       if (shouldKeepAlive) {
         unawaited(_keepAlivePlayer?.start());
       } else {
@@ -162,10 +157,7 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
         unawaited(_keepAlivePlayer?.stop());
       } else {
         final hfState = ref.read(handsFreeControllerProvider);
-        if (hfState is HandsFreeListening ||
-            hfState is HandsFreeWithBacklog ||
-            hfState is HandsFreeCapturing ||
-            hfState is HandsFreeSuspendedByUser) {
+        if (hfState is HandsFreeListening) {
           unawaited(_keepAlivePlayer?.start());
         }
       }
@@ -181,8 +173,9 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
     final isNewConversationDisabled = recState is RecordingActive ||
         recState is RecordingPaused ||
         recState is RecordingTranscribing ||
-        hfState is HandsFreeCapturing ||
-        hfState is HandsFreeStopping;
+        (hfState is HandsFreeListening &&
+            (hfState.phase == HandsFreeListeningPhase.capturing ||
+                hfState.phase == HandsFreeListeningPhase.stopping));
 
     return Scaffold(
       appBar: AppBar(
@@ -389,10 +382,6 @@ class _HandsFreeSection extends StatelessWidget {
 
   static List<SegmentJob> _jobsOf(HandsFreeSessionState s) => switch (s) {
         HandsFreeListening(:final jobs) => jobs,
-        HandsFreeWithBacklog(:final jobs) => jobs,
-        HandsFreeCapturing(:final jobs) => jobs,
-        HandsFreeStopping(:final jobs) => jobs,
-        HandsFreeSuspendedByUser(:final jobs) => jobs,
         HandsFreeSessionError(:final jobs) => jobs,
         HandsFreeIdle() => const [],
       };
@@ -418,12 +407,25 @@ class _HfStatusStrip extends StatelessWidget {
           requiresAppSettings: requiresAppSettings,
           onRetry: onRetry,
         ),
-      HandsFreeListening() => const _StatusText('Listening...'),
-      HandsFreeCapturing() => const _StatusText('Capturing...'),
-      HandsFreeStopping() => const _StatusText('Processing segment...'),
-      HandsFreeWithBacklog() => const _StatusText('Listening (jobs pending)...'),
-      HandsFreeSuspendedByUser() => const _StatusText('Listening paused'),
+      HandsFreeListening(:final phase, :final jobs) =>
+        _StatusText(_listeningStatusText(phase, jobs)),
       HandsFreeIdle() => const SizedBox.shrink(),
+    };
+  }
+
+  static String _listeningStatusText(
+    HandsFreeListeningPhase phase,
+    List<SegmentJob> jobs,
+  ) {
+    final hasBacklog = jobs.any((j) =>
+        j.state is QueuedForTranscription ||
+        j.state is Transcribing ||
+        j.state is Persisting);
+    return switch (phase) {
+      HandsFreeListeningPhase.capturing => 'Capturing...',
+      HandsFreeListeningPhase.stopping => 'Processing segment...',
+      HandsFreeListeningPhase.listening =>
+        hasBacklog ? 'Listening (jobs pending)...' : 'Listening...',
     };
   }
 }
@@ -529,7 +531,10 @@ class _MicButtonState extends ConsumerState<_MicButton> {
     final hfCtrl = ref.read(handsFreeControllerProvider.notifier);
 
     if (recState is RecordingIdle) {
-      if (hfState is HandsFreeStopping) return; // no-op — wait for stop
+      if (hfState is HandsFreeListening &&
+          hfState.phase == HandsFreeListeningPhase.stopping) {
+        return; // no-op — wait for stop
+      }
       ref.read(latestAgentReplyProvider.notifier).state = null;
       await ref.read(ttsServiceProvider).stop();
       await hfCtrl.suspendForManualRecording();
@@ -549,7 +554,10 @@ class _MicButtonState extends ConsumerState<_MicButton> {
 
     // Only start if idle and engine not stopping.
     if (recState is! RecordingIdle) return;
-    if (hfState is HandsFreeStopping) return;
+    if (hfState is HandsFreeListening &&
+        hfState.phase == HandsFreeListeningPhase.stopping) {
+      return;
+    }
 
     _longPressActive = true;
     setState(() => _isPressAndHold = true);
@@ -580,7 +588,8 @@ class _MicButtonState extends ConsumerState<_MicButton> {
     final isRecording = recState is RecordingActive;
     final isPaused = recState is RecordingPaused;
     final isTranscribing = recState is RecordingTranscribing;
-    final isHfCapturing = hfState is HandsFreeCapturing;
+    final isHfCapturing = hfState is HandsFreeListening &&
+        hfState.phase == HandsFreeListeningPhase.capturing;
 
     // Clear press-and-hold flag when recording returns to idle or errors out.
     ref.listen<RecordingState>(recordingControllerProvider, (_, next) {

--- a/test/features/recording/domain/hands_free_session_state_test.dart
+++ b/test/features/recording/domain/hands_free_session_state_test.dart
@@ -4,14 +4,12 @@ import 'package:voice_agent/features/recording/domain/hands_free_session_state.d
 import 'package:voice_agent/features/recording/domain/segment_job.dart';
 
 void main() {
-  group('HandsFreeSessionState sealed class exhaustiveness', () {
+  group('HandsFreeSessionState sealed class exhaustiveness (P037 v2)', () {
     final states = <HandsFreeSessionState>[
       const HandsFreeIdle(),
       const HandsFreeListening([]),
-      const HandsFreeCapturing([]),
-      const HandsFreeStopping([]),
-      const HandsFreeWithBacklog([]),
-      const HandsFreeSuspendedByUser([]),
+      const HandsFreeListening([], phase: HandsFreeListeningPhase.capturing),
+      const HandsFreeListening([], phase: HandsFreeListeningPhase.stopping),
       const HandsFreeSessionError(message: 'oops'),
     ];
 
@@ -22,19 +20,30 @@ void main() {
             break;
           case HandsFreeListening():
             break;
-          case HandsFreeCapturing():
-            break;
-          case HandsFreeStopping():
-            break;
-          case HandsFreeWithBacklog():
-            break;
-          case HandsFreeSuspendedByUser():
-            break;
           case HandsFreeSessionError():
             break;
         }
       }
-      expect(states.length, 7);
+      expect(states.length, 5);
+    });
+
+    test('HandsFreeListening defaults to listening phase', () {
+      const s = HandsFreeListening([]);
+      expect(s.phase, HandsFreeListeningPhase.listening);
+      expect(s.jobs, isEmpty);
+    });
+
+    test('HandsFreeListening preserves phase + jobs', () {
+      final job = SegmentJob(
+        id: 'j1',
+        label: 'Segment 1',
+        state: const Transcribing(),
+      );
+      final s = HandsFreeListening([job],
+          phase: HandsFreeListeningPhase.capturing);
+      expect(s.phase, HandsFreeListeningPhase.capturing);
+      expect(s.jobs, hasLength(1));
+      expect(s.jobs.first.id, 'j1');
     });
   });
 

--- a/test/features/recording/presentation/hands_free_controller_pause_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_pause_test.dart
@@ -214,7 +214,7 @@ void main() {
   setUpAll(() => WidgetsFlutterBinding.ensureInitialized());
 
   group('suspendByUser', () {
-    test('from listening transitions to HandsFreeSuspendedByUser', () async {
+    test('from listening transitions to HandsFreeIdle (P037 v2)', () async {
       final engine = _FakeHandsFreeEngine();
       final c = _makeContainer(engine: engine);
       await _ctrl(c).startSession();
@@ -224,7 +224,7 @@ void main() {
 
       await _ctrl(c).suspendByUser();
 
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
     });
 
     test('is no-op when already suspended by user', () async {
@@ -235,11 +235,11 @@ void main() {
       await Future.delayed(Duration.zero);
 
       await _ctrl(c).suspendByUser();
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
 
       // Second call should be no-op
       await _ctrl(c).suspendByUser();
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
     });
 
     test('is no-op from HandsFreeIdle', () async {
@@ -274,7 +274,7 @@ void main() {
       // Now suspend by user — should take the fast path
       await _ctrl(c).suspendByUser();
 
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
     });
   });
 
@@ -287,7 +287,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       await _ctrl(c).suspendByUser();
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
 
       engine.started = false;
       await _ctrl(c).resumeByUser();
@@ -317,7 +317,7 @@ void main() {
 
       await _ctrl(c).suspendForTts();
       await _ctrl(c).suspendByUser();
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
 
       engine.started = false;
       engine.startCount = 0;
@@ -338,7 +338,7 @@ void main() {
 
       await _ctrl(c).suspendForManualRecording();
       await _ctrl(c).suspendByUser();
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
 
       engine.started = false;
       engine.startCount = 0;
@@ -360,7 +360,7 @@ void main() {
       final result = await _ctrl(c).toggleUserSuspend();
 
       expect(result, isTrue);
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
     });
 
     test('resumes when already suspended', () async {
@@ -371,7 +371,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       await _ctrl(c).suspendByUser();
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
 
       final result = await _ctrl(c).toggleUserSuspend();
 
@@ -391,7 +391,7 @@ void main() {
       // TTS + user suspend
       await _ctrl(c).suspendForTts();
       await _ctrl(c).suspendByUser();
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
 
       engine.started = false;
       engine.startCount = 0;
@@ -414,7 +414,7 @@ void main() {
 
       await _ctrl(c).suspendForManualRecording();
       await _ctrl(c).suspendByUser();
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
 
       engine.started = false;
       engine.startCount = 0;
@@ -436,7 +436,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       await _ctrl(c).suspendByUser();
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
 
       engine.started = false;
       engine.startCount = 0;
@@ -457,7 +457,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       await _ctrl(c).suspendByUser();
-      expect(_stateOf(c), isA<HandsFreeSuspendedByUser>());
+      expect(_stateOf(c), isA<HandsFreeIdle>());
 
       await _ctrl(c).stopSession();
 

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -56,7 +56,9 @@ class _TrackingBackgroundService implements BackgroundService {
   }
 
   @override
-  Future<void> stopService() async {
+  Future<void> stopService({
+    AudioSessionTarget target = AudioSessionTarget.playback,
+  }) async {
     calls.add('stopService');
     _running = false;
     lastStopCompleted = DateTime.now();
@@ -391,13 +393,13 @@ HandsFreeSessionState stateOf(ProviderContainer c) =>
 /// Extracts jobs from any [HandsFreeSessionState] variant that carries them.
 List<SegmentJob> jobsOf(HandsFreeSessionState s) => switch (s) {
       HandsFreeListening(:final jobs) => jobs,
-      HandsFreeWithBacklog(:final jobs) => jobs,
-      HandsFreeCapturing(:final jobs) => jobs,
-      HandsFreeStopping(:final jobs) => jobs,
-      HandsFreeSuspendedByUser(:final jobs) => jobs,
       HandsFreeSessionError(:final jobs) => jobs,
       HandsFreeIdle() => [],
     };
+
+/// True when [s] is [HandsFreeListening] with the given [phase].
+bool isPhase(HandsFreeSessionState s, HandsFreeListeningPhase phase) =>
+    s is HandsFreeListening && s.phase == phase;
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -499,7 +501,7 @@ void main() {
       expect(stateOf(c), isA<HandsFreeListening>());
     });
 
-    test('EngineCapturing → HandsFreeCapturing', () async {
+    test('EngineCapturing → HandsFreeListening(phase=capturing)', () async {
       final engine = FakeHandsFreeEngine();
       final c = makeContainer(engine: engine);
       await ctrl(c).startSession();
@@ -507,7 +509,7 @@ void main() {
       engine.emit(const EngineCapturing());
       await Future.delayed(Duration.zero);
 
-      expect(stateOf(c), isA<HandsFreeCapturing>());
+      expect(isPhase(stateOf(c), HandsFreeListeningPhase.capturing), isTrue);
     });
 
     test('EngineCapturing → TtsService.stop() called', () async {
@@ -522,7 +524,7 @@ void main() {
       expect(spy.stopCount, 1);
     });
 
-    test('EngineStopping → HandsFreeStopping', () async {
+    test('EngineStopping → HandsFreeListening(phase=stopping)', () async {
       final engine = FakeHandsFreeEngine();
       final c = makeContainer(engine: engine);
       await ctrl(c).startSession();
@@ -530,10 +532,11 @@ void main() {
       engine.emit(const EngineStopping());
       await Future.delayed(Duration.zero);
 
-      expect(stateOf(c), isA<HandsFreeStopping>());
+      expect(isPhase(stateOf(c), HandsFreeListeningPhase.stopping), isTrue);
     });
 
-    test('EngineSegmentReady → job added, state becomes WithBacklog', () async {
+    test('EngineSegmentReady → job added, state still HandsFreeListening',
+        () async {
       final engine = FakeHandsFreeEngine();
       final c = makeContainer(engine: engine); // uses _HangingSttService
       await ctrl(c).startSession();
@@ -542,8 +545,8 @@ void main() {
       await Future.delayed(Duration.zero); // job transitions to Transcribing
 
       final s = stateOf(c);
-      expect(s, isA<HandsFreeWithBacklog>());
-      final jobs = (s as HandsFreeWithBacklog).jobs;
+      expect(s, isA<HandsFreeListening>());
+      final jobs = (s as HandsFreeListening).jobs;
       expect(jobs, hasLength(1));
       // After one microtask tick the job has transitioned from Queued → Transcribing.
       expect(jobs.first.state, isA<Transcribing>());
@@ -826,7 +829,7 @@ void main() {
       engine.emit(const EngineSegmentReady('/tmp/seg2.wav'));
       await Future.delayed(Duration.zero);
 
-      final jobs = (stateOf(c) as HandsFreeWithBacklog).jobs;
+      final jobs = (stateOf(c) as HandsFreeListening).jobs;
       expect(jobs, hasLength(2));
     });
 
@@ -937,7 +940,7 @@ void main() {
       }
       await Future.delayed(Duration.zero);
 
-      final jobs = (stateOf(c) as HandsFreeWithBacklog).jobs;
+      final jobs = (stateOf(c) as HandsFreeListening).jobs;
       expect(jobs, hasLength(4), reason: '5th segment must be dropped');
     });
 
@@ -989,6 +992,10 @@ void main() {
       final jobsBefore = jobsOf(stateOf(c)).length;
       await ctrl(c).suspendForManualRecording();
 
+      // P037 v2 collapses the suspended state into HandsFreeIdle, so the
+      // public job list isn't visible during the suspension. Resume to
+      // observe that the controller never cleared its internal _jobs list.
+      await ctrl(c).resumeAfterManualRecording();
       final jobsAfter = jobsOf(stateOf(c)).length;
       expect(jobsAfter, equals(jobsBefore),
           reason: 'suspendForManualRecording must not clear the job list');

--- a/test/helpers/stub_background_service.dart
+++ b/test/helpers/stub_background_service.dart
@@ -12,7 +12,10 @@ class StubBackgroundService implements BackgroundService {
   Future<void> startService() async => _running = true;
 
   @override
-  Future<void> stopService() async => _running = false;
+  Future<void> stopService({
+    AudioSessionTarget target = AudioSessionTarget.playback,
+  }) async =>
+      _running = false;
 
   @override
   Future<void> updateNotification({


### PR DESCRIPTION
## Summary

Implements the **core architectural refactor** for P037 v2 (tap-to-engage hands-free), tasks **T3 + T4 + T6 + T8** from `docs/proposals/037-airpods-listening-control.md` (v2 — Candidate B).

### State-model collapse (T8)

`HandsFreeSessionState` reduces to three variants:

- `HandsFreeIdle`
- `HandsFreeListening({jobs, phase})` — phase enum: `listening / capturing / stopping`
- `HandsFreeSessionError`

The previous `HandsFreeWithBacklog`, `HandsFreeCapturing`, `HandsFreeStopping`, and `HandsFreeSuspendedByUser` distinctions are gone:

- `WithBacklog` is recovered by inspecting `jobs` on `HandsFreeListening`.
- `Capturing` and `Stopping` become `phase` values on the same state.
- `SuspendedByUser` was a continuous-listening artefact; in the v2 one-shot model a "user pause" simply closes the engagement (state goes to `HandsFreeIdle`). The controller still tracks the suspension reason (`_suspendedByUser` / `_suspendedForTts` / `_suspendedForManualRecording`) so resume paths honour user intent and don't silently re-engage.

### EngagementController (T3 + T6)

New domain class at `lib/features/recording/domain/engagement_controller.dart`:

- States: `Idle / Listening / Capturing / Error` (sealed `EngagementState`)
- Methods: `engage()`, `disengage()`, `markCaptureStarted()`, `tickTimeout()`, `markError(message)`, `dispose()`
- Owns the 30 s auto-disengage timer (`kListeningEngagementTimeout`)
- Timer is cancelled on `markCaptureStarted` (VAD start-of-speech)
- Pure Dart — no Riverpod, no platform imports — so it stays in `domain/` per the dependency rule

`HandsFreeController` now embeds an `EngagementController` and calls `engage()` on session start, `markCaptureStarted()` on `EngineCapturing`, `disengage()` on suspends, and `markError()` on terminal errors. The 30 s configurable knob is hard-coded as a `Duration` constant in the controller — no `AppConfig` plumbing in this PR (deferred per the proposal).

### HandsFreeController one-shot refactor (T4)

- Public state machine collapses to `Idle ↔ Listening ↔ Error`
- Existing UI auto-start path (`startSession`) is preserved so the rest of the app keeps working without T7
- The legacy compatibility surface (`suspendForTts/resumeAfterTts`, `suspendForManualRecording/resumeAfterManualRecording`, `suspendByUser/resumeByUser/toggleUserSuspend`, `reloadVadConfig`) is retained — the methods now translate to engage/disengage on the underlying `EngagementController` while preserving the resume-priority semantics the old tests assert

### Audio-session bridge decision

The proposal's "wait — `setAmbient` is the old behaviour…" note offered two options for moving the post-disengage iOS audio session from `.ambient` to `.playback`:

- **(a)** add a third bridge method `setPlaybackOnly` mirroring the existing `setPlayback` (without the TTS save-state machinery), or
- **(b)** parameterise `BackgroundService.stopService()` to select target category.

**This PR does both, in their natural layers.**

- Native side (a): `AudioSessionBridge.swift` gains a `setPlaybackOnly` case that switches to `.playback` mode `.spokenAudio` without saving prior category — this is the new resting state, not a temporary detour around TTS so the save-state hook would be wrong.
- Dart side (b): `BackgroundService.stopService({AudioSessionTarget target = AudioSessionTarget.playback})` selects between the new `setPlaybackOnly` path and the legacy `setAmbient` path. The default flips from `.ambient` (pre-P037) to `.playback` (P037 v2) so AirPods media-button presses keep being routed to the app's `MPRemoteCommandCenter` targets after disengage. The legacy `.ambient` path remains available for callers that want to fully yield.

This avoids overloading the existing `setPlayback` (which intentionally saves the prior category for `restoreAudioSession`); the v2 disengage transition is not a TTS detour and shouldn't share that state machine.

### Acceptance criteria (proposal v2 §"Acceptance criteria")

Covered by this PR:

- [x] State-model and audio-session plumbing for "Default state after app open: Idle … silence loop running" (existing `KeepAliveSilentPlayer` retained per scope; AmbientLoopPlayer wiring deferred)
- [x] Engagement state machine + 30 s timer cancelled on VAD start-of-speech
- [x] `stopService` default flips to `.playback`, preserving AirPods routing in idle (the underlying mechanism for "AirPods short-click in Idle: engage…")

Need T7 to land:

- [ ] AirPods short-click in Idle → engage to Listening within 200 ms
- [ ] Manual disengage path via UI

Need T9 to land:

- [ ] "Listening loop audibly distinct from silence" UX (T1 asset already merged in #275; consumer wiring deferred per scope)
- [ ] "Tap to talk" / countdown UI text

Need T10 to land:

- [ ] Integration tests covering the full Idle → engage → speech → capture → disengage cycle
- [ ] VAD self-trigger regression test on the listening loop

## Test plan

- [x] `make verify` green (939 tests pass, analyzer clean)
- [x] Existing fixtures updated where state classes were removed (controller tests, pause tests, session-state exhaustiveness test)
- [x] No new tests added (out of scope per task instructions; T10 follow-up)
- [ ] Manual device verification deferred to T7/T9 PRs

## Open question

The proposal lists the `EngagementController` states as `Idle / Listening / Capturing / Error` (T3) but later says `HandsFreeSessionState` collapses to `Idle / Listening` (T8). Interpreted as: the engagement layer keeps the four states (because the timer is only meaningful before VAD start-of-speech), while the public session state collapses to Idle/Listening + a phase indicator. The `HandsFreeListeningPhase` enum bridges the two layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
