### PR TITLE
fix(recording): finish P037 v2 idle path + listener guard

### DIFF
--- a/ios/Runner/MediaButtonBridge.swift
+++ b/ios/Runner/MediaButtonBridge.swift
@@ -89,8 +89,18 @@ class MediaButtonBridge: NSObject, FlutterStreamHandler {
         center.pauseCommand.isEnabled = true
         center.pauseCommand.addTarget(handler: makeHandler("pause"))
 
+        // Proposal 037 T1+T2: hypothesis test. Are nextTrack / previousTrack
+        // (AirPods double-tap / triple-tap) gated by the same .playAndRecord
+        // call-mode rule as togglePlayPause? Targets are NSLog-only — we do
+        // NOT yet forward to Dart. The presence (or absence) of the
+        // "TARGET FIRED" log answers the hypothesis.
+        center.nextTrackCommand.isEnabled = true
+        center.nextTrackCommand.addTarget(handler: makeHandler("nextTrack"))
+        center.previousTrackCommand.isEnabled = true
+        center.previousTrackCommand.addTarget(handler: makeHandler("previousTrack"))
+
         // Diagnostic: confirm registration stuck.
-        NSLog("[MediaButtonDbg] toggle.enabled=\(center.togglePlayPauseCommand.isEnabled) play.enabled=\(center.playCommand.isEnabled) pause.enabled=\(center.pauseCommand.isEnabled)")
+        NSLog("[MediaButtonDbg] toggle.enabled=\(center.togglePlayPauseCommand.isEnabled) play.enabled=\(center.playCommand.isEnabled) pause.enabled=\(center.pauseCommand.isEnabled) next.enabled=\(center.nextTrackCommand.isEnabled) prev.enabled=\(center.previousTrackCommand.isEnabled)")
         startStatePolling()
 
         // Now-playing info must signal "actively playing" so iOS treats this
@@ -136,6 +146,10 @@ class MediaButtonBridge: NSObject, FlutterStreamHandler {
         center.playCommand.removeTarget(nil)
         center.pauseCommand.isEnabled = false
         center.pauseCommand.removeTarget(nil)
+        center.nextTrackCommand.isEnabled = false
+        center.nextTrackCommand.removeTarget(nil)
+        center.previousTrackCommand.isEnabled = false
+        center.previousTrackCommand.removeTarget(nil)
 
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
     }

--- a/ios/Runner/MediaButtonBridge.swift
+++ b/ios/Runner/MediaButtonBridge.swift
@@ -89,18 +89,8 @@ class MediaButtonBridge: NSObject, FlutterStreamHandler {
         center.pauseCommand.isEnabled = true
         center.pauseCommand.addTarget(handler: makeHandler("pause"))
 
-        // Proposal 037 T1+T2: hypothesis test. Are nextTrack / previousTrack
-        // (AirPods double-tap / triple-tap) gated by the same .playAndRecord
-        // call-mode rule as togglePlayPause? Targets are NSLog-only — we do
-        // NOT yet forward to Dart. The presence (or absence) of the
-        // "TARGET FIRED" log answers the hypothesis.
-        center.nextTrackCommand.isEnabled = true
-        center.nextTrackCommand.addTarget(handler: makeHandler("nextTrack"))
-        center.previousTrackCommand.isEnabled = true
-        center.previousTrackCommand.addTarget(handler: makeHandler("previousTrack"))
-
         // Diagnostic: confirm registration stuck.
-        NSLog("[MediaButtonDbg] toggle.enabled=\(center.togglePlayPauseCommand.isEnabled) play.enabled=\(center.playCommand.isEnabled) pause.enabled=\(center.pauseCommand.isEnabled) next.enabled=\(center.nextTrackCommand.isEnabled) prev.enabled=\(center.previousTrackCommand.isEnabled)")
+        NSLog("[MediaButtonDbg] toggle.enabled=\(center.togglePlayPauseCommand.isEnabled) play.enabled=\(center.playCommand.isEnabled) pause.enabled=\(center.pauseCommand.isEnabled)")
         startStatePolling()
 
         // Now-playing info must signal "actively playing" so iOS treats this
@@ -146,10 +136,6 @@ class MediaButtonBridge: NSObject, FlutterStreamHandler {
         center.playCommand.removeTarget(nil)
         center.pauseCommand.isEnabled = false
         center.pauseCommand.removeTarget(nil)
-        center.nextTrackCommand.isEnabled = false
-        center.nextTrackCommand.removeTarget(nil)
-        center.previousTrackCommand.isEnabled = false
-        center.previousTrackCommand.removeTarget(nil)
 
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
     }

--- a/lib/features/recording/domain/hands_free_session_state.dart
+++ b/lib/features/recording/domain/hands_free_session_state.dart
@@ -31,9 +31,13 @@ sealed class HandsFreeSessionState {
   const HandsFreeSessionState();
 }
 
-/// Session not running. No jobs.
+/// Session not running. The [jobs] list carries in-flight work from a
+/// previous engagement (P037 v2 one-shot model — STT/persistence
+/// continues asynchronously after the controller disengages).
 class HandsFreeIdle extends HandsFreeSessionState {
-  const HandsFreeIdle();
+  const HandsFreeIdle({this.jobs = const []});
+
+  final List<SegmentJob> jobs;
 }
 
 /// Session is engaged. The [phase] indicates the engine sub-state

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -55,7 +55,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     // engine down and reflect it in the public state. The re-entry
     // guard (`state is! HandsFreeIdle`) prevents recursion when
     // [_disengageOneShot] itself drives engagement to Idle.
-    _engagementSub = _engagement.stream.listen((engagementState) {
+    _engagementSub = _engagement.stream.listen((_) {
       // Guard against the controller being disposed mid-flight; stream
       // events may still arrive on the same microtask.
       if (!mounted) return;
@@ -140,7 +140,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     _engine = null;
     _engagement.disengage();
     _suspendedForManualRecording = true;
-    state = const HandsFreeIdle();
+    state = HandsFreeIdle(jobs: List.unmodifiable(_jobs));
   }
 
   /// Toggles user-initiated suspension. Called by media button dispatch.
@@ -170,7 +170,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
     _suspendedByUser = true;
     await _closeEngagement(toAmbientFor: AudioSessionTarget.playback);
-    state = const HandsFreeIdle();
+    state = HandsFreeIdle(jobs: List.unmodifiable(_jobs));
   }
 
   Future<void> resumeByUser() async {
@@ -221,7 +221,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
     _suspendedForTts = true;
     await _closeEngagement(toAmbientFor: AudioSessionTarget.playback);
-    state = const HandsFreeIdle();
+    state = HandsFreeIdle(jobs: List.unmodifiable(_jobs));
   }
 
   /// Re-engages after TTS finishes playing.
@@ -614,12 +614,19 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
 
   // ── Helpers ──────────────────────────────────────────────────────────────
 
-  /// Returns a [HandsFreeListening] state with the current jobs and
-  /// engine-driven [_phase]. Replaces the pre-v2 split between
-  /// `HandsFreeListening` and `HandsFreeWithBacklog` (the distinction is
-  /// recovered by inspecting `jobs` if needed).
+  /// Returns the current public state with an up-to-date [_jobs]
+  /// snapshot. Reads [_engagement.state] (not the current
+  /// [HandsFreeSessionState]) to decide between idle/listening — that
+  /// way job-progression updates from the async [_sttSlot] don't flip
+  /// [HandsFreeIdle] back to [HandsFreeListening] after a one-shot
+  /// disengage, while engine events that arrive after [startSession]
+  /// (when the public state is still the seeded [HandsFreeIdle]) still
+  /// drive the controller into [HandsFreeListening] correctly.
   HandsFreeSessionState _listeningOrBacklog() {
     final jobs = List<SegmentJob>.unmodifiable(_jobs);
+    if (_engagement.state is EngagementIdle) {
+      return HandsFreeIdle(jobs: jobs);
+    }
     return HandsFreeListening(jobs, phase: _phase);
   }
 

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -50,6 +50,24 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
       : _engagement = engagement ?? EngagementController(),
         super(const HandsFreeIdle()) {
     WidgetsBinding.instance.addObserver(this);
+    // P037 v2 one-shot model: when the engagement layer transitions to
+    // Idle externally (e.g. 30 s timer expiry without speech), tear the
+    // engine down and reflect it in the public state. The re-entry
+    // guard (`state is! HandsFreeIdle`) prevents recursion when
+    // [_disengageOneShot] itself drives engagement to Idle.
+    _engagementSub = _engagement.stream.listen((engagementState) {
+      // Guard against the controller being disposed mid-flight; stream
+      // events may still arrive on the same microtask.
+      if (!mounted) return;
+      // Re-read the current engagement state instead of trusting the
+      // emitted event: the event may be stale (e.g. a disengage→engage
+      // pair issued synchronously by suspend+resume produces two
+      // microtask events; by the time the first runs, engagement is
+      // already Listening again and we must not tear the engine down).
+      if (_engagement.state is EngagementIdle && state is! HandsFreeIdle) {
+        unawaited(_disengageOneShot());
+      }
+    });
   }
 
   final Ref _ref;
@@ -57,6 +75,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
 
   HandsFreeEngine? _engine;
   StreamSubscription<HandsFreeEngineEvent>? _engineSub;
+  StreamSubscription<EngagementState>? _engagementSub;
 
   // ── Job list ─────────────────────────────────────────────────────────────
   // Mutable list kept in controller; copied into each emitted state.
@@ -367,6 +386,30 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   /// or clearing the [_suspendedForManualRecording] flag. Used by the
   /// "soft pause" paths ([suspendForTts], [suspendForManualRecording],
   /// [suspendByUser]) where we want to come back to listening shortly.
+  /// P037 v2 one-shot: close the engagement after a captured utterance
+  /// or a 30 s silence timeout. Stops the engine, switches the audio
+  /// session back to .playback (so AirPods buttons keep routing), and
+  /// transitions to [HandsFreeIdle] preserving the in-flight job
+  /// queue. Does NOT drain jobs — STT and persistence continue
+  /// asynchronously via [_sttSlot].
+  Future<void> _disengageOneShot() async {
+    if (!mounted) return;
+    if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
+    _ref.read(sessionActiveProvider.notifier).state = false;
+    await _ref
+        .read(backgroundServiceProvider)
+        .stopService(target: AudioSessionTarget.playback);
+    if (!mounted) return;
+    _engagement.disengage();
+    await _engineSub?.cancel();
+    _engineSub = null;
+    await _engine?.stop();
+    _engine = null;
+    if (!mounted) return;
+    _phase = HandsFreeListeningPhase.listening;
+    state = HandsFreeIdle(jobs: List.unmodifiable(_jobs));
+  }
+
   Future<void> _closeEngagement({
     required AudioSessionTarget toAmbientFor,
   }) async {
@@ -385,6 +428,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    unawaited(_engagementSub?.cancel());
     unawaited(_engagement.dispose());
     // Clean up WAV files for any remaining unprocessed jobs.
     for (final job in _jobs) {
@@ -416,6 +460,10 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
 
       case EngineSegmentReady(wavPath: final path):
         _onSegmentReady(path);
+        // Note: engine continues listening after a segment in this
+        // commit. Full one-shot (disengage on segment ready) is
+        // deferred — it requires a coordinated update of ~25 tests
+        // that assume continuous mode.
 
       case EngineError(
           message: final msg,

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -35,11 +35,13 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        ref.read(handsFreeControllerProvider.notifier).startSession();
+        // P037 v2: app opens in Idle. User engages explicitly via
+        // AirPods short-click (handled in _onMediaButtonEvent) or the
+        // mic UI button. The previous auto-startSession in initState
+        // is removed — that was the continuous-listening contract from
+        // the pre-v2 model.
         _activateMediaButton();
         _ambientPlayer = AmbientLoopPlayer();
-        // Initial Idle silence; the listener below switches to listening
-        // mode as soon as the controller transitions to HandsFreeListening.
         unawaited(_ambientPlayer!.setMode(AmbientMode.idle));
       }
     });

--- a/test/app/app_shell_scaffold_test.dart
+++ b/test/app/app_shell_scaffold_test.dart
@@ -182,7 +182,12 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    expect(controller.startCalls, 1); // RecordingScreen.initState
+    // P037 v2: app opens in Idle. Engage explicitly to mirror the
+    // production AirPods short-click entry point so the tab-switch
+    // teardown has something to stop.
+    await controller.startSession();
+    await tester.pumpAndSettle();
+    expect(controller.startCalls, 1);
 
     await tester.tap(find.byIcon(Icons.calendar_today));
     await tester.pumpAndSettle();
@@ -205,13 +210,17 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
+    // v2: explicit engage first (replaces auto-start in initState).
+    await controller.startSession();
+    await tester.pumpAndSettle();
+
     await tester.tap(find.byIcon(Icons.calendar_today));
     await tester.pumpAndSettle(); // stopSession called, state → idle
 
     await tester.tap(recordNavIcon);
     await tester.pumpAndSettle();
 
-    expect(controller.startCalls, 2); // 1 from initState + 1 from tab return
+    expect(controller.startCalls, 2); // 1 manual engage + 1 from tab return
   });
 
   testWidgets('session recovers when user returns to Record during stopSession drain',
@@ -231,6 +240,9 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
+    // v2: explicit engage first (replaces auto-start in initState).
+    await controller.startSession();
+    await tester.pumpAndSettle();
     expect(controller.startCalls, 1);
 
     // Navigate away — stopSession starts but won't finish until drainCompleter fires.

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -394,7 +394,7 @@ HandsFreeSessionState stateOf(ProviderContainer c) =>
 List<SegmentJob> jobsOf(HandsFreeSessionState s) => switch (s) {
       HandsFreeListening(:final jobs) => jobs,
       HandsFreeSessionError(:final jobs) => jobs,
-      HandsFreeIdle() => [],
+      HandsFreeIdle(:final jobs) => jobs,
     };
 
 /// True when [s] is [HandsFreeListening] with the given [phase].
@@ -548,7 +548,6 @@ void main() {
       expect(s, isA<HandsFreeListening>());
       final jobs = (s as HandsFreeListening).jobs;
       expect(jobs, hasLength(1));
-      // After one microtask tick the job has transitioned from Queued → Transcribing.
       expect(jobs.first.state, isA<Transcribing>());
       expect(jobs.first.wavPath, '/tmp/seg1.wav');
     });

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -17,6 +17,7 @@ import 'package:voice_agent/core/providers/session_active_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
 import 'package:voice_agent/core/config/vad_config.dart';
+import 'package:voice_agent/features/recording/domain/engagement_controller.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_session_state.dart';
 import 'package:voice_agent/features/recording/domain/recording_result.dart';
@@ -1061,4 +1062,95 @@ void main() {
           reason: 'resumeAfterManualRecording must not reset _jobs');
     });
   });
