### PR TITLE
fix(ios): conservative audio-session reactivation — stop racing the recorder

### DIFF
--- a/ios/Runner/MediaButtonBridge.swift
+++ b/ios/Runner/MediaButtonBridge.swift
@@ -150,8 +150,13 @@ class MediaButtonBridge: NSObject, FlutterStreamHandler {
                 object: nil,
                 queue: .main
             ) { [weak self] _ in
-                NSLog("[MediaButtonDbg] didBecomeActive — reactivating session + nowPlayingInfo")
-                self?.reactivateSession()
+                // Refresh-only: the audio session may already be owned
+                // by the recorder or the ambient player. Calling
+                // setActive(true) here races with their activation and
+                // surfaces as PlatformException("Failed to start audio")
+                // when AudioRecorder later attempts setCategory + setActive.
+                NSLog("[MediaButtonDbg] didBecomeActive — refreshing nowPlayingInfo")
+                self?.refreshNowPlayingInfo()
             }
         }
         if routeChangeObserver == nil {
@@ -187,11 +192,15 @@ class MediaButtonBridge: NSObject, FlutterStreamHandler {
             let optsRaw = (userInfo[AVAudioSessionInterruptionOptionKey] as? UInt) ?? 0
             let opts = AVAudioSession.InterruptionOptions(rawValue: optsRaw)
             NSLog("[MediaButtonDbg] interruption ended (shouldResume=\(opts.contains(.shouldResume)))")
-            // Reactivate regardless of `shouldResume` — for our use
-            // case (hardware-button routing) we always want the slot
-            // back; iOS will pause output if the user truly didn't
-            // intend to resume.
-            reactivateSession()
+            // Only call setActive(true) when iOS hands back the
+            // session via .shouldResume. Forcing reactivation in
+            // every case races with the recorder/ambient player and
+            // surfaces as PlatformException on the next startSession.
+            if opts.contains(.shouldResume) {
+                reactivateSession()
+            } else {
+                refreshNowPlayingInfo()
+            }
         @unknown default:
             break
         }


### PR DESCRIPTION
## Summary

Follow-up to PR #281: stop racing the recorder when the app comes back from the lock screen.

## Why

User reports after PR #281: no more "boop" on AirPods click, but on app open after lock-screen unlock the screen shows `Failed to start audio: PlatformException`. Tapping Retry works.

Root cause: PR #281's `didBecomeActive` observer called `setActive(true)` aggressively. That raced with `AudioRecorder`'s own `setCategory + setActive` on the next `startSession`, leaving the AVAudioSession in a half-state that surfaced as `PlatformException` on engage. Retry succeeded because the second engagement ran without a fresh `didBecomeActive` in between.

## Fix

- `interruption.ended` only reactivates when iOS sets `.shouldResume` (Apple's documented pattern). Otherwise just refresh `nowPlayingInfo`.
- `didBecomeActive` and `routeChange` no longer touch session activation — they only refresh `nowPlayingInfo`, which is what was actually fixing the "boop" anyway (recovering the media-participant slot for hardware-button routing).

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 943/943 pass
- [ ] On-device:
  - [ ] App idle → lock → unlock → no "Failed to start audio" splash
  - [ ] Click AirPods after lock-unlock → engages cleanly, no boop, no error
  - [ ] Background → click AirPods → engages, no boop
  - [ ] Foreground click still works (regression check)
