### PR TITLE
feat(recording): always-on capture with volume-button engagement (P038 impl)

### DIFF
--- a/docs/proposals/038-always-on-capture-volume-button-engagement.md
+++ b/docs/proposals/038-always-on-capture-volume-button-engagement.md
@@ -1,0 +1,206 @@
+# Proposal 038 — Always-on capture with volume-button engagement
+
+## Status: Implemented as experiment on `experiment/volume-button-engage` (2026-05-02). Replaces / consolidates the never-merged P038 draft (PR #283) and the post-review T0 pre-flight risk that landed empirically on the device.
+
+## Origin
+
+P037 v2 closed the AirPods short-click engagement path for the foreground case but left **lock → click → capture** broken: `AudioRecorder.startStream` rejects with `avfaudio error 2003329396` when called from a locked-screen `MPRemoteCommand` callback. PRs #277–#282 tried five smaller mitigations (keep `.playAndRecord` active across disengage; prime in the Swift handler; skip our `setPlayAndRecord`; AppDelegate-launch prime; conservative reactivation). All failed at the I/O-unit acquisition step.
+
+The P038 design pivot was to keep the recorder running for the lifetime of the app session and gate audio chunks at the orchestrator level. The **gesture**, however, did not work via `MPRemoteCommand` — iOS uniformly blocks media-button delivery while `.playAndRecord` has an active mic engine, regardless of `mode`. The user proposed a different gesture: **iPhone / AirPods volume buttons**, observed via `AVAudioSession.outputVolume` KVO. Empirically that path is not gated by the call-mode rule and survives a locked screen with a hot mic.
+
+## Goals (achieved)
+
+1. **lock → press → capture** works on iPhone after the user has engaged at least once during the current app session. ✓ Verified on device.
+2. The Dart-level engagement contract is unchanged: a captured segment only flows into VAD → STT → backend → TTS when the user has explicitly engaged. ✓ (chunk-level gate)
+3. Privacy: no audio bytes touch VAD or the network when the gate is closed. ✓ (orchestrator early-returns in `_enqueueChunk`; pre-roll cleared on close)
+4. Auto-resume after TTS reply opens the gate again. ✓ (subject to `_pendingConversationResume` flag — cold TTS does not engage)
+5. Existing P037 v2 invariants hold: public state machine `Idle / Listening / Error`, jobs preserved across `HandsFreeIdle`. ✓
+
+## Non-Goals
+
+- Recording from the lock screen *before* the user has ever engaged in the current process (the orchestrator must be warmed by an unlocked engage first).
+- Keeping the AirPods short-click as an engagement trigger. P037 v2's MPRemoteCommand path is preserved but is empirically unreliable for engagement during a hot mic — kept only for **TTS interrupt** (its proven use case).
+- A drop-in replacement for the disabled `AmbientLoopPlayer` listening tone — that work is deferred (see *Known Compromises*).
+
+## User-Visible Changes
+
+- **Volume Up = engage** (start hands-free listening). Toast: "Listening". Light haptic.
+- **Volume Down behavior is contextual:**
+  - During TTS playback → interrupts the agent's reply, leaves the gate state alone (auto-resume after TTS will fire on completion as usual).
+  - While engaged with no TTS → suspends listening (closes the gate; mic stays warm but no STT/API).
+- **iOS recording indicator** (orange dot / pill) is **continuously visible** after the first engage of an app session. This is the privacy-indicator cost of the always-on capture model.
+- **First engagement of an app session must be performed unlocked.** After that, the user can lock the phone and engage from the lock screen with a Volume Up press.
+- The system volume **does change** when the user presses volume buttons — we do not yet restore it programmatically (see *Known Compromises*).
+
+## Solution Design (as shipped)
+
+### Engagement gesture: hardware volume buttons
+
+A new native bridge `ios/Runner/VolumeButtonBridge.swift` registers a KVO observer on `AVAudioSession.outputVolume`:
+
+- On each observed change, classify direction by comparing the new value to the previously observed value (NOT to `change[.oldKey]`, which is sometimes equal to `newKey` on the first observation).
+- A small `_stepThreshold` filter (0.001) suppresses noise / programmatic restore artifacts.
+- Direction → `"up"` or `"down"` event posted to the Dart side via `EventChannel("com.voiceagent/volume_button/events")`.
+
+Dart-side `VolumeButtonPort` / `VolumeButtonService` / `volumeButtonProvider` mirror the existing `MediaButtonPort` shape. `RecordingScreen.initState` calls `_volumeButtonPort.activate()` after first frame; `dispose` deactivates.
+
+`_onVolumeButtonEvent` in `recording_screen.dart` dispatches:
+
+| Event | TTS playing? | hfState | Action |
+|---|---|---|---|
+| `up` | — | Idle / SessionError | `hfCtrl.startSession()` + toast "Listening" + haptic |
+| `up` | — | Listening | no-op (already engaged) |
+| `down` | yes | — | `ttsService.stop()` (interrupt agent reply; gate untouched) |
+| `down` | no | Listening | `hfCtrl.suspendByUser()` + toast "Paused" + haptic |
+| `down` | no | other | no-op |
+
+### Orchestrator capture gate
+
+`HandsFreeOrchestrator` gains:
+
+```dart
+bool _captureGateOpen = true;
+
+@override
+Future<void> setCaptureGate({required bool open}) async { … }
+```
+
+Default state on `start()` is **open** so the first-engage path is unchanged. `_enqueueChunk` early-returns when `!_captureGateOpen` — chunks read from the underlying `AudioRecorder` PCM stream are immediately discarded; the recorder + audio session stay alive.
+
+On gate-**close** the following state is reset (so a half-segment captured before the close cannot leak into the next open window):
+
+- `_remainder.clear()`
+- `_speechBuffer = BytesBuilder(copy: false)`
+- `_speechFrameCount = 0`
+- `_captureFrameCount = 0`
+- `_hangoverCount = 0`
+- `_preRoll.clear()` — privacy invariant: closed-gate audio cannot appear in the next segment's pre-roll
+- `_pendingFrames.clear()`, `_pendingLabels.clear()`, `_pendingSpeechStarted = false`
+- `_cooldownTimer?.cancel()` AND `_inCooldown = false` (explicit, not just timer cancel)
+- `_chunkQueue.clear()`
+
+On gate-**open** the orchestrator emits a fresh `EngineListening` event so the controller can transition the public state.
+
+### Controller lifecycle (gate-driven)
+
+| Op | Behavior |
+|---|---|
+| First `startSession` (engine null) | Full setup: guards, `bg.startService`, `_engagement.engage()`, `_startEngine(...)`. |
+| Subsequent `startSession` (engine alive) | Guards re-validated, `_pendingConversationResume = false`, `_suspendedByUser = false`, `_suspendedForTts = false`, `_engagement.engage()`, `await _engine!.setCaptureGate(open: true)`. **No** recorder restart. |
+| `_disengageOneShot` (per-segment + 30 s timeout) | `await _engine?.setCaptureGate(open: false)` + `_engagement.disengage()` + `state = HandsFreeIdle(jobs)` + `_pendingConversationResume = true`. **No** engine teardown. |
+| `suspendByUser` (Volume Down) | Same as `_disengageOneShot` but sets `_suspendedByUser = true` instead of `_pendingConversationResume`. |
+| `suspendForTts` (TTS started) | Same gate-close pattern; sets `_suspendedForTts = true`. |
+| `resumeAfterTts` (TTS ended) | If not user/manual-suspended AND state is Idle AND (`_suspendedForTts` OR `_pendingConversationResume`) → `_resumeEngagement()`. The flag check is the cold-TTS guard: a TTS that fires without a preceding capture must not silently spin up the mic. |
+| `_resumeEngagement` | If engine alive: `engagement.engage()` + `setCaptureGate(open: true)`. If engine null: full `_startEngine`. |
+| `stopSession` | Unchanged — full teardown including recorder. |
+| `suspendForManualRecording` | **Unchanged from P037 v2** — still does full teardown. The manual recorder swaps the audio session and steals the I/O unit; staying alive is impossible there. Documented limitation: lock-screen-press after manual recording reverts to the old failure mode until one foreground engage warms the orchestrator again. |
+
+### TTS suspend/resume listener (controller-level, not widget-level)
+
+The original P037 v2 wiring put the `ttsPlayingProvider → suspendForTts/resumeAfterTts` bridge in `RecordingScreen.build()` via `ref.listen`. That listener fires reliably in foreground but is paused when iOS pauses Flutter rendering on a lock screen — observed empirically: foreground auto-resume worked, lock-screen did not.
+
+The fix subscribes **directly to the underlying `ValueNotifier<bool>`** in the controller's constructor:
+
+```dart
+final tts = _ref.read(ttsServiceProvider);
+final isSpeaking = tts.isSpeaking;
+void ttsListener() {
+  if (!mounted) return;
+  if (isSpeaking.value) {
+    unawaited(suspendForTts());
+  } else {
+    unawaited(resumeAfterTts());
+  }
+}
+isSpeaking.addListener(ttsListener);
+```
+
+`ValueNotifier` callbacks fire on every `value` change regardless of widget rendering state. Cleanup happens in `dispose`.
+
+### Audio session always `.playAndRecord + .spokenAudio`
+
+`AppDelegate.application(launch)` sets the category and activates the session at process launch (`primeAudioSessionForLaunch`). The foreground service's `setPlayAndRecord` becomes a same-category fast-path no-op (`AudioSessionBridge.swift`). `stopService` skips the iOS category switch entirely — the session never leaves `.playAndRecord` for the lifetime of the process.
+
+### TTS no longer swaps the audio session
+
+`flutter_tts_service.dart`'s `_acquirePlaybackFocus` / `_releasePlaybackFocus` are no-ops. The setActive(false) → setCategory(.playback) → setActive(true) round-trip required to swap to `.playback` for hardware-button routing tore down the recorder I/O unit. Hardware buttons during TTS now route via `.playAndRecord + .spokenAudio` (same path the volume button gesture already uses).
+
+## Affected Mutation Points
+
+**Native (iOS):**
+- `ios/Runner/VolumeButtonBridge.swift` — new
+- `ios/Runner/AppDelegate.swift` — prime session at launch + register `VolumeButtonBridge`
+- `ios/Runner/AudioSessionBridge.swift` — same-category fast-path skip in `setPlayAndRecord`
+- `ios/Runner/MediaButtonBridge.swift` — lifecycle observers (interruption, didBecomeActive, routeChange) for `nowPlayingInfo` refresh
+- `ios/Runner.xcodeproj/project.pbxproj` — `VolumeButtonBridge.swift` registered as a source file
+
+**Dart (core):**
+- `lib/core/volume_button/volume_button_port.dart` / `_service.dart` / `_provider.dart` — new
+- `lib/core/audio/ambient_loop_player.dart` — disabled at the call site (`recording_screen.dart`); player itself unchanged
+- `lib/core/background/flutter_foreground_task_service.dart` — `stopService` skips iOS category switch; `startService` setPlayAndRecord call left in place (now a no-op via AudioSessionBridge fast path)
+- `lib/core/tts/flutter_tts_service.dart` — `_acquirePlaybackFocus` / `_releasePlaybackFocus` reduced to no-ops
+
+**Dart (recording feature):**
+- `lib/features/recording/domain/hands_free_engine.dart` — `Future<void> setCaptureGate({required bool open})` added to interface
+- `lib/features/recording/data/hands_free_orchestrator.dart` — `_captureGateOpen` field; `_enqueueChunk` early-return; `setCaptureGate` impl with on-close reset list
+- `lib/features/recording/presentation/hands_free_controller.dart` — `_disengageOneShot` / `suspendByUser` / `suspendForTts` / `resumeAfterTts` / `_resumeEngagement` / `startSession` updated for gate model; ValueNotifier-based TTS listener in constructor; `_ttsListenerCleanup` in `dispose`
+- `lib/features/recording/presentation/recording_screen.dart` — volume button activation + `_onVolumeButtonEvent`; segment list rendering decoupled from `isOn` flag; widget-level TTS listener removed (moved to controller)
+
+## Tests
+
+`test/features/recording/data/hands_free_orchestrator_test.dart` — new `captureGate` group with 4 tests:
+
+1. Chunks discarded when gate closed; recorder stays running.
+2. Reopening the gate emits a fresh `EngineListening`.
+3. Audio captured before gate-close does not leak into next open window via pre-roll (structural assertion: orchestrator does not crash on close→open cycle; the privacy invariant is enforced by the buffer-reset list).
+4. `setCaptureGate` is idempotent (open→open and close→close are no-ops).
+
+`test/features/recording/presentation/hands_free_controller_pause_test.dart` — three tests rewritten for the gate model:
+
+- `resumeByUser from suspended transitions to HandsFreeListening (gate model)` — engine is NOT stopped on suspend (engine.stopped == false).
+- `TTS-end after per-segment one-shot reopens the gate` — public state goes from Idle → Listening on resumeAfterTts; engine.stopped stays false throughout.
+- `cold TTS-end (no prior engagement) is a no-op` — protects against random TTS spinning up mic from cold.
+- `user re-engaging before TTS-end keeps the manual engage` — deferred TTS-end is a no-op while state is already Listening.
+
+All other test fakes that implement `HandsFreeEngine` got a `setCaptureGate` stub.
+
+`make verify` (analyze + 947 tests) passes.
+
+## Acceptance Criteria
+
+1. ✅ **lock → Volume Up → speak → segment captured** works after one foreground engage in the current app session.
+2. ✅ Volume Down during TTS interrupts the reply and leaves the gate state for the post-TTS auto-resume to pick up.
+3. ✅ Volume Down while engaged (no TTS) closes the gate; mic stays warm.
+4. ✅ Volume Up after volume-down opens the gate without restarting the recorder.
+5. ✅ Per-segment one-shot still fires (`_disengageOneShot` runs on `EngineSegmentReady`).
+6. ✅ Auto-resume after TTS works in both foreground and lock screen (controller-level ValueNotifier listener).
+7. ✅ Cold TTS-end (no preceding capture) does not auto-engage.
+8. ✅ STT/persist running after `_disengageOneShot` keeps state at `HandsFreeIdle` (PR #278 invariant).
+9. ✅ `make verify` passes (947/947).
+10. ⚠️ Manual on-device verification: **all functional scenarios confirmed working** by user. Known cosmetic gap: no listening tone (AmbientLoopPlayer disabled).
+
+## Risks
+
+| Risk | Status |
+|---|---|
+| `MPRemoteCommand` blocked during hot mic — kills the AirPods click engagement path | Confirmed real. Bypassed via volume button gesture. |
+| Volume button presses change the actual system volume | **Open**. Programmatic restore via `MPVolumeView` slider trick is not yet wired. UX: each engage / suspend nudges the volume one step. |
+| `audioplayers` package fights the audio session, killing the recorder | Confirmed real. `AmbientLoopPlayer` disabled. |
+| iOS continuously displays the orange recording indicator | Accepted trade-off (see ADR-AUDIO-011). |
+| First engage of a session must be foreground | Accepted limitation. Documented. |
+| Manual recording resets the always-on guarantee until one foreground engage warms the orchestrator | Accepted limitation. Documented in T4 carve-out. |
+| iOS audio interruptions (phone call, Siri, alarm) tear down the I/O unit | Inherits P037's interruption observers (PRs #281/#282); recovery is best-effort. |
+
+## Known Compromises and Follow-Up Direction
+
+- **Listening tone** (AmbientLoopPlayer) — disabled. Need a tone player that respects the existing shared `AVAudioSession` rather than re-acquiring it. Options: small native AVAudioPlayer bridge, or `audio_session` package configuration that doesn't reset the session on play.
+- **Volume restore** — observe the press, then programmatically set the volume back via `MPVolumeView` slider. Tricky: needs an in-view-hierarchy MPVolumeView, may flash the volume HUD briefly.
+- **First engage must be unlocked** — closing this needs a "always-ready listening" setting that pre-warms the orchestrator at process launch (one knob away from the current architecture).
+- **Manual-recording reacquisition** — `engine.reacquire()` API to re-attach the recorder to a fresh PCM stream without reinitializing VAD state. Defers cleanly out of v1.
+- **PushToTalk framework** as an alternative engagement gesture would give us an iOS-native "PTT button on lock screen" + `didActivateAudioSession` callback. Requires `com.apple.developer.push-to-talk` entitlement application. Independent track.
+
+## ADR Impact
+
+`ADR-AUDIO-011 — Always-on capture with engagement gate` (drafted in PR #283 alongside the original P038) captures the always-on-capture decision and the privacy-indicator trade-off. It carries forward unchanged for this implementation; the engagement gesture (volume buttons vs MPRemoteCommand) is a tactical choice within the same architectural model.
+
+The supersession note on `ADR-AUDIO-009` (lifecycle portion superseded by ADR-AUDIO-011) also carries forward unchanged.

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		320352C92F923962006B5EB7 /* AudioSessionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320352C82F923962006B5EB7 /* AudioSessionBridge.swift */; };
 		320352CA2F923963006B5EB7 /* MediaButtonBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320352CB2F923963006B5EB7 /* MediaButtonBridge.swift */; };
