### PR TITLE
feat(recording): auto-resume listening 30s after TTS reply

### DIFF
--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -209,8 +209,17 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   }
 
   // Tracks whether the most recent engagement closure was due to a TTS
-  // suspend; only that path should auto-resume when TTS ends.
+  // suspend; only that path should auto-resume when TTS ends. (Legacy
+  // path: still in use for the rare case where TTS starts mid-listen.)
   bool _suspendedForTts = false;
+
+  // P037 v2 conversational-turn signal: set when [_disengageOneShot]
+  // closes the engagement after a captured segment, so the controller
+  // knows that the next TTS-end is the agent's reply to that turn and
+  // should re-open a fresh 30 s listening window. Cleared by
+  // [resumeAfterTts] after auto-resuming, by [startSession] when the
+  // user takes manual control, and by [stopSession] / pause flows.
+  bool _pendingConversationResume = false;
 
   /// Pauses the VAD engine while TTS is playing to prevent the mic from
   /// picking up speaker output. In the v2 one-shot model this collapses
@@ -224,13 +233,28 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     state = HandsFreeIdle(jobs: List.unmodifiable(_jobs));
   }
 
-  /// Re-engages after TTS finishes playing.
+  /// Re-engages after TTS finishes playing. Two paths:
+  ///
+  /// * Legacy: TTS started while engagement was open — [_suspendedForTts]
+  ///   is set. Resume restores the engagement.
+  /// * v2 conversational turn: per-segment one-shot already closed the
+  ///   engagement before TTS started, so [_suspendedForTts] is false.
+  ///   [_pendingConversationResume] (set by [_disengageOneShot]) signals
+  ///   that this TTS is the agent's reply to the user's captured
+  ///   utterance, so we open a fresh listening window.
   Future<void> resumeAfterTts() async {
-    if (!_suspendedForTts) return;
-    _suspendedForTts = false;
-    if (_suspendedForManualRecording) return;
-    if (_suspendedByUser) return;
-    _resumeEngagement();
+    if (_suspendedForManualRecording || _suspendedByUser) return;
+    if (state is! HandsFreeIdle) return;
+    if (_suspendedForTts) {
+      _suspendedForTts = false;
+      _pendingConversationResume = false;
+      _resumeEngagement();
+      return;
+    }
+    if (_pendingConversationResume) {
+      _pendingConversationResume = false;
+      _resumeEngagement();
+    }
   }
 
   /// Re-opens an engagement after a soft-suspend (TTS / manual recording /
@@ -316,6 +340,10 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     if (_jobs.isEmpty) {
       _jobCounter = 0;
     }
+    // Explicit user-initiated engage cancels any pending TTS-driven
+    // auto-resume — if the user clicks before the agent's reply lands,
+    // they're taking control of the next listening window.
+    _pendingConversationResume = false;
     _phase = HandsFreeListeningPhase.listening;
     _engagement.engage();
     _startEngine(_ref.read(appConfigProvider).vadConfig);
@@ -383,6 +411,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     _suspendedForManualRecording = false;
     _suspendedByUser = false;
     _suspendedForTts = false;
+    _pendingConversationResume = false;
     _phase = HandsFreeListeningPhase.listening;
   }
 
@@ -411,6 +440,12 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     _engine = null;
     if (!mounted) return;
     _phase = HandsFreeListeningPhase.listening;
+    // P037 v2: this disengage was driven by a captured segment, so the
+    // upcoming TTS reply (if any) should auto-resume into a fresh
+    // listening window. Setting the flag here covers both "VAD ended
+    // utterance" and "30 s timeout" — in the timeout case there's
+    // simply no jobs, so no TTS will play and the flag is harmless.
+    _pendingConversationResume = true;
     state = HandsFreeIdle(jobs: List.unmodifiable(_jobs));
   }
 

--- a/test/features/recording/presentation/hands_free_controller_pause_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_pause_test.dart
@@ -404,6 +404,86 @@ void main() {
     });
   });
 