+
+  // ── Auto-disengage with in-flight jobs (P037 v2 regression) ────────────────
+  group('auto-disengage with in-flight jobs', () {
+    test('STT completing after auto-disengage keeps state HandsFreeIdle',
+        () async {
+      // Reproduces the regression where _processJob's
+      // `state = _listeningOrBacklog()` flipped HandsFreeIdle back to
+      // HandsFreeListening when a job state advanced (Transcribing →
+      // Persisting → Completed) while engagement was already closed.
+      final engine = FakeHandsFreeEngine();
+      final sttCompleter = Completer<TranscriptResult>();
+      final stt = _ControllableSttService(sttCompleter);
+      final storage = FakeStorageService();
+      final engagement =
+          EngagementController(timeout: const Duration(milliseconds: 5));
+
+      final container = ProviderContainer(overrides: [
+        handsFreeEngineProvider.overrideWithValue(engine),
+        appConfigServiceProvider.overrideWithValue(
+          _FixedConfigService(const AppConfig(
+            groqApiKey: 'gsk_test_valid',
+            apiUrl: 'https://test.example.com/api',
+          )),
+        ),
+        recordingControllerProvider.overrideWith(
+          (ref) => _IdleRecordingController(ref),
+        ),
+        sttServiceProvider.overrideWithValue(stt),
+        storageServiceProvider.overrideWithValue(storage),
+        ttsServiceProvider.overrideWithValue(_StubTtsService()),
+        audioFeedbackServiceProvider.overrideWithValue(
+          _StubAudioFeedbackService(),
+        ),
+        backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
+        handsFreeControllerProvider.overrideWith(
+          (ref) => HandsFreeController(ref, engagement: engagement),
+        ),
+      ]);
+      addTearDown(container.dispose);
+
+      await container.read(handsFreeControllerProvider.notifier).startSession();
+      engine.emit(const EngineSegmentReady('/tmp/seg1.wav'));
+      await Future.delayed(Duration.zero); // Queued → Transcribing
+
+      // Trigger the 30 s auto-disengage. Listener microtask runs and the
+      // controller should transition to HandsFreeIdle preserving the
+      // Transcribing job in `jobs`.
+      engagement.tickTimeout();
+      await Future.delayed(const Duration(milliseconds: 10));
+      expect(
+        container.read(handsFreeControllerProvider),
+        isA<HandsFreeIdle>(),
+        reason: 'auto-disengage should land in HandsFreeIdle',
+      );
+
+      // Now finish STT — this triggers the original bug if
+      // _listeningOrBacklog ignores the current Idle state.
+      sttCompleter.complete(TranscriptResult(
+        text: 'Hello',
+        segments: [],
+        detectedLanguage: 'en',
+        audioDurationMs: 1000,
+      ));
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      final after = container.read(handsFreeControllerProvider);
+      expect(after, isA<HandsFreeIdle>(),
+          reason:
+              'job advances must not flip HandsFreeIdle back to Listening');
+      final jobs = jobsOf(after);
+      expect(jobs, hasLength(1));
+      expect(jobs.first.state, isA<Completed>(),
+          reason: 'job state must reflect post-STT progression');
+    });
+  });
+}
+
+class _ControllableSttService implements SttService {
+  _ControllableSttService(this._completer);
+  final Completer<TranscriptResult> _completer;
+
+  @override
+  Future<TranscriptResult> transcribe(String wavPath,
+          {String? languageCode}) =>
+      _completer.future;
+
+  @override
+  Future<bool> isModelLoaded() async => true;
+  @override
+  Future<void> loadModel() async {}
 }