+		320352CC2F923964006B5EB7 /* VolumeButtonBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320352CD2F923964006B5EB7 /* VolumeButtonBridge.swift */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
@@ -51,6 +52,7 @@
 		2F7B75EDD63DBF2E7DCC2C24 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		320352C82F923962006B5EB7 /* AudioSessionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionBridge.swift; sourceTree = "<group>"; };
 		320352CB2F923963006B5EB7 /* MediaButtonBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaButtonBridge.swift; sourceTree = "<group>"; };
+		320352CD2F923964006B5EB7 /* VolumeButtonBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeButtonBridge.swift; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		33FFD1A0B6824BC28CA22801 /* Profile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Profile.xcconfig; path = Flutter/Profile.xcconfig; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 			children = (
 				320352C82F923962006B5EB7 /* AudioSessionBridge.swift */,
 				320352CB2F923963006B5EB7 /* MediaButtonBridge.swift */,
+				320352CD2F923964006B5EB7 /* VolumeButtonBridge.swift */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -450,6 +453,7 @@
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				320352C92F923962006B5EB7 /* AudioSessionBridge.swift in Sources */,
 				320352CA2F923963006B5EB7 /* MediaButtonBridge.swift in Sources */,
+				320352CC2F923964006B5EB7 /* VolumeButtonBridge.swift in Sources */,
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -20,5 +20,8 @@ import UIKit
     if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "MediaButtonBridge") {
       MediaButtonBridge.shared.configure(with: registrar.messenger())
     }
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "VolumeButtonBridge") {
+      VolumeButtonBridge.shared.configure(with: registrar.messenger())
+    }
   }
 }

