### PR TITLE
refactor(recording): remove 30s auto-disengage timer (P038 addendum)

### DIFF
--- a/docs/decisions/ADR-AUDIO-011-always-on-capture-with-engagement-gate.md
+++ b/docs/decisions/ADR-AUDIO-011-always-on-capture-with-engagement-gate.md
@@ -51,7 +51,22 @@ Documented limitation: the first lock-screen press after a manual recording reve
 
 `flutter_tts_service.dart`'s `_acquirePlaybackFocus` / `_releasePlaybackFocus` (the `setActive(false) → setCategory(.playback) → setActive(true)` round-trip from P034 follow-up) are reduced to no-ops. The round-trip tore down the recorder I/O unit, defeating the always-on capture model. Hardware-button routing during TTS now relies on the same `.playAndRecord + .spokenAudio` posture the volume button gesture already uses.
 
-### 5. TTS suspend/resume listener at controller level
+### 5. The 30 s auto-disengage timer is removed
+
+P037 v2's `EngagementController` carried a 30 s timer that auto-closed
+a listening window if no speech arrived. With the volume-button
+gesture the user has explicit hardware control over the capture gate
+(Volume Up to engage, Volume Down to suspend), so the timer is
+redundant and produces surprising "session quietly closed" behaviour.
+
+`kListeningEngagementTimeout`, `EngagementController._timer` /
+`tickTimeout()` / `markCaptureStarted()`, and the
+`EngagementCapturing` state variant are removed. The state machine
+collapses to `Idle / Listening / Error`. Engagement is now driven
+exclusively by user gesture (volume buttons), per-segment one-shot,
+or error.
+
+### 6. TTS suspend/resume listener at controller level
 
 The `ttsPlayingProvider → suspendForTts/resumeAfterTts` bridge moved from `RecordingScreen.build()` (Riverpod `ref.listen`) to a direct `ValueNotifier.addListener` in the `HandsFreeController` constructor. The widget-level subscription does not fire reliably when iOS pauses Flutter rendering on a lock screen; ValueNotifier callbacks fire on every value change regardless of UI state.
 

