### PR TITLE
feat(recording): per-segment one-shot disengage + Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deps vad-model analyze test verify clean setup doctor env run-web run-ios run-ios-dev run-macos simulator install-ios install-ios-dev help
+.PHONY: deps vad-model analyze test verify clean setup doctor env run-web run-ios run-ios-dev run-macos simulator install-ios install-ios-dev install-ios-dev-debug help
 
 MODEL_DIR := assets/models
 
@@ -105,30 +105,41 @@ run-macos:
 simulator:
 	@open -a Simulator
 
-## install-ios: Build and install stable on a physical iOS device (USB or wireless)
-install-ios:
-	@DEVICE_ID=$$(flutter devices 2>/dev/null | grep '• ios •' | head -1 | awk -F'•' '{gsub(/^[ \t]+|[ \t]+$$/, "", $$2); print $$2}'); \
-	if [ -z "$$DEVICE_ID" ]; then \
-		echo "ERROR: No physical iOS device found."; \
-		echo "Connect your iPhone via USB or enable wireless debugging:"; \
-		echo "  Xcode > Window > Devices and Simulators > pair your device"; \
-		exit 1; \
-	fi; \
-	DEVICE_NAME=$$(flutter devices 2>/dev/null | grep '• ios •' | head -1 | awk -F'•' '{gsub(/[ \t]+$$/, "", $$1); print $$1}'); \
-	echo "Installing stable on: $$DEVICE_NAME ($$DEVICE_ID)"; \
-	flutter run -d "$$DEVICE_ID" --flavor stable $(DART_DEFINE_FLAG)
+# Splits flutter-devices output on '•' (with surrounding spaces collapsed).
+# Field layout: $$1=name, $$2=id, $$3=platform, $$4=os version. The
+# previous `grep '• ios •'` filter was brittle — flutter pads the
+# platform column with whitespace so the literal pattern never matched
+# on recent versions. Using awk's regex field separator handles any
+# spacing.
+IOS_DEVICE_ID = flutter devices 2>/dev/null | awk -F' *• *' '$$3=="ios"{print $$2; exit}'
+IOS_DEVICE_NAME = flutter devices 2>/dev/null | awk -F' *• *' '$$3=="ios"{print $$1; exit}'
+IOS_NOT_FOUND = echo "ERROR: No physical iOS device found."; \
+	echo "Connect your iPhone via USB or enable wireless debugging:"; \
+	echo "  Xcode > Window > Devices and Simulators > pair your device"; \
+	exit 1
 
-## install-ios-dev: Build and install dev on a physical iOS device (USB or wireless)
+## install-ios: Build and install stable (release) on a physical iOS device
+install-ios:
+	@DEVICE_ID=$$($(IOS_DEVICE_ID)); \
+	if [ -z "$$DEVICE_ID" ]; then $(IOS_NOT_FOUND); fi; \
+	DEVICE_NAME=$$($(IOS_DEVICE_NAME)); \
+	echo "Installing stable (release) on: $$DEVICE_NAME ($$DEVICE_ID)"; \
+	flutter run -d "$$DEVICE_ID" --flavor stable --release $(DART_DEFINE_FLAG)
+
+## install-ios-dev: Build and install dev (release) on a physical iOS device
 install-ios-dev:
-	@DEVICE_ID=$$(flutter devices 2>/dev/null | grep '• ios •' | head -1 | awk -F'•' '{gsub(/^[ \t]+|[ \t]+$$/, "", $$2); print $$2}'); \
-	if [ -z "$$DEVICE_ID" ]; then \
-		echo "ERROR: No physical iOS device found."; \
-		echo "Connect your iPhone via USB or enable wireless debugging:"; \
-		echo "  Xcode > Window > Devices and Simulators > pair your device"; \
-		exit 1; \
-	fi; \
-	DEVICE_NAME=$$(flutter devices 2>/dev/null | grep '• ios •' | head -1 | awk -F'•' '{gsub(/[ \t]+$$/, "", $$1); print $$1}'); \
-	echo "Installing dev on: $$DEVICE_NAME ($$DEVICE_ID)"; \
+	@DEVICE_ID=$$($(IOS_DEVICE_ID)); \
+	if [ -z "$$DEVICE_ID" ]; then $(IOS_NOT_FOUND); fi; \
+	DEVICE_NAME=$$($(IOS_DEVICE_NAME)); \
+	echo "Installing dev (release) on: $$DEVICE_NAME ($$DEVICE_ID)"; \
+	flutter run -d "$$DEVICE_ID" --flavor dev --release $(DART_DEFINE_FLAG)
+
+## install-ios-dev-debug: Build and install dev (debug, hot reload) on a physical iOS device
+install-ios-dev-debug:
+	@DEVICE_ID=$$($(IOS_DEVICE_ID)); \
+	if [ -z "$$DEVICE_ID" ]; then $(IOS_NOT_FOUND); fi; \
+	DEVICE_NAME=$$($(IOS_DEVICE_NAME)); \
+	echo "Installing dev (debug) on: $$DEVICE_NAME ($$DEVICE_ID)"; \
 	flutter run -d "$$DEVICE_ID" --flavor dev $(DART_DEFINE_FLAG)
 
 ## devices: List available devices

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -341,7 +341,11 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
 
   @override
   Future<void> stopSession() async {
-    if (state is HandsFreeIdle) return;
+    // P037 v2 one-shot: when [HandsFreeIdle] is reached via per-segment
+    // disengage, [_jobs] may still hold in-flight transcripts. Treat
+    // [stopSession] as the explicit "drain everything" entry point —
+    // only short-circuit if both the engagement and the queue are quiet.
+    if (state is HandsFreeIdle && _jobs.isEmpty) return;
 
     // Flip the session-active flag early so SyncWorker stops draining in the
     // background while we tear down (P027, ADR-NET-002).
@@ -460,10 +464,12 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
 
       case EngineSegmentReady(wavPath: final path):
         _onSegmentReady(path);
-        // Note: engine continues listening after a segment in this
-        // commit. Full one-shot (disengage on segment ready) is
-        // deferred — it requires a coordinated update of ~25 tests
-        // that assume continuous mode.
+        // P037 v2 one-shot: VAD has emitted an utterance, so close the
+        // engagement. STT and persistence continue asynchronously on
+        // [_sttSlot]; the public state transitions to [HandsFreeIdle]
+        // (with the in-flight job preserved). Re-engaging requires a
+        // fresh user action (AirPods short-click / mic UI).
+        unawaited(_disengageOneShot());
 
       case EngineError(
           message: final msg,

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -536,18 +536,21 @@ void main() {
       expect(isPhase(stateOf(c), HandsFreeListeningPhase.stopping), isTrue);
     });
 
-    test('EngineSegmentReady → job added, state still HandsFreeListening',
-        () async {
+    test('EngineSegmentReady → job added, state collapses to HandsFreeIdle '
+        '(P037 v2 one-shot)', () async {
       final engine = FakeHandsFreeEngine();
       final c = makeContainer(engine: engine); // uses _HangingSttService
       await ctrl(c).startSession();
 
       engine.emit(const EngineSegmentReady('/tmp/seg1.wav'));
-      await Future.delayed(Duration.zero); // job transitions to Transcribing
+      // Two microtask ticks: one for job → Transcribing, one for the
+      // _disengageOneShot listener to land state in HandsFreeIdle.
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
 
       final s = stateOf(c);
-      expect(s, isA<HandsFreeListening>());
-      final jobs = (s as HandsFreeListening).jobs;
+      expect(s, isA<HandsFreeIdle>());
+      final jobs = (s as HandsFreeIdle).jobs;
       expect(jobs, hasLength(1));
       expect(jobs.first.state, isA<Transcribing>());
       expect(jobs.first.wavPath, '/tmp/seg1.wav');
@@ -794,17 +797,21 @@ void main() {
     });
 
     test('queued jobs rejected and WAVs cleaned up on stop', () async {
-      // Use a slow STT (50ms) so seg1 stays in Transcribing when stopSession
-      // is called, seg2 stays in QueuedForTranscription.
-      // stopSession() rejects seg2 synchronously, then drains seg1 (~50ms).
-      // Only seg1's transcript should be saved; seg2 never reaches STT.
+      // P037 v2 one-shot: each segment closes the engagement, so the
+      // backlog is built up across multiple engage→segment cycles.
+      // Use a slow STT (50ms) so seg1 stays in Transcribing while seg2
+      // sits Queued behind it on _sttSlot. stopSession() rejects seg2
+      // synchronously, then drains seg1 (~50ms).
       final stt = _SlowSttService(text: 'Hello');
       final storage = FakeStorageService();
       final engine = FakeHandsFreeEngine();
       final c = makeContainer(engine: engine, sttService: stt, storageService: storage);
       await ctrl(c).startSession();
-
       engine.emit(const EngineSegmentReady('/tmp/seg1.wav'));
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero); // disengage lands
+
+      await ctrl(c).startSession();
       engine.emit(const EngineSegmentReady('/tmp/seg2.wav'));
       await Future.delayed(Duration.zero); // seg1 → Transcribing, seg2 → Queued
 
@@ -821,16 +828,22 @@ void main() {
 
   group('job tracking', () {
     test('multiple segments → job list grows monotonically', () async {
+      // P037 v2: each segment closes the engagement, so multi-segment
+      // accumulation requires re-engaging between segments. The job
+      // list must persist across the engagement cycle.
       final engine = FakeHandsFreeEngine();
-      final c = makeContainer(engine: engine);
+      final c = makeContainer(engine: engine); // hanging STT keeps jobs in flight
       await ctrl(c).startSession();
-
       engine.emit(const EngineSegmentReady('/tmp/seg1.wav'));
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero); // disengage lands
+
+      await ctrl(c).startSession();
       engine.emit(const EngineSegmentReady('/tmp/seg2.wav'));
       await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
 
-      final jobs = (stateOf(c) as HandsFreeListening).jobs;
-      expect(jobs, hasLength(2));
+      expect(jobsOf(stateOf(c)), hasLength(2));
     });
 
     test('no pending jobs → EngineListening maps to HandsFreeListening',
@@ -930,30 +943,38 @@ void main() {
 
     test('queue saturation: 5th segment is dropped (max 4 non-terminal jobs)',
         () async {
-      // Use a hanging STT so no jobs complete — all 4 slots stay occupied.
+      // P037 v2 one-shot: each engagement yields one segment. Build up
+      // five jobs by re-engaging between emits. Hanging STT keeps all
+      // accepted jobs in Transcribing so the queue stays saturated.
       final engine = FakeHandsFreeEngine();
       final c = makeContainer(engine: engine); // hanging STT default
-      await ctrl(c).startSession();
-
       for (var i = 1; i <= 5; i++) {
+        await ctrl(c).startSession();
         engine.emit(EngineSegmentReady('/tmp/seg$i.wav'));
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero); // disengage lands
       }
-      await Future.delayed(Duration.zero);
 
-      final jobs = (stateOf(c) as HandsFreeListening).jobs;
-      expect(jobs, hasLength(4), reason: '5th segment must be dropped');
+      expect(jobsOf(stateOf(c)), hasLength(4),
+          reason: '5th segment must be dropped (max 4 non-terminal jobs)');
     });
 
     test('jobs run serially (second job starts after first completes)',
         () async {
+      // P037 v2 one-shot: emit two segments via separate engagements.
+      // The serial _sttSlot guarantees seg2 starts only after seg1
+      // finishes, regardless of how the segments arrived.
       final stt = FakeSttService(text: 'Text');
       final storage = FakeStorageService();
       final engine = FakeHandsFreeEngine();
       final c =
           makeContainer(engine: engine, sttService: stt, storageService: storage);
       await ctrl(c).startSession();
-
       engine.emit(const EngineSegmentReady('/tmp/seg1.wav'));
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      await ctrl(c).startSession();
       engine.emit(const EngineSegmentReady('/tmp/seg2.wav'));
       await Future.delayed(const Duration(milliseconds: 100));
 


### PR DESCRIPTION
## Summary

- **Per-segment one-shot** (the deferred follow-up from PR #278): VAD-emitted segments now close the engagement immediately. STT/persistence continue async; the public state drops to `HandsFreeIdle(jobs:…)` and the ambient loop returns to silence until the user re-engages.
- **Makefile**: fix the `grep '• ios •'` parser that broke on newer flutter output; add `install-ios-dev-debug`; have `install-ios` / `install-ios-dev` default to `--release`.

## Why

User feedback on the previous build: "Wraca do nasłuchu z tym zapętlonym tonem" — after a captured utterance the engine kept listening and the looped tone never stopped. This PR closes the engagement on `EngineSegmentReady`, so each utterance is one-shot.

`stopSession` is now a true "drain everything" — the early return on `HandsFreeIdle` was hiding pending in-flight jobs that the v2 idle-with-jobs path can leave behind.

## Test plan

- [x] `flutter test` — 940/940 pass
- [x] `flutter analyze` — no issues
- [x] 4 multi-segment tests rewritten to the v2 engage→emit→re-engage pattern
- [ ] On-device: AirPods short-click → tone → speak → tone stops + silence resumes the moment VAD ends; subsequent click engages a fresh session