--- a/ios/Runner/VolumeButtonBridge.swift
+++ b/ios/Runner/VolumeButtonBridge.swift
@@ -1,0 +1,139 @@
+import AVFoundation
+import Flutter
+import MediaPlayer
+import UIKit
+
+/// Bridges hardware volume button presses (iPhone, Apple Watch, AirPods
+/// stem swipe) to Dart via platform channels.
+///
+/// Why: P037/P038 established that `MPRemoteCommand` (toggle / next /
+/// prev) is uniformly blocked by iOS while the audio session is
+/// `.playAndRecord` with an active mic engine. Volume buttons go
+/// through a separate iOS routing path (`AVAudioSession.outputVolume`
+/// KVO) that does NOT pass through the `MPRemoteCommand` gate, so
+/// presses survive the call-mode block.
+///
+/// Trade-off: the observed volume change is real — the system volume
+/// HUD flashes and the device volume actually moves a step. We do NOT
+/// attempt to restore the volume here (would be a separate UX layer).
+///
+/// Channels:
+/// - MethodChannel `com.voiceagent/volume_button` — `activate` / `deactivate`
+/// - EventChannel  `com.voiceagent/volume_button/events` — emits `"up"` or `"down"`
+///
+/// Pattern mirrors `MediaButtonBridge`.
+class VolumeButtonBridge: NSObject, FlutterStreamHandler {
+    static let shared = VolumeButtonBridge()
+
+    private let methodChannelName = "com.voiceagent/volume_button"
+    private let eventChannelName = "com.voiceagent/volume_button/events"
+
+    private var methodChannel: FlutterMethodChannel?
+    private var eventSink: FlutterEventSink?
+
+    private var observing = false
+    private var lastVolume: Float = -1.0
+    // Threshold for change detection. iOS volume steps are ~0.0625 (16
+    // increments). Anything smaller is noise / programmatic restore.
+    private let _stepThreshold: Float = 0.001
+
+    private override init() {
+        super.init()
+    }
+
+    /// Call from AppDelegate after the Flutter engine is available.
+    func configure(with messenger: FlutterBinaryMessenger) {
+        methodChannel = FlutterMethodChannel(
+            name: methodChannelName,
+            binaryMessenger: messenger
+        )
+        methodChannel?.setMethodCallHandler { [weak self] call, result in
+            self?.handle(call, result: result)
+        }
+
+        let eventChannel = FlutterEventChannel(
+            name: eventChannelName,
+            binaryMessenger: messenger
+        )
+        eventChannel.setStreamHandler(self)
+    }
+
+    // MARK: - MethodChannel handler
+
+    private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "activate":
+            startObserving()
+            result(nil)
+        case "deactivate":
+            stopObserving()
+            result(nil)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    // MARK: - KVO on AVAudioSession.outputVolume
+
+    private func startObserving() {
+        guard !observing else { return }
+        let session = AVAudioSession.sharedInstance()
+        // Capture initial value so the first real press has something to
+        // diff against.
+        lastVolume = session.outputVolume
+        session.addObserver(self,
+                            forKeyPath: "outputVolume",
+                            options: [.new, .old],
+                            context: nil)
+        observing = true
+        NSLog("[VolumeBtnDbg] startObserving — initial volume=\(lastVolume)")
+    }
+
+    private func stopObserving() {
+        guard observing else { return }
+        AVAudioSession.sharedInstance().removeObserver(self,
+                                                      forKeyPath: "outputVolume")
+        observing = false
+        NSLog("[VolumeBtnDbg] stopObserving")
+    }
+
+    override func observeValue(forKeyPath keyPath: String?,
+                               of object: Any?,
+                               change: [NSKeyValueChangeKey: Any]?,
+                               context: UnsafeMutableRawPointer?) {
+        guard keyPath == "outputVolume",
+              let new = change?[.newKey] as? Float else {
+            return
+        }
+        // Compute direction against the most recent observed value
+        // rather than `change[.oldKey]` — `oldKey` is sometimes equal
+        // to `newKey` for the first observation after registration on
+        // some iOS versions.
+        let prev = lastVolume
+        lastVolume = new
+        if prev < 0 {
+            // First observation since startObserving — no direction yet.
+            return
+        }
+        let delta = new - prev
+        if abs(delta) < _stepThreshold {
+            return
+        }
+        let direction = delta > 0 ? "up" : "down"
+        NSLog("[VolumeBtnDbg] volume \(direction): \(prev) → \(new)")
+        eventSink?(direction)
+    }
+
+    // MARK: - FlutterStreamHandler
+
+    func onListen(withArguments arguments: Any?,
+                  eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        eventSink = events
+        return nil
+    }
+
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        eventSink = nil
+        return nil
+    }
+}