--- a/docs/proposals/038-always-on-capture-volume-button-engagement.md
+++ b/docs/proposals/038-always-on-capture-volume-button-engagement.md
@@ -204,3 +204,53 @@ All other test fakes that implement `HandsFreeEngine` got a `setCaptureGate` stu
 `ADR-AUDIO-011 — Always-on capture with engagement gate` (drafted in PR #283 alongside the original P038) captures the always-on-capture decision and the privacy-indicator trade-off. It carries forward unchanged for this implementation; the engagement gesture (volume buttons vs MPRemoteCommand) is a tactical choice within the same architectural model.
 
 The supersession note on `ADR-AUDIO-009` (lifecycle portion superseded by ADR-AUDIO-011) also carries forward unchanged.
+
+## Addendum (2026-05-02): the 30 s auto-disengage timer is removed
+
+P037 v2 added a 30 s auto-disengage timer in `EngagementController` to
+auto-close a listening window if no speech arrived. The timer was a
+safety net for the `MPRemoteCommand` engagement gesture, where the user
+could click AirPods and forget — the app would silently close the
+session after a quiet half-minute.
+
+In the P038 always-on capture model that timer is **redundant and
+surprising**:
+
+- Engagement is now driven by **explicit hardware gestures** (Volume
+  Up to engage, Volume Down to suspend / interrupt TTS). The user has
+  unambiguous control over the capture gate at any moment.
+- The recorder + audio session stay alive across disengage anyway —
+  the cost the timer was minimising (mic warm uselessly) no longer
+  matters because the mic is always warm by design.
+- A timer-driven "session quietly closed" is harder to reason about
+  in a model where the user expects "I pressed Volume Up so I'm
+  listening, until I press Volume Down."
+
+The following code is removed in this addendum:
+
+- `kListeningEngagementTimeout` constant
+- `EngagementController._timer` / `_timeout` / `tickTimeout()` / the
+  `Timer(_timeout, tickTimeout)` start in `engage()`
+- `EngagementController.markCaptureStarted()` (its sole purpose was
+  to cancel the timer on VAD start-of-speech)
+- `EngagementCapturing` state variant (only set by
+  `markCaptureStarted`; replaced semantically by `HandsFreeListening`
+  with `phase == capturing` at the controller layer)
+- The `_engagement.markCaptureStarted()` call in
+  `HandsFreeController._onEngineEvent` for `EngineCapturing`
+
+The `EngagementController` API is now: `engage` / `disengage` /
+`markError` / `state` / `stream` / `dispose`. State machine collapses
+to `Idle / Listening / Error`.
+
+Test impact: the PR #278 regression test ("STT completing after
+auto-disengage keeps state HandsFreeIdle") was rewritten to use
+`suspendByUser` instead of `tickTimeout` — the underlying invariant
+(jobs progressing async after disengage do not flip state back to
+Listening) is unchanged; only the trigger differs.
+
+If a future feature needs an inactivity timeout (e.g. "auto-pause
+after 5 min of no speech to release the orange dot"), it can be
+re-added at the controller layer with explicit user-visible
+semantics, rather than at the engagement layer where it produced
+silent state changes.

--- a/lib/features/recording/domain/engagement_controller.dart
+++ b/lib/features/recording/domain/engagement_controller.dart
@@ -2,15 +2,10 @@ import 'dart:async';
 
 import 'package:voice_agent/features/recording/domain/engagement_state.dart';
 
-/// Auto-disengage timeout for the [EngagementController]. Hard-coded per
-/// the P037 v2 task list (T6) — exposed via [AppConfig] later.
-const Duration kListeningEngagementTimeout = Duration(seconds: 30);
-
-/// State machine for the P037 v2 tap-to-engage listening lifecycle (T3).
+/// State machine for the hands-free engagement lifecycle.
 ///
 /// Owns:
 ///   • the [EngagementState] (`Idle / Listening / Capturing / Error`),
-///   • the 30 s auto-disengage timer (T6),
 ///   • notifications to interested observers via [stream].
 ///
 /// Lives in `features/recording/domain/` because it is a state machine
@@ -23,15 +18,21 @@ const Duration kListeningEngagementTimeout = Duration(seconds: 30);
 /// Keeping that bridge outside the state machine preserves the layering
 /// rule (domain depends on no platform code) and lets the controller
 /// orchestrate side effects synchronously around state transitions.
+///
+/// **P038 update (2026-05-02):** the original P037 v2 30 s
+/// auto-disengage timer was removed. With the always-on capture +
+/// volume-button engagement model the user has explicit hardware
+/// control over the capture gate (Volume Up to engage, Volume Down to
+/// suspend / interrupt TTS), so the auto-disengage safety net is
+/// redundant and was producing surprising "session quietly closed"
+/// behaviour. Engage / disengage are now driven exclusively by user
+/// gesture, segment-ready (per-segment one-shot), or error.
 class EngagementController {
-  EngagementController({Duration? timeout})
-      : _timeout = timeout ?? kListeningEngagementTimeout;
+  EngagementController();
 
-  final Duration _timeout;
   final _controller = StreamController<EngagementState>.broadcast();
 
   EngagementState _state = const EngagementIdle();
-  Timer? _timer;
   bool _disposed = false;
 
   /// Current engagement state.
@@ -40,58 +41,32 @@ class EngagementController {
   /// Stream of engagement state changes.
   Stream<EngagementState> get stream => _controller.stream;
 
-  /// Open an engagement: Idle → Listening. Starts the auto-disengage
-  /// timer. Idempotent when already engaged.
+  /// Open an engagement: any non-error → Listening. Idempotent when
+  /// already engaged.
   void engage() {
     _ensureNotDisposed();
-    if (_state is EngagementListening || _state is EngagementCapturing) return;
-    _cancelTimer();
+    if (_state is EngagementListening) return;
     _setState(const EngagementListening());
-    _timer = Timer(_timeout, tickTimeout);
   }
 
-  /// Mark VAD start-of-speech: Listening → Capturing. Cancels the
-  /// auto-disengage timer (the segment will end naturally on VAD
-  /// end-of-speech). No-op if not in Listening.
-  void markCaptureStarted() {
-    _ensureNotDisposed();
-    if (_state is! EngagementListening) return;
-    _cancelTimer();
-    _setState(const EngagementCapturing());
-  }
-
-  /// Close the current engagement: any non-Idle → Idle. Cancels the
-  /// auto-disengage timer. Idempotent when already idle.
+  /// Close the current engagement: any non-Idle → Idle. Idempotent
+  /// when already idle.
   void disengage() {
     _ensureNotDisposed();
     if (_state is EngagementIdle) return;
-    _cancelTimer();
     _setState(const EngagementIdle());
   }
 
-  /// Auto-disengage trigger fired by the 30 s timer. Public so tests
-  /// (and future synchronous-fake callers) can drive the transition
-  /// without waiting for real time. Equivalent to [disengage] when in
-  /// Listening; no-op otherwise.
-  void tickTimeout() {
-    _ensureNotDisposed();
-    if (_state is! EngagementListening) return;
-    _cancelTimer();
-    _setState(const EngagementIdle());
-  }
-
-  /// Mark an unrecoverable engagement-layer error. Cancels the timer.
+  /// Mark an unrecoverable engagement-layer error.
   void markError(String message) {
     _ensureNotDisposed();
-    _cancelTimer();
     _setState(EngagementError(message));
   }
 
-  /// Release timer + stream resources. Safe to call multiple times.
+  /// Release stream resources. Safe to call multiple times.
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
-    _cancelTimer();
     await _controller.close();
   }
 
@@ -102,11 +77,6 @@ class EngagementController {
     if (!_controller.isClosed) {
       _controller.add(next);
     }
-  }
-
-  void _cancelTimer() {
-    _timer?.cancel();
-    _timer = null;
   }
 
   void _ensureNotDisposed() {

--- a/lib/features/recording/domain/engagement_state.dart
+++ b/lib/features/recording/domain/engagement_state.dart
@@ -1,41 +1,38 @@
-/// Runtime state of the tap-to-engage listening machine introduced by
-/// P037 v2 (Candidate B). The engagement machine is the high-level
-/// "are we currently capturing speech for one turn or not?" model that
-/// drives audio-session category transitions and the 30 s auto-disengage
-/// timer.
+/// Runtime state of the engagement machine.
 ///
-/// Layered above this, [HandsFreeSessionState] still carries the segment
-/// job list so the UI can render in-flight transcription/persistence work.
+/// The engagement machine is the high-level "is the user actively
+/// engaged in a hands-free turn?" model that drives capture-gate
+/// transitions in the always-on capture model (P038).
+///
+/// Layered above this, [HandsFreeSessionState] still carries the
+/// segment job list so the UI can render in-flight
+/// transcription/persistence work.
+///
+/// **History:**
+/// - P037 v2 added a third [EngagementCapturing] variant and a 30 s
+///   auto-disengage timer that ran while [EngagementListening].
+/// - P038 (2026-05-02) collapsed the model back to two active variants
+///   (Idle / Listening) and removed the timer. Engagement is now
+///   driven exclusively by user gesture (volume buttons), per-segment
+///   one-shot disengage, and explicit error.
 sealed class EngagementState {
   const EngagementState();
 }
 
-/// Resting state. Audio session is `.playback`; mic is not engaged. The
-/// app remains the active media participant so AirPods short-click is
-/// routed via `MPRemoteCommandCenter`.
+/// Resting state. Capture gate is closed; the recorder may still be
+/// running with chunks discarded (always-on capture model from P038).
 class EngagementIdle extends EngagementState {
   const EngagementIdle();
 }
 
-/// Engagement opened. Audio session is `.playAndRecord`, VAD is running,
-/// the 30 s auto-disengage timer is active. Transitions to
-/// [EngagementCapturing] on VAD start-of-speech (which cancels the timer)
-/// or back to [EngagementIdle] on `disengage()` / `tickTimeout()`.
+/// Engagement opened. Capture gate is open; VAD is processing audio
+/// chunks. Transitions back to [EngagementIdle] on `disengage()`.
 class EngagementListening extends EngagementState {
   const EngagementListening();
 }
 
-/// VAD detected start-of-speech and is accumulating an utterance. The
-/// 30 s timer was cancelled at start-of-speech. Transitions back to
-/// [EngagementIdle] on `disengage()` (typically called when the engine
-/// reports the segment is ready and the controller decides to close the
-/// turn).
-class EngagementCapturing extends EngagementState {
-  const EngagementCapturing();
-}
-
-/// Unrecoverable engagement error. Mirrors [HandsFreeSessionError] at the
-/// engagement layer. The owning [HandsFreeController] surfaces the
+/// Unrecoverable engagement error. Mirrors [HandsFreeSessionError] at
+/// the engagement layer. The owning [HandsFreeController] surfaces the
 /// detailed error message via [HandsFreeSessionError]; this variant is
 /// only used to gate transitions inside [EngagementController].
 class EngagementError extends EngagementState {

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -537,8 +537,9 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
       case EngineCapturing():
         unawaited(_ref.read(ttsServiceProvider).stop());
         _phase = HandsFreeListeningPhase.capturing;
-        // Inform the engagement layer so the 30 s timer is cancelled.
-        _engagement.markCaptureStarted();
+        // P038 update: the 30 s auto-disengage timer was removed
+        // (engagement is now exclusively user-driven via volume
+        // buttons), so there is nothing to cancel here.
         state = _listeningOrBacklog();
 
       case EngineStopping():

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -1092,18 +1092,19 @@ void main() {
 
   // ── Auto-disengage with in-flight jobs (P037 v2 regression) ────────────────
   group('auto-disengage with in-flight jobs', () {
-    test('STT completing after auto-disengage keeps state HandsFreeIdle',
-        () async {
-      // Reproduces the regression where _processJob's
-      // `state = _listeningOrBacklog()` flipped HandsFreeIdle back to
-      // HandsFreeListening when a job state advanced (Transcribing →
-      // Persisting → Completed) while engagement was already closed.
+    test('STT completing after user-driven disengage keeps state '
+        'HandsFreeIdle', () async {
+      // PR #278 regression: `_processJob`'s `state = _listeningOrBacklog()`
+      // used to flip HandsFreeIdle back to HandsFreeListening when a job
+      // state advanced (Transcribing → Persisting → Completed) while
+      // engagement was already closed. P038 keeps the same invariant:
+      // any disengage path (per-segment one-shot, suspendByUser,
+      // suspendForTts) leaves jobs in flight to complete asynchronously,
+      // and the public state must stay Idle.
       final engine = FakeHandsFreeEngine();
       final sttCompleter = Completer<TranscriptResult>();
       final stt = _ControllableSttService(sttCompleter);
       final storage = FakeStorageService();
-      final engagement =
-          EngagementController(timeout: const Duration(milliseconds: 5));
 
       final container = ProviderContainer(overrides: [
         handsFreeEngineProvider.overrideWithValue(engine),
@@ -1123,25 +1124,21 @@ void main() {
           _StubAudioFeedbackService(),
         ),
         backgroundServiceProvider.overrideWithValue(StubBackgroundService()),
-        handsFreeControllerProvider.overrideWith(
-          (ref) => HandsFreeController(ref, engagement: engagement),
-        ),
       ]);
       addTearDown(container.dispose);
 
-      await container.read(handsFreeControllerProvider.notifier).startSession();
+      final ctrl = container.read(handsFreeControllerProvider.notifier);
+      await ctrl.startSession();
       engine.emit(const EngineSegmentReady('/tmp/seg1.wav'));
       await Future.delayed(Duration.zero); // Queued → Transcribing
 
-      // Trigger the 30 s auto-disengage. Listener microtask runs and the
-      // controller should transition to HandsFreeIdle preserving the
-      // Transcribing job in `jobs`.
-      engagement.tickTimeout();
-      await Future.delayed(const Duration(milliseconds: 10));
+      // User-driven disengage (Volume Down). Replaces the P037 v2
+      // 30 s timer that this test originally exercised.
+      await ctrl.suspendByUser();
       expect(
         container.read(handsFreeControllerProvider),
         isA<HandsFreeIdle>(),
-        reason: 'auto-disengage should land in HandsFreeIdle',
+        reason: 'user-driven disengage should land in HandsFreeIdle',
       );
 
       // Now finish STT — this triggers the original bug if


### PR DESCRIPTION
P038 addendum. With volume-button engagement the user has explicit hardware control over the capture gate, so the P037 v2 30s timer is redundant and produces surprising 'session quietly closed' behaviour. Removes the timer + its cancellation hook (`markCaptureStarted`) + the unused `EngagementCapturing` state variant.

ADR-AUDIO-011 and P038 proposal updated with the rationale.

PR #278's regression test rewritten to use `suspendByUser` instead of `tickTimeout`; the underlying invariant (jobs progressing async after disengage stay in HandsFreeIdle) is unchanged.

947/947 tests pass.