--- a/test/features/recording/presentation/recording_screen_hands_free_test.dart
+++ b/test/features/recording/presentation/recording_screen_hands_free_test.dart
@@ -149,14 +149,31 @@ Future<void> pumpRecordScreen(
   WidgetTester tester, {
   required FakeHfEngine engine,
   List<Override> extra = const [],
+  bool engageAfterPump = true,
 }) async {
+  late ProviderContainer container;
   await tester.pumpWidget(
     ProviderScope(
       overrides: [...baseOverrides(engine), ...extra],
-      child: const App(),
+      child: Builder(
+        builder: (context) {
+          container = ProviderScope.containerOf(context);
+          return const App();
+        },
+      ),
     ),
   );
   await tester.pumpAndSettle();
+
+  // P037 v2: app opens in HandsFreeIdle (no auto-start). Tests that
+  // exercise the listening state machine engage explicitly here, which
+  // mirrors the AirPods short-click entry point in production.
+  if (engageAfterPump) {
+    await container
+        .read(handsFreeControllerProvider.notifier)
+        .startSession();
+    await tester.pumpAndSettle();
+  }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -164,13 +181,15 @@ Future<void> pumpRecordScreen(
 void main() {
   setUpAll(() => WidgetsFlutterBinding.ensureInitialized());
 
-  group('auto-start', () {
-    testWidgets('hands-free session starts automatically on screen load',
+  group('auto-start (P037 v2: removed)', () {
+    testWidgets('hands-free session does NOT auto-start on screen load',
         (tester) async {
       final engine = FakeHfEngine();
-      await pumpRecordScreen(tester, engine: engine);
+      await pumpRecordScreen(tester, engine: engine, engageAfterPump: false);
 
-      expect(engine.started, isTrue);
+      // v2 contract: app opens in Idle. Engagement requires an explicit
+      // user action (AirPods short-click → startSession).
+      expect(engine.started, isFalse);
     });
   });
 
@@ -248,6 +267,11 @@ void main() {
           }),
         ),
       );
+      await tester.pumpAndSettle();
+      // v2: explicit engage replaces the legacy auto-start.
+      await container
+          .read(handsFreeControllerProvider.notifier)
+          .startSession();
       await tester.pumpAndSettle();
 
       expect(container.read(latestAgentReplyProvider), 'stale reply');

--- a/test/features/recording/presentation/recording_screen_new_conversation_test.dart
+++ b/test/features/recording/presentation/recording_screen_new_conversation_test.dart
@@ -313,12 +313,23 @@ void main() {
     testWidgets('button is disabled when hands-free is capturing',
         (tester) async {
       final engine = _FakeHfEngine();
+      late ProviderContainer container;
       await tester.pumpWidget(
         ProviderScope(
           overrides: _baseOverrides(engine: engine),
-          child: const App(),
+          child: Builder(builder: (context) {
+            container = ProviderScope.containerOf(context);
+            return const App();
+          }),
         ),
       );
+      await tester.pumpAndSettle();
+
+      // P037 v2: app opens in Idle. Engage so the controller subscribes
+      // to the engine stream and reflects the emitted phase.
+      await container
+          .read(handsFreeControllerProvider.notifier)
+          .startSession();
       await tester.pumpAndSettle();
 
       engine.emit(const EngineCapturing());
@@ -333,12 +344,21 @@ void main() {
     testWidgets('button is disabled when hands-free is stopping',
         (tester) async {
       final engine = _FakeHfEngine();
+      late ProviderContainer container;
       await tester.pumpWidget(
         ProviderScope(
           overrides: _baseOverrides(engine: engine),
-          child: const App(),
+          child: Builder(builder: (context) {
+            container = ProviderScope.containerOf(context);
+            return const App();
+          }),
         ),
       );
+      await tester.pumpAndSettle();
+
+      await container
+          .read(handsFreeControllerProvider.notifier)
+          .startSession();
       await tester.pumpAndSettle();
 
       engine.emit(const EngineStopping());
@@ -382,6 +402,7 @@ void main() {
       final toaster = _SpyToaster();
       final haptic = _SpyHapticService();
       final engine = _FakeHfEngine();
+      late ProviderContainer container;
 
       await tester.pumpWidget(
         ProviderScope(
@@ -391,9 +412,17 @@ void main() {
             toaster: toaster,
             hapticService: haptic,
           ),
-          child: const App(),
+          child: Builder(builder: (context) {
+            container = ProviderScope.containerOf(context);
+            return const App();
+          }),
         ),
       );
+      await tester.pumpAndSettle();
+
+      await container
+          .read(handsFreeControllerProvider.notifier)
+          .startSession();
       await tester.pumpAndSettle();
 
       engine.emit(const EngineCapturing());

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -124,6 +124,7 @@ void main() {
 
   testWidgets('Record screen shows error when API URL not configured',
       (tester) async {
+    late ProviderContainer container;
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -132,9 +133,19 @@ void main() {
             _FixedConfigService(const AppConfig(groqApiKey: 'test-key', apiUrl: null)),
           ),
         ],
-        child: const App(),
+        child: Builder(builder: (context) {
+          container = ProviderScope.containerOf(context);
+          return const App();
+        }),
       ),
     );
+    await tester.pumpAndSettle();
+
+    // P037 v2: app opens in Idle. Engage explicitly so the missing-API-URL
+    // guard fires and surfaces the banner.
+    await container
+        .read(handsFreeControllerProvider.notifier)
+        .startSession();
     await tester.pumpAndSettle();
 
     expect(find.text('API URL not set.'), findsOneWidget);


### PR DESCRIPTION
## Summary

- Guard the engagement stream listener and `_disengageOneShot` against stale events / disposed-controller crashes.
- Make the public state robustly track engagement: `_listeningOrBacklog` reads `_engagement.state` so async job-progression updates can't flip `HandsFreeIdle` back to `HandsFreeListening` after a one-shot disengage.
- `HandsFreeIdle` carries `jobs` so in-flight STT/persistence stays visible after engagement closes (timeout + soft-suspend paths).
- `RecordingScreen.initState` no longer auto-starts; engagement is explicit (AirPods short-click / mic UI). Tests engage explicitly where they previously relied on auto-start.

## Why

`HandsFreeController._engagementSub` reacts to `EngagementIdle` by calling `_disengageOneShot()`. In the suspend→resume path the listener runs in a microtask after both events have fired, so by the time it sees the (stale) `Idle` event, engagement is already back to `Listening`. The listener then awaited `stopService` and crashed when assigning `state =` on a disposed controller in tests.

Fixes:
- Listener re-reads `_engagement.state` instead of trusting the emitted event.
- `_disengageOneShot` adds `mounted` guards after each `await`.
- `_listeningOrBacklog` decides idle vs. listening from `_engagement.state` rather than the current public state, so a job state advance during the Idle window stays Idle.

## Scope note (per-segment one-shot still deferred)

This PR lands the engagement-driven idle path and the 30 s auto-disengage. Closing the engagement on every `EngineSegmentReady` (true per-segment one-shot — the user-visible "Wraca do nasłuchu z tym zapętlonym tonem" symptom) is left as a follow-up; the comment in `_onEngineEvent` calls this out explicitly.

## Test plan

- [x] `flutter test` — 940/940 pass (new regression test added)
- [x] `flutter analyze` — no issues
- [x] Regression test verified red without the fix
- [ ] On-device: app opens in Idle (silence), AirPods short-click engages, 30 s auto-disengage closes engagement, segment is transcribed and persisted while the public state stays Idle.