--- a/lib/core/tts/flutter_tts_service.dart
+++ b/lib/core/tts/flutter_tts_service.dart
@@ -54,24 +54,20 @@ class FlutterTtsService implements TtsService {
   /// best-effort: failures don't abort speech.
   Future<void> _acquirePlaybackFocus() async {
     if (!_isIOS) return;
-    try {
-      await _audioSession.invokeMethod<void>('setPlayback');
-    } on PlatformException catch (e) {
-      debugPrint('[TtsDbg] setPlayback failed: ${e.message}');
-    } on MissingPluginException {
-      // Bridge not registered (tests etc.) — proceed without focus switch.
-    }
+    // EXPERIMENT (volume-button gate model): do NOT switch the audio
+    // session to .playback during TTS. The setActive(false)/setCategory
+    // round-trip required to swap categories tears down the recorder
+    // I/O unit, which is exactly what the always-on capture model is
+    // built to avoid (iOS rejects re-acquisition from a locked
+    // context). Hardware-button routing during TTS will fall back to
+    // whatever .playAndRecord + .spokenAudio delivers, which is the
+    // same routing the volume-button path already uses.
   }
 
   Future<void> _releasePlaybackFocus() async {
     if (!_isIOS) return;
-    try {
-      await _audioSession.invokeMethod<void>('restoreAudioSession');
-    } on PlatformException catch (e) {
-      debugPrint('[TtsDbg] restoreAudioSession failed: ${e.message}');
-    } on MissingPluginException {
-      // Bridge not registered — no state to restore.
-    }
+    // Symmetric no-op: nothing was changed in _acquirePlaybackFocus,
+    // nothing to restore.
   }
 
   @override

--- a/lib/core/volume_button/volume_button_port.dart
+++ b/lib/core/volume_button/volume_button_port.dart
@@ -1,0 +1,27 @@
+/// Events emitted by hardware volume button presses (iPhone hardware
+/// keys, AirPods stem volume swipe, Apple Watch crown).
+///
+/// Why we route these to engagement: iOS uniformly blocks
+/// `MPRemoteCommand` (toggle / next / prev) while the audio session is
+/// `.playAndRecord` with an active mic engine. Volume buttons travel a
+/// separate path (`AVAudioSession.outputVolume` KVO) that is NOT
+/// gated by the same call-mode rule, so the press still reaches the
+/// app on a locked screen with a hot mic.
+enum VolumeButtonEvent { up, down }
+
+/// Port interface for listening to hardware volume button presses.
+///
+/// Lives in `core/` so higher layers can depend on it without coupling
+/// to platform channel details. The concrete adapter is
+/// [VolumeButtonService] backed by platform channels registered in
+/// `AppDelegate.swift` via `VolumeButtonBridge`.
+abstract class VolumeButtonPort {
+  /// Stream of volume up / down events forwarded from the native layer.
+  Stream<VolumeButtonEvent> get events;
+
+  /// Starts the native KVO observer on `AVAudioSession.outputVolume`.
+  Future<void> activate();
+
+  /// Stops the native KVO observer.
+  Future<void> deactivate();
+}

--- a/lib/core/volume_button/volume_button_provider.dart
+++ b/lib/core/volume_button/volume_button_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:voice_agent/core/volume_button/volume_button_port.dart';
+import 'package:voice_agent/core/volume_button/volume_button_service.dart';
+
+/// Provides a [VolumeButtonPort] backed by platform channels.
+final volumeButtonProvider = Provider<VolumeButtonPort>((ref) {
+  return VolumeButtonService();
+});

--- a/lib/core/volume_button/volume_button_service.dart
+++ b/lib/core/volume_button/volume_button_service.dart
@@ -1,0 +1,65 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'package:voice_agent/core/volume_button/volume_button_port.dart';
+
+/// Platform-channel implementation of [VolumeButtonPort].
+class VolumeButtonService implements VolumeButtonPort {
+  VolumeButtonService({
+    MethodChannel? methodChannel,
+    EventChannel? eventChannel,
+  })  : _methodChannel = methodChannel ??
+            const MethodChannel('com.voiceagent/volume_button'),
+        _eventChannel = eventChannel ??
+            const EventChannel('com.voiceagent/volume_button/events');
+
+  final MethodChannel _methodChannel;
+  final EventChannel _eventChannel;
+
+  @override
+  Stream<VolumeButtonEvent> get events {
+    return _eventChannel
+        .receiveBroadcastStream()
+        .map<VolumeButtonEvent?>((dynamic event) {
+          debugPrint('[VolumeBtnDbg] raw event from native: $event');
+          if (event == 'up') return VolumeButtonEvent.up;
+          if (event == 'down') return VolumeButtonEvent.down;
+          developer.log(
+            'Unknown volume button event: $event',
+            name: 'VolumeButtonService',
+          );
+          return null;
+        })
+        .where((e) => e != null)
+        .cast<VolumeButtonEvent>();
+  }
+
+  @override
+  Future<void> activate() async {
+    debugPrint('[VolumeBtnDbg] Dart→native activate() invoked');
+    try {
+      await _methodChannel.invokeMethod<void>('activate');
+      debugPrint('[VolumeBtnDbg] Dart→native activate() returned');
+    } catch (e) {
+      developer.log(
+        'Failed to activate volume button: $e',
+        name: 'VolumeButtonService',
+      );
+    }
+  }
+
+  @override
+  Future<void> deactivate() async {
+    debugPrint('[VolumeBtnDbg] Dart→native deactivate() invoked');
+    try {
+      await _methodChannel.invokeMethod<void>('deactivate');
+    } catch (e) {
+      developer.log(
+        'Failed to deactivate volume button: $e',
+        name: 'VolumeButtonService',
+      );
+    }
+  }
+}

--- a/lib/features/recording/data/hands_free_orchestrator.dart
+++ b/lib/features/recording/data/hands_free_orchestrator.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:record/record.dart';
 import 'package:voice_agent/core/config/vad_config.dart';
@@ -31,6 +32,13 @@ class HandsFreeOrchestrator implements HandsFreeEngine {
   StreamSubscription<Uint8List>? _audioSub;
 
   _Phase _phase = _Phase.idle;
+
+  /// Capture gate: when `false`, incoming audio chunks are discarded
+  /// before reaching VAD. Recorder + audio session stay active so the
+  /// I/O unit is preserved across disengage (iOS lock-screen recording
+  /// requires this). Default `true` so first-engage path works
+  /// unchanged. Driven by [setCaptureGate].
+  bool _captureGateOpen = true;
 
   // Derived from VadService.frameSize after init()
   int _frameSize = 0;
@@ -139,6 +147,38 @@ class HandsFreeOrchestrator implements HandsFreeEngine {
     unawaited(_stopAndRelease());
   }
 
+  @override
+  Future<void> setCaptureGate({required bool open}) async {
+    if (_captureGateOpen == open) return;
+    _captureGateOpen = open;
+    debugPrint('[HFODbg] setCaptureGate(open=$open)');
+    if (open) {
+      // Synchronous flag flip; takes effect on the next chunk.
+      // VAD pipeline picks up from a clean buffer (we cleared on close).
+      _phase = _Phase.listening;
+      _emit(const EngineListening());
+      return;
+    }
+    // Closing the gate: drop all in-flight VAD state so a half-segment
+    // captured before the close cannot leak into the next open window.
+    // Pre-roll is also cleared — closed-gate audio must not appear in
+    // the pre-roll of the next segment.
+    _chunkQueue.clear();
+    _remainder.clear();
+    _speechBuffer = BytesBuilder(copy: false);
+    _speechFrameCount = 0;
+    _captureFrameCount = 0;
+    _hangoverCount = 0;
+    _preRoll.clear();
+    _pendingFrames.clear();
+    _pendingLabels.clear();
+    _pendingSpeechStarted = false;
+    _cooldownTimer?.cancel();
+    _cooldownTimer = null;
+    _inCooldown = false;
+    _phase = _Phase.listening; // engine itself is still alive in "listening" sub-state
+  }
+
   Future<void> _stopAndRelease() async {
     await stop();
     try {
@@ -192,6 +232,7 @@ class HandsFreeOrchestrator implements HandsFreeEngine {
   // ── Chunk queue (ensures sequential async frame processing) ─────────────────
 
   void _enqueueChunk(Uint8List chunk) {
+    if (!_captureGateOpen) return; // gate closed: discard, mic still warm
     _chunkQueue.add(chunk);
     if (!_processingChunks) _drainQueue();
   }

--- a/lib/features/recording/domain/hands_free_engine.dart
+++ b/lib/features/recording/domain/hands_free_engine.dart
@@ -82,4 +82,23 @@ abstract interface class HandsFreeEngine {
   /// Release all resources. Must be called when the owning controller is
   /// disposed. Safe to call after [stop].
   void dispose();
+
+  /// Open or close the chunk-processing gate.
+  ///
+  /// When the gate is closed the underlying audio stream keeps draining
+  /// (so the OS-level recorder, audio session, and microphone remain
+  /// active) but each chunk is discarded before reaching VAD. No
+  /// segments are emitted, no STT is invoked, no API calls fire.
+  ///
+  /// Used to model "mic stays warm but app is not engaged" — the gate
+  /// is closed on disengage and reopened on engage, so the recorder
+  /// does not have to be torn down and re-acquired (which iOS rejects
+  /// on a locked screen).
+  ///
+  /// On close the in-flight VAD state is reset (remainder, speech
+  /// buffer, pre-roll, cooldown) so a half-segment captured before
+  /// the close cannot leak into the next open window.
+  ///
+  /// Default state on [start] is **open**.
+  Future<void> setCaptureGate({required bool open});
 }

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -68,7 +68,30 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
         unawaited(_disengageOneShot());
       }
     });
+    // Subscribe directly to the TTS ValueNotifier (not via Riverpod's
+    // ttsPlayingProvider) so the auto-resume after TTS fires reliably
+    // on a locked screen. Riverpod's `Provider.invalidateSelf` ->
+    // listener chain depends on the provider being re-evaluated;
+    // when iOS pauses Flutter rendering during lock, that
+    // re-evaluation can be deferred. ValueNotifier listeners fire
+    // synchronously on each value change regardless of UI state.
+    final tts = _ref.read(ttsServiceProvider);
+    final isSpeaking = tts.isSpeaking;
+    void ttsListener() {
+      if (!mounted) return;
+      final speaking = isSpeaking.value;
+      debugPrint('[HFCDbg] tts.isSpeaking → $speaking');
+      if (speaking) {
+        unawaited(suspendForTts());
+      } else {
+        unawaited(resumeAfterTts());
+      }
+    }
+    isSpeaking.addListener(ttsListener);
+    _ttsListenerCleanup = () => isSpeaking.removeListener(ttsListener);
   }
+
+  void Function()? _ttsListenerCleanup;
 
   final Ref _ref;
   final EngagementController _engagement;
@@ -169,7 +192,12 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
 
     if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
     _suspendedByUser = true;
-    await _closeEngagement(toAmbientFor: AudioSessionTarget.playback);
+    // Volume-button engagement model: close the chunk gate; keep the
+    // recorder + audio session alive so the mic is "warm" and the next
+    // engage doesn't have to re-acquire the I/O unit (which iOS
+    // rejects on a locked screen).
+    await _engine?.setCaptureGate(open: false);
+    _engagement.disengage();
     state = HandsFreeIdle(jobs: List.unmodifiable(_jobs));
   }
 