+  group('conversation-turn auto-resume after TTS (P037 v2)', () {
+    test('TTS-end after per-segment one-shot re-engages a fresh '
+        'listening window', () async {
+      // Reproduces the user-reported gap: per-segment one-shot closes
+      // the engagement immediately, so by the time TTS plays the
+      // controller is already HandsFreeIdle and the legacy
+      // `_suspendedForTts` flag is never set. The conversational
+      // signal `_pendingConversationResume` (set by _disengageOneShot)
+      // must drive the resume instead.
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+
+      await _ctrl(c).startSession();
+      engine.emit(const EngineSegmentReady('/tmp/seg1.wav'));
+      // Two microtask ticks: one for job → Transcribing, one for
+      // _disengageOneShot to land HandsFreeIdle with the flag set.
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+      expect(_stateOf(c), isA<HandsFreeIdle>(),
+          reason: 'per-segment one-shot must close engagement');
+
+      engine.startCount = 0;
+
+      // No suspendForTts in v2 — the recording_screen still calls it
+      // when ttsPlayingProvider flips to true, but it short-circuits
+      // because state is already Idle. So we only need to fire the
+      // resume callback to model "TTS just ended."
+      await _ctrl(c).resumeAfterTts();
+
+      expect(engine.startCount, 1,
+          reason: 'TTS-end after captured utterance must re-engage');
+    });
+
+    test('does NOT auto-resume when no segment was captured (cold TTS)',
+        () async {
+      // If TTS plays without a preceding captured segment (e.g. an
+      // unrelated background announcement), we must not silently open
+      // a listening window — that would steal the mic with no user
+      // intent.
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+
+      // Controller starts in HandsFreeIdle, never engaged → no flag.
+      engine.startCount = 0;
+      await _ctrl(c).resumeAfterTts();
+
+      expect(engine.startCount, 0,
+          reason: 'cold TTS-end (no captured segment) must NOT engage');
+    });
+
+    test('user re-engaging before TTS-end clears the conversation flag',
+        () async {
+      // User clicks AirPods between disengage and TTS-end. They've
+      // taken control. The deferred TTS-end must NOT trigger a second
+      // engage on top of the user's manual one.
+      final engine = _FakeHandsFreeEngine();
+      final c = _makeContainer(engine: engine);
+
+      await _ctrl(c).startSession();
+      engine.emit(const EngineSegmentReady('/tmp/seg1.wav'));
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+      expect(_stateOf(c), isA<HandsFreeIdle>());
+
+      // User clicks again before TTS plays.
+      await _ctrl(c).startSession();
+      engine.emit(const EngineListening());
+      await Future.delayed(Duration.zero);
+      expect(_stateOf(c), isA<HandsFreeListening>());
+      engine.startCount = 0;
+
+      // Now (delayed) TTS-end fires. Should be a no-op — we're
+      // already engaged via the user's manual click.
+      await _ctrl(c).resumeAfterTts();
+
+      expect(engine.startCount, 0,
+          reason: 'manual re-engage must clear pending conversation flag');
+    });
+  });
+
   group('suspension priority — resumeAfterManualRecording', () {
     test('does not restart when _suspendedByUser is true', () async {
       final engine = _FakeHandsFreeEngine();


### PR DESCRIPTION
## Summary

Fix the missing 30 s auto-resume after the agent's TTS reply.

## Why

The v2 per-segment one-shot (PR #279) closes the engagement immediately when VAD captures an utterance — so by the time TTS plays the controller is already `HandsFreeIdle`. The legacy `_suspendedForTts` flag (set by `suspendForTts()`) never gets armed because that method short-circuits when state is `Idle`. Result: `resumeAfterTts()` was a no-op and the user had to click AirPods after every reply.

## Fix

Add `_pendingConversationResume`, set by `_disengageOneShot` and consumed by `resumeAfterTts`. Cleared on successful resume, on manual `startSession` (user took control), and on `stopSession`.

The 30 s-timeout path also runs through `_disengageOneShot`, so the flag is set there too — but harmlessly: no segment → no STT → no TTS → flag never consumed.

## Test plan

- [x] `flutter test` — 943/943 pass (3 new)
- [x] `flutter analyze` — no issues
- [x] Primary regression test verified red without the fix
- [ ] On-device: click → speak → tone stops → TTS plays → tone resumes for 30s. Speaking again continues the conversation without an extra click.