@@ -229,7 +257,12 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     if (_suspendedForManualRecording) return;
     if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
     _suspendedForTts = true;
-    await _closeEngagement(toAmbientFor: AudioSessionTarget.playback);
+    // Volume-button engagement model: close the gate so the mic does
+    // not feed TTS audio back into VAD. Keep the recorder + audio
+    // session alive — tearing them down would force a re-acquisition
+    // on resume that iOS rejects on a locked screen.
+    await _engine?.setCaptureGate(open: false);
+    _engagement.disengage();
     state = HandsFreeIdle(jobs: List.unmodifiable(_jobs));
   }
 
@@ -245,27 +278,37 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   Future<void> resumeAfterTts() async {
     if (_suspendedForManualRecording || _suspendedByUser) return;
     if (state is! HandsFreeIdle) return;
-    if (_suspendedForTts) {
-      _suspendedForTts = false;
-      _pendingConversationResume = false;
-      _resumeEngagement();
-      return;
-    }
-    if (_pendingConversationResume) {
-      _pendingConversationResume = false;
-      _resumeEngagement();
-    }
+    // Auto-resume only after a TTS that was the agent's reply to a
+    // captured segment. `_pendingConversationResume` is set by
+    // `_disengageOneShot` (which runs on every per-segment one-shot
+    // and on the 30 s auto-disengage). A "cold" TTS — one that fires
+    // without a preceding capture — must not silently spin up the
+    // mic. `_suspendedForTts` is the legacy fallback for TTS that
+    // started while the engagement was still open.
+    debugPrint(
+      '[HFCDbg] resumeAfterTts (suspendedForTts=$_suspendedForTts '
+      'pendingConv=$_pendingConversationResume)',
+    );
+    if (!_suspendedForTts && !_pendingConversationResume) return;
+    _suspendedForTts = false;
+    _pendingConversationResume = false;
+    _resumeEngagement();
   }
 
   /// Re-opens an engagement after a soft-suspend (TTS / manual recording /
   /// user pause). Skips the [startSession] start-up guards because they
-  /// were already validated on the first start; the session is just being
-  /// re-engaged. Mirrors the pre-v2 inline `_startEngine` + state assign.
+  /// were already validated on the first start.
   void _resumeEngagement() {
     if (state is! HandsFreeIdle) return;
     _engagement.engage();
     _phase = HandsFreeListeningPhase.listening;
-    _startEngine(_ref.read(appConfigProvider).vadConfig);
+    if (_engine != null) {
+      // Gate-only path: engine + recorder still alive after a
+      // suspend that used setCaptureGate (suspendByUser / TTS).
+      unawaited(_engine!.setCaptureGate(open: true));
+    } else {
+      _startEngine(_ref.read(appConfigProvider).vadConfig);
+    }
     state = _listeningOrBacklog();
   }
 
@@ -341,12 +384,24 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
       _jobCounter = 0;
     }
     // Explicit user-initiated engage cancels any pending TTS-driven
-    // auto-resume — if the user clicks before the agent's reply lands,
-    // they're taking control of the next listening window.
+    // auto-resume and clears any prior suspension flags. The user is
+    // taking control of the next listening window — `resumeAfterTts`
+    // (which gates on these flags) must not bail out if the user
+    // previously volume-down'd before this volume-up.
     _pendingConversationResume = false;
+    _suspendedByUser = false;
+    _suspendedForTts = false;
     _phase = HandsFreeListeningPhase.listening;
     _engagement.engage();
-    _startEngine(_ref.read(appConfigProvider).vadConfig);
+    if (_engine != null) {
+      // Volume-button engagement model: engine + recorder already
+      // running with the gate closed. Just reopen it — no recorder
+      // restart, no audio session re-acquisition. iOS lock-screen
+      // recording requires the I/O unit to stay attached.
+      await _engine!.setCaptureGate(open: true);
+    } else {
+      _startEngine(_ref.read(appConfigProvider).vadConfig);
+    }
     // State is left as-is — the controller transitions into a concrete
     // [HandsFreeListening] (with the right phase) when the first engine
     // event arrives. This matches the pre-v2 contract and keeps the
@@ -428,23 +483,15 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   Future<void> _disengageOneShot() async {
     if (!mounted) return;
     if (state is HandsFreeIdle || state is HandsFreeSessionError) return;
-    _ref.read(sessionActiveProvider.notifier).state = false;
-    await _ref
-        .read(backgroundServiceProvider)
-        .stopService(target: AudioSessionTarget.playback);
-    if (!mounted) return;
+    // Volume-button engagement model: keep the recorder + audio session
+    // alive (mic stays warm), just close the chunk gate so VAD/STT/API
+    // stop processing audio. iOS lock-screen recording requires the
+    // audio I/O unit to remain attached across disengage, so we
+    // deliberately skip stopService / engine.stop here.
+    await _engine?.setCaptureGate(open: false);
     _engagement.disengage();
-    await _engineSub?.cancel();
-    _engineSub = null;
-    await _engine?.stop();
-    _engine = null;
     if (!mounted) return;
     _phase = HandsFreeListeningPhase.listening;
-    // P037 v2: this disengage was driven by a captured segment, so the
-    // upcoming TTS reply (if any) should auto-resume into a fresh
-    // listening window. Setting the flag here covers both "VAD ended
-    // utterance" and "30 s timeout" — in the timeout case there's
-    // simply no jobs, so no TTS will play and the flag is harmless.
     _pendingConversationResume = true;
     state = HandsFreeIdle(jobs: List.unmodifiable(_jobs));
   }
@@ -467,6 +514,7 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _ttsListenerCleanup?.call();
     unawaited(_engagementSub?.cancel());
     unawaited(_engagement.dispose());
     // Clean up WAV files for any remaining unprocessed jobs.

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -8,6 +8,8 @@ import 'package:voice_agent/core/audio/ambient_loop_player.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/media_button/media_button_port.dart';
 import 'package:voice_agent/core/media_button/media_button_provider.dart';
+import 'package:voice_agent/core/volume_button/volume_button_port.dart';
+import 'package:voice_agent/core/volume_button/volume_button_provider.dart';
 import 'package:voice_agent/core/providers/agent_reply_provider.dart';
 import 'package:voice_agent/core/providers/api_url_provider.dart';
 import 'package:voice_agent/core/session_control/session_control_provider.dart';
@@ -28,6 +30,8 @@ class RecordingScreen extends ConsumerStatefulWidget {
 class _RecordingScreenState extends ConsumerState<RecordingScreen> {
   StreamSubscription<MediaButtonEvent>? _mediaButtonSub;
   MediaButtonPort? _mediaButtonPort;
+  StreamSubscription<VolumeButtonEvent>? _volumeButtonSub;
+  VolumeButtonPort? _volumeButtonPort;
   AmbientLoopPlayer? _ambientPlayer;
 
   @override
@@ -41,8 +45,15 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
         // is removed — that was the continuous-listening contract from
         // the pre-v2 model.
         _activateMediaButton();
-        _ambientPlayer = AmbientLoopPlayer();
-        unawaited(_ambientPlayer!.setMode(AmbientMode.idle));
+        _activateVolumeButton();
+        // EXPERIMENT: AmbientLoopPlayer disabled. `audioplayers` package
+        // takes ownership of the AVAudioSession on play/stop, which tears
+        // down the recorder's I/O unit and kills the mic — exactly the
+        // failure mode the always-on capture model is trying to avoid.
+        // Without this player there is no listening tone; will be added
+        // back via a different audio path once gate semantics are stable.
+        // _ambientPlayer = AmbientLoopPlayer();
+        // unawaited(_ambientPlayer!.setMode(AmbientMode.idle));
       }
     });
   }
@@ -51,6 +62,57 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
     _mediaButtonPort = ref.read(mediaButtonProvider);
     unawaited(_mediaButtonPort!.activate());
     _mediaButtonSub = _mediaButtonPort!.events.listen(_onMediaButtonEvent);
+  }
+
+  void _activateVolumeButton() {
+    _volumeButtonPort = ref.read(volumeButtonProvider);
+    unawaited(_volumeButtonPort!.activate());
+    _volumeButtonSub = _volumeButtonPort!.events.listen(_onVolumeButtonEvent);
+  }
+
+  /// Volume UP → engage (start hands-free listening). Volume DOWN →
+  /// suspend (close gate / disengage). Used as a fallback hardware
+  /// gesture for lock-screen capture, since `MPRemoteCommand` events
+  /// are blocked by iOS while `.playAndRecord` has an active mic
+  /// engine. Volume buttons travel a different routing path that is
+  /// not gated by the call-mode rule.
+  void _onVolumeButtonEvent(VolumeButtonEvent event) {
+    final hfState = ref.read(handsFreeControllerProvider);
+    final hfCtrl = ref.read(handsFreeControllerProvider.notifier);
+    final ttsPlaying = ref.read(ttsPlayingProvider);
+    debugPrint(
+      '[VolumeBtnDbg] _onVolumeButtonEvent event=$event hfState=${hfState.runtimeType} ttsPlaying=$ttsPlaying',
+    );
+
+    switch (event) {
+      case VolumeButtonEvent.up:
+        if (hfState is HandsFreeIdle || hfState is HandsFreeSessionError) {
+          debugPrint('[VolumeBtnDbg] branch=engage');
+          unawaited(hfCtrl.startSession().then((_) {
+            ref.read(toasterProvider).show('Listening');
+            ref.read(hapticServiceProvider).lightImpact();
+          }));
+        } else {
+          debugPrint('[VolumeBtnDbg] branch=up-noop (already engaged)');
+        }
+      case VolumeButtonEvent.down:
+        if (ttsPlaying) {
+          // Volume-down during TTS: interrupt the agent's reply but
+          // keep the listening gate open. resumeAfterTts (wired to
+          // ttsPlayingProvider flipping to false) will reopen the
+          // gate automatically.
+          debugPrint('[VolumeBtnDbg] branch=stopTts');
+          unawaited(ref.read(ttsServiceProvider).stop());
+        } else if (hfState is HandsFreeListening) {
+          debugPrint('[VolumeBtnDbg] branch=suspend');
+          unawaited(hfCtrl.suspendByUser().then((_) {
+            ref.read(toasterProvider).show('Paused');
+            ref.read(hapticServiceProvider).lightImpact();
+          }));
+        } else {
+          debugPrint('[VolumeBtnDbg] branch=down-noop (not engaged, no TTS)');
+        }
+    }
   }
 
   void _onMediaButtonEvent(MediaButtonEvent event) {
@@ -106,6 +168,8 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
   void dispose() {
     _mediaButtonSub?.cancel();
     unawaited(_mediaButtonPort?.deactivate());
+    _volumeButtonSub?.cancel();
+    unawaited(_volumeButtonPort?.deactivate());
     unawaited(_ambientPlayer?.dispose());
     super.dispose();
   }
@@ -133,15 +197,11 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
       }
     });
 
-    // Pause VAD while TTS is playing to avoid mic picking up speaker output.
-    ref.listen<bool>(ttsPlayingProvider, (prev, next) {
-      final hfCtrl = ref.read(handsFreeControllerProvider.notifier);
-      if (next) {
-        unawaited(hfCtrl.suspendForTts());
-      } else {
-        unawaited(hfCtrl.resumeAfterTts());
-      }
-    });
+    // TTS suspend/resume is wired at the controller level (in
+    // HandsFreeController's constructor). Doing it in this widget via
+    // `ref.listen` does not survive the lock-screen UI pause —
+    // controller-level listeners are bound to the provider scope and
+    // fire reliably whether the widget tree is visible or not.
 
     // P037 v2: AmbientLoopPlayer drives the audible engagement state.
     //   Idle (no TTS)       → silence_loop.wav (volume 0) — keeps iOS
@@ -369,14 +429,15 @@ class _HandsFreeSection extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         const Divider(height: 1),
-        if (isOn) ...[
-          _HfStatusStrip(hfState: hfState, onRetry: onRetry),
-          if (jobs.isNotEmpty)
-            ConstrainedBox(
-              constraints: const BoxConstraints(maxHeight: 200),
-              child: _SegmentList(jobs: jobs),
-            ),
-        ],
+        if (isOn) _HfStatusStrip(hfState: hfState, onRetry: onRetry),
+        // Segment list remains visible after disengage as long as
+        // there are in-flight or recently-completed jobs — STT and
+        // persistence continue async beyond the engagement window.
+        if (jobs.isNotEmpty)
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 200),
+            child: _SegmentList(jobs: jobs),
+          ),
         const _VadParamsStrip(),
       ],
     );
@@ -385,7 +446,7 @@ class _HandsFreeSection extends StatelessWidget {
   static List<SegmentJob> _jobsOf(HandsFreeSessionState s) => switch (s) {
         HandsFreeListening(:final jobs) => jobs,
         HandsFreeSessionError(:final jobs) => jobs,
-        HandsFreeIdle() => const [],
+        HandsFreeIdle(:final jobs) => jobs,
       };
 }
 

--- a/test/app/app_shell_scaffold_test.dart
+++ b/test/app/app_shell_scaffold_test.dart
@@ -61,6 +61,9 @@ class _NoOpConnectivity extends ConnectivityService {
 }
 
 class _IdleHfEngine implements HandsFreeEngine {
+  @override
+  Future<void> setCaptureGate({required bool open}) async {}
+
   final _ctrl = StreamController<HandsFreeEngineEvent>.broadcast();
   @override Future<bool> hasPermission() async => true;
   @override Stream<HandsFreeEngineEvent> start({required VadConfig config}) => _ctrl.stream;

--- a/test/features/recording/data/hands_free_orchestrator_test.dart
+++ b/test/features/recording/data/hands_free_orchestrator_test.dart
@@ -449,4 +449,124 @@ void main() {
           reason: 'no new events after interruptCapture');
     });
   });
+
+  // ── Capture gate (P038-experiment, "always-on capture with engagement gate") ──
+
+  group('captureGate', () {
+    test('chunks are discarded when gate is closed; recorder stays running',
+        () async {
+      // A long run of speech that would normally trigger EngineCapturing.
+      final labels = List.filled(_minSpeechFrameThreshold * 2, VadLabel.speech);
+      orch = make(labels);
+
+      final events = <HandsFreeEngineEvent>[];
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
+      await waitFor<EngineListening>(events);
+
+      // Close the gate before any chunk arrives.
+      await orch.setCaptureGate(open: false);
+
+      recorder.push(pcm(labels.length));
+      await Future.delayed(const Duration(milliseconds: 200));
+
+      // Recorder is still running (gate is a chunk-level filter, not a
+      // recorder lifecycle event).
+      expect(recorder.started, isTrue,
+          reason: 'closing the gate must not stop the underlying recorder');
+      // VAD never saw the chunks → no Capturing/SegmentReady events.
+      expect(events.whereType<EngineCapturing>(), isEmpty);
+      expect(events.whereType<EngineSegmentReady>(), isEmpty);
+
+      await orch.stop();
+      await sub.cancel();
+    });
+
+    test('reopening the gate emits a fresh EngineListening', () async {
+      orch = make([]);
+
+      final events = <HandsFreeEngineEvent>[];
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
+      await waitFor<EngineListening>(events);
+
+      await orch.setCaptureGate(open: false);
+      final beforeReopen = events.whereType<EngineListening>().length;
+      await orch.setCaptureGate(open: true);
+      // Listener fires asynchronously through the broadcast stream.
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      expect(events.whereType<EngineListening>().length,
+          greaterThan(beforeReopen),
+          reason: 'reopening the gate must signal a fresh listening window');
+
+      await orch.stop();
+      await sub.cancel();
+    });
+
+    test('audio captured BEFORE gate-close does not leak into next open '
+        'window via pre-roll', () async {
+      // Step 1: stream speech with the gate OPEN. Some frames land in the
+      // pre-roll ring. Step 2: close the gate (must clear pre-roll).
+      // Step 3: reopen the gate, push silence, then push enough speech to
+      // emit a segment — and assert the segment does NOT carry the
+      // pre-roll from step 1.
+      final labels = [
+        // Step 1: 3 speech frames (below minSpeechMs; will be in pre-roll
+        // ring once they're processed as labelled-but-not-captured).
+        ...List.filled(3, VadLabel.speech),
+        ...List.filled(_hangoverFrameThreshold, VadLabel.nonSpeech),
+        // Step 3: enough speech to actually emit a segment.
+        ...List.filled(_minSpeechFrameThreshold, VadLabel.speech),
+        ...List.filled(_hangoverFrameThreshold, VadLabel.nonSpeech),
+      ];
+      orch = make(labels);
+
+      final events = <HandsFreeEngineEvent>[];
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
+      await waitFor<EngineListening>(events);
+
+      // Step 1
+      recorder.push(pcm(3 + _hangoverFrameThreshold));
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      // Step 2: close the gate. This MUST clear the pre-roll ring so
+      // step-1 frames cannot leak into the step-3 segment.
+      await orch.setCaptureGate(open: false);
+
+      // Step 3
+      await orch.setCaptureGate(open: true);
+      recorder.push(pcm(_minSpeechFrameThreshold + _hangoverFrameThreshold));
+      await Future.delayed(const Duration(milliseconds: 200));
+
+      // The segment was captured (length >= minSpeechMs), so EngineStopping
+      // must have fired for step 3.
+      expect(events.whereType<EngineStopping>(), isNotEmpty);
+      // We can't inspect the WAV bytes from the test (path_provider is
+      // unavailable). Structural privacy invariant: gate-close is what
+      // resets `_preRoll`, so step-1 audio cannot appear in step-3's
+      // pre-roll. The deeper assertion is that the orchestrator did
+      // not crash on the close→open cycle.
+
+      await orch.stop();
+      await sub.cancel();
+    });
+
+    test('setCaptureGate is idempotent', () async {
+      orch = make([]);
+      final events = <HandsFreeEngineEvent>[];
+      final sub = orch.start(config: const VadConfig.defaults()).listen(events.add);
+      await waitFor<EngineListening>(events);
+
+      // Already open → no-op.
+      await orch.setCaptureGate(open: true);
+      await orch.setCaptureGate(open: true);
+      // Close + double-close.
+      await orch.setCaptureGate(open: false);
+      await orch.setCaptureGate(open: false);
+
+      expect(recorder.started, isTrue);
+
+      await orch.stop();
+      await sub.cancel();
+    });
+  });
 }

--- a/test/features/recording/presentation/hands_free_controller_pause_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_pause_test.dart
@@ -35,6 +35,9 @@ import '../../../helpers/stub_background_service.dart';
 // ── FakeHandsFreeEngine ──────────────────────────────────────────────────────
 
 class _FakeHandsFreeEngine implements HandsFreeEngine {
+  @override
+  Future<void> setCaptureGate({required bool open}) async {}
+
   bool permissionGranted = true;
   bool started = false;
   bool stopped = false;
@@ -279,7 +282,11 @@ void main() {
   });
 
   group('resumeByUser', () {
-    test('from suspended transitions to HandsFreeListening', () async {
+    test('from suspended transitions to HandsFreeListening (gate model)',
+        () async {
+      // Always-on capture model: suspendByUser closes the gate and
+      // disengages, but the recorder + engine stay alive. resumeByUser
+      // reopens the gate without restarting the engine.
       final engine = _FakeHandsFreeEngine();
       final c = _makeContainer(engine: engine);
       await _ctrl(c).startSession();
@@ -288,12 +295,13 @@ void main() {
 
       await _ctrl(c).suspendByUser();
       expect(_stateOf(c), isA<HandsFreeIdle>());
+      // Engine stays running across user suspend; it was never stopped.
+      expect(engine.stopped, isFalse,
+          reason: 'gate model: engine must NOT be stopped on suspend');
 
-      engine.started = false;
       await _ctrl(c).resumeByUser();
 
       expect(_stateOf(c), isA<HandsFreeListening>());
-      expect(engine.started, isTrue, reason: 'engine must restart on resume');
     });
 
     test('is no-op when not suspended by user', () async {
@@ -405,60 +413,52 @@ void main() {
   });
 
   group('conversation-turn auto-resume after TTS (P037 v2)', () {
-    test('TTS-end after per-segment one-shot re-engages a fresh '
-        'listening window', () async {
-      // Reproduces the user-reported gap: per-segment one-shot closes
-      // the engagement immediately, so by the time TTS plays the
-      // controller is already HandsFreeIdle and the legacy
-      // `_suspendedForTts` flag is never set. The conversational
-      // signal `_pendingConversationResume` (set by _disengageOneShot)
-      // must drive the resume instead.
+    test('TTS-end after per-segment one-shot reopens the gate', () async {
+      // Always-on capture model: per-segment one-shot closes the gate
+      // (and disengages); TTS plays; on TTS-end the gate reopens. The
+      // engine is NOT stopped or restarted — only the chunk gate
+      // toggles. State transitions to HandsFreeListening.
       final engine = _FakeHandsFreeEngine();
       final c = _makeContainer(engine: engine);
 
       await _ctrl(c).startSession();
       engine.emit(const EngineSegmentReady('/tmp/seg1.wav'));
-      // Two microtask ticks: one for job → Transcribing, one for
-      // _disengageOneShot to land HandsFreeIdle with the flag set.
+      // Two microtask ticks: one for job → Transcribing, one for the
+      // _disengageOneShot gate-close to land HandsFreeIdle.
       await Future.delayed(Duration.zero);
       await Future.delayed(Duration.zero);
       expect(_stateOf(c), isA<HandsFreeIdle>(),
           reason: 'per-segment one-shot must close engagement');
+      // Engine is NOT stopped — it stays alive with gate closed.
+      expect(engine.stopped, isFalse,
+          reason: 'gate model: engine must stay alive across disengage');
 
-      engine.startCount = 0;
-
-      // No suspendForTts in v2 — the recording_screen still calls it
-      // when ttsPlayingProvider flips to true, but it short-circuits
-      // because state is already Idle. So we only need to fire the
-      // resume callback to model "TTS just ended."
+      // TTS-end (model the listener firing).
       await _ctrl(c).resumeAfterTts();
 
-      expect(engine.startCount, 1,
-          reason: 'TTS-end after captured utterance must re-engage');
+      expect(_stateOf(c), isA<HandsFreeListening>(),
+          reason: 'TTS-end after captured utterance must reopen the gate');
     });
 
-    test('does NOT auto-resume when no segment was captured (cold TTS)',
-        () async {
-      // If TTS plays without a preceding captured segment (e.g. an
-      // unrelated background announcement), we must not silently open
-      // a listening window — that would steal the mic with no user
-      // intent.
+    test('cold TTS-end (no prior engagement) is a no-op', () async {
+      // The user has never engaged in this app session, so _engine is
+      // null. resumeAfterTts must not silently spin up the recorder
+      // from cold — that would surprise the user with an unexpected
+      // mic activation.
       final engine = _FakeHandsFreeEngine();
       final c = _makeContainer(engine: engine);
 
-      // Controller starts in HandsFreeIdle, never engaged → no flag.
-      engine.startCount = 0;
       await _ctrl(c).resumeAfterTts();
 
-      expect(engine.startCount, 0,
-          reason: 'cold TTS-end (no captured segment) must NOT engage');
+      // No engine started, state is still Idle.
+      expect(engine.started, isFalse);
+      expect(_stateOf(c), isA<HandsFreeIdle>());
     });
 
-    test('user re-engaging before TTS-end clears the conversation flag',
-        () async {
-      // User clicks AirPods between disengage and TTS-end. They've
-      // taken control. The deferred TTS-end must NOT trigger a second
-      // engage on top of the user's manual one.
+    test('user re-engaging before TTS-end keeps the manual engage', () async {
+      // User pressed VolumeUp between disengage and TTS-end. They are
+      // already engaged via the explicit press. The deferred TTS-end
+      // must not crash or break the engaged state.
       final engine = _FakeHandsFreeEngine();
       final c = _makeContainer(engine: engine);
 
@@ -468,19 +468,18 @@ void main() {
       await Future.delayed(Duration.zero);
       expect(_stateOf(c), isA<HandsFreeIdle>());
 
-      // User clicks again before TTS plays.
+      // User VolumeUp's again before TTS plays — manually re-engages.
       await _ctrl(c).startSession();
       engine.emit(const EngineListening());
       await Future.delayed(Duration.zero);
       expect(_stateOf(c), isA<HandsFreeListening>());
-      engine.startCount = 0;
 
-      // Now (delayed) TTS-end fires. Should be a no-op — we're
-      // already engaged via the user's manual click.
+      // Now (delayed) TTS-end fires. resumeAfterTts short-circuits on
+      // `state is! HandsFreeIdle`, so no double engage.
       await _ctrl(c).resumeAfterTts();
 
-      expect(engine.startCount, 0,
-          reason: 'manual re-engage must clear pending conversation flag');
+      expect(_stateOf(c), isA<HandsFreeListening>(),
+          reason: 'state stays Listening; TTS-end is a no-op while engaged');
     });
   });
 

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -77,6 +77,9 @@ class _TrackingBackgroundService implements BackgroundService {
 // ── FakeHandsFreeEngine ──────────────────────────────────────────────────────
 
 class FakeHandsFreeEngine implements HandsFreeEngine {
+  @override
+  Future<void> setCaptureGate({required bool open}) async {}
+
   bool permissionGranted = true;
   bool started = false;
   bool stopped = false;
@@ -295,6 +298,9 @@ class _NullSttService implements SttService {
 /// used to verify which path [HandsFreeController.suspendForManualRecording]
 /// takes based on the current session state.
 class _TrackingHfEngine implements HandsFreeEngine {
+  @override
+  Future<void> setCaptureGate({required bool open}) async {}
+
   _TrackingHfEngine({this.onInterruptCapture});
 
   final VoidCallback? onInterruptCapture;

--- a/test/features/recording/presentation/recording_screen_hands_free_test.dart
+++ b/test/features/recording/presentation/recording_screen_hands_free_test.dart
@@ -98,6 +98,9 @@ class _NoOpSttService implements SttService {
 
 /// Fake [HandsFreeEngine] that tests control via [emit].
 class FakeHfEngine implements HandsFreeEngine {
+  @override
+  Future<void> setCaptureGate({required bool open}) async {}
+
   final _ctrl = StreamController<HandsFreeEngineEvent>.broadcast();
   bool started = false;
   bool stopped = false;

--- a/test/features/recording/presentation/recording_screen_mic_button_test.dart
+++ b/test/features/recording/presentation/recording_screen_mic_button_test.dart
@@ -65,6 +65,9 @@ class _NoOpConnectivity extends ConnectivityService {
 }
 
 class _IdleHfEngine implements HandsFreeEngine {
+  @override
+  Future<void> setCaptureGate({required bool open}) async {}
+
   final _ctrl = StreamController<HandsFreeEngineEvent>.broadcast();
   @override Future<bool> hasPermission() async => true;
   @override Stream<HandsFreeEngineEvent> start({required VadConfig config}) => _ctrl.stream;

--- a/test/features/recording/presentation/recording_screen_new_conversation_test.dart
+++ b/test/features/recording/presentation/recording_screen_new_conversation_test.dart
@@ -84,6 +84,9 @@ class _NoOpConnectivity extends ConnectivityService {
 }
 
 class _IdleHfEngine implements HandsFreeEngine {
+  @override
+  Future<void> setCaptureGate({required bool open}) async {}
+
   final _ctrl = StreamController<HandsFreeEngineEvent>.broadcast();
   @override
   Future<bool> hasPermission() async => true;
@@ -100,6 +103,9 @@ class _IdleHfEngine implements HandsFreeEngine {
 
 /// Fake [HandsFreeEngine] that tests control via [emit].
 class _FakeHfEngine implements HandsFreeEngine {
+  @override
+  Future<void> setCaptureGate({required bool open}) async {}
+
   final _ctrl = StreamController<HandsFreeEngineEvent>.broadcast();
 
   void emit(HandsFreeEngineEvent e) => _ctrl.add(e);

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -61,6 +61,9 @@ class _NoOpConnectivity extends ConnectivityService {
 }
 
 class _IdleHfEngine implements HandsFreeEngine {
+  @override
+  Future<void> setCaptureGate({required bool open}) async {}
+
   final _ctrl = StreamController<HandsFreeEngineEvent>.broadcast();
   @override Future<bool> hasPermission() async => true;
   @override Stream<HandsFreeEngineEvent> start({required VadConfig config}) => _ctrl.stream;

--- a/test/features/settings/advanced_settings_screen_test.dart
+++ b/test/features/settings/advanced_settings_screen_test.dart
@@ -57,6 +57,9 @@ class _NoOpConnectivity extends ConnectivityService {
 }
 
 class _IdleHfEngine implements HandsFreeEngine {
+  @override
+  Future<void> setCaptureGate({required bool open}) async {}
+
   final _ctrl = StreamController<HandsFreeEngineEvent>.broadcast();
   @override Future<bool> hasPermission() async => true;
   @override Stream<HandsFreeEngineEvent> start({required VadConfig config}) => _ctrl.stream;


### PR DESCRIPTION
## Summary

Always-on capture with **volume-button engagement** — the working implementation of P038 (the original PR #283 proposal assumed MPRemoteCommand-based engagement, which iOS uniformly blocks while `.playAndRecord` has an active mic engine).

Empirically validated on device:
- VolumeUp from a locked screen engages and starts capturing speech.
- VolumeDown during TTS interrupts the agent's reply (auto-resume picks up after TTS-end).
- VolumeDown while listening (no TTS) closes the capture gate but keeps the mic warm.
- Conversation flow round-trips through TTS in foreground AND on lock screen.

## Architecture

The capture gate from P038 ships as designed:
- `HandsFreeEngine.setCaptureGate({open})` — chunk-level discard, on-close buffer reset (incl. pre-roll clear, cooldown reset).
- Recorder + AVAudioSession stay alive for the lifetime of the app session after first engage.
- `_disengageOneShot` / `suspendByUser` / `suspendForTts` close the gate instead of stopping the engine.

Two key fixes during empirical bring-up:
- **TTS suspend/resume listener moved from widget to controller** (direct `ValueNotifier.addListener` in HandsFreeController constructor). The Riverpod `ref.listen` in `RecordingScreen.build()` does not fire reliably on a locked screen because iOS pauses Flutter rendering. ValueNotifier callbacks fire regardless of UI state.
- **AVAudioSession primed at AppDelegate launch** to `.playAndRecord + .spokenAudio` so the I/O unit is attached before any user gesture. `setPlayAndRecord` becomes a same-category fast-path no-op.

## Why volume buttons (not AirPods)

The empirical T0 from P038 turned out negative: with `.playAndRecord + .spokenAudio` and a hot mic, MPRemoteCommand events are delivered intermittently at best. Volume buttons travel the `AVAudioSession.outputVolume` KVO path which is not gated by the call-mode rule.

Trade-off: the system volume actually changes by one step on each press (programmatic restore via `MPVolumeView` slider is deferred).

## Documented trade-offs

- iOS orange recording indicator continuously visible after first engage.
- First engage of an app session must be performed unlocked.
- Manual recording resets the always-on guarantee until one foreground engage warms the orchestrator (legacy full-teardown path retained for that flow).
- No listening tone — `AmbientLoopPlayer` (audioplayers) was re-acquiring the audio session on every `setMode`, killing the recorder. Disabled. Replacement deferred.
- TTS audio session swap (`_acquirePlaybackFocus` / `_releasePlaybackFocus`) reduced to no-ops for the same reason.

## Test plan

- [x] `flutter test` — 947/947 pass
- [x] `flutter analyze` — no errors (2 unused-element warnings on legacy code paths)
- [x] On-device foreground: VolumeUp engage, speak, segment captured, STT/backend/TTS, auto-resume after TTS, conversation flow ✓
- [x] On-device lock screen: same flow ✓
- [x] VolumeDown during TTS interrupts the reply, auto-resume picks up ✓
- [x] VolumeDown while listening closes gate, mic stays warm (orange dot persists) ✓

## Diff

21 files, +872 / -108. New native bridge (Swift), new Dart `core/volume_button/` triplet, gate field + setter on `HandsFreeOrchestrator`, controller suspension paths refactored to use the gate, full proposal document, 4 new orchestrator tests + 3 rewritten controller tests, `setCaptureGate` stubs added to all `HandsFreeEngine` test fakes.

Replaces / consolidates PR #283 (the original P038 draft) — the architectural decision (always-on capture with engagement gate) is the same; the engagement gesture differs from the proposal's assumption.
