### PR TITLE
feat(recording): mic button engages hands-free (orange when listening)

### DIFF
--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -593,15 +593,22 @@ class _MicButtonState extends ConsumerState<_MicButton> {
     final recCtrl = ref.read(recordingControllerProvider.notifier);
     final hfCtrl = ref.read(handsFreeControllerProvider.notifier);
 
+    // Tap-driven hands-free engagement (P038): mirror the Volume Up
+    // gesture so the on-screen button is a UI parity affordance.
+    // Idle (or in error state) → engage. Listening → suspend. The
+    // legacy push-to-talk path stays on long-press; tapping here used
+    // to start manual recording, but with always-on capture in place
+    // long-press is the cleaner gesture for that intent.
     if (recState is RecordingIdle) {
-      if (hfState is HandsFreeListening &&
-          hfState.phase == HandsFreeListeningPhase.stopping) {
-        return; // no-op — wait for stop
+      if (hfState is HandsFreeListening) {
+        if (hfState.phase == HandsFreeListeningPhase.stopping) return;
+        await hfCtrl.suspendByUser();
+      } else if (hfState is HandsFreeIdle ||
+          hfState is HandsFreeSessionError) {
+        ref.read(latestAgentReplyProvider.notifier).state = null;
+        await ref.read(ttsServiceProvider).stop();
+        await hfCtrl.startSession();
       }
-      ref.read(latestAgentReplyProvider.notifier).state = null;
-      await ref.read(ttsServiceProvider).stop();
-      await hfCtrl.suspendForManualRecording();
-      await recCtrl.startRecording();
     } else if (recState is RecordingActive) {
       await recCtrl.stopAndTranscribe();
     } else if (recState is RecordingPaused) {
@@ -653,6 +660,8 @@ class _MicButtonState extends ConsumerState<_MicButton> {
     final isTranscribing = recState is RecordingTranscribing;
     final isHfCapturing = hfState is HandsFreeListening &&
         hfState.phase == HandsFreeListeningPhase.capturing;
+    final isHfListeningQuiet = hfState is HandsFreeListening &&
+        hfState.phase == HandsFreeListeningPhase.listening;
 
     // Clear press-and-hold flag when recording returns to idle or errors out.
     ref.listen<RecordingState>(recordingControllerProvider, (_, next) {
@@ -661,6 +670,12 @@ class _MicButtonState extends ConsumerState<_MicButton> {
       }
     });
 
+    // Color reflects what the next tap does + what is currently going
+    // on under the hood. Red = audio is actively being captured (manual
+    // record OR VAD mid-utterance). Orange = engaged but quiet (gate
+    // open, manual paused, or press-and-hold mid-recording). Grey =
+    // transcribing in progress (button is non-interactive). Green =
+    // idle / available — tap to engage.
     final color = isTranscribing
         ? Colors.grey
         : isPaused
@@ -669,7 +684,9 @@ class _MicButtonState extends ConsumerState<_MicButton> {
                 ? Colors.orange
                 : (isRecording || isHfCapturing)
                     ? Colors.red
-                    : Colors.green;
+                    : isHfListeningQuiet
+                        ? Colors.orange
+                        : Colors.green;
 
     final label = isPaused
         ? 'Paused — tap to resume'
@@ -677,7 +694,9 @@ class _MicButtonState extends ConsumerState<_MicButton> {
             ? (_isPressAndHold ? 'Release to stop' : 'Tap to stop')
             : isTranscribing
                 ? 'Transcribing...'
-                : 'Tap to record';
+                : isHfListeningQuiet
+                    ? 'Listening — tap to suspend'
+                    : 'Tap to start listening';
 
     return GestureDetector(
       onTap: _onTap,

--- a/test/features/recording/presentation/recording_screen_mic_button_test.dart
+++ b/test/features/recording/presentation/recording_screen_mic_button_test.dart
@@ -65,12 +65,20 @@ class _NoOpConnectivity extends ConnectivityService {
 }
 
 class _IdleHfEngine implements HandsFreeEngine {
-  @override
-  Future<void> setCaptureGate({required bool open}) async {}
-
   final _ctrl = StreamController<HandsFreeEngineEvent>.broadcast();
+
+  @override
+  Future<void> setCaptureGate({required bool open}) async {
+    if (open) _ctrl.add(const EngineListening());
+  }
+
   @override Future<bool> hasPermission() async => true;
-  @override Stream<HandsFreeEngineEvent> start({required VadConfig config}) => _ctrl.stream;
+  @override Stream<HandsFreeEngineEvent> start({required VadConfig config}) {
+    // Mirror the real orchestrator: emit EngineListening once subscribed
+    // so the controller transitions out of HandsFreeIdle.
+    Future.microtask(() => _ctrl.add(const EngineListening()));
+    return _ctrl.stream;
+  }
   @override Future<void> stop() async {}
   @override Future<void> interruptCapture() async {}
   @override void dispose() => _ctrl.close();
@@ -215,8 +223,8 @@ Future<_SpyTtsService> _pumpAppWithSpyTts(WidgetTester tester) async {
 void main() {
   setUpAll(() => WidgetsFlutterBinding.ensureInitialized());
 
-  group('tap-to-record', () {
-    testWidgets('idle → tap → button turns red', (tester) async {
+  group('tap-to-engage (P038 — hands-free via mic button)', () {
+    testWidgets('idle → tap → button turns orange (listening)', (tester) async {
       await pumpApp(tester);
 
       await tester.tap(find.byKey(const Key('record-button')));
@@ -226,17 +234,19 @@ void main() {
         find.byKey(const Key('record-button')),
       );
       final decoration = container.decoration as BoxDecoration;
-      expect(decoration.color, equals(Colors.red));
+      expect(decoration.color, equals(Colors.orange),
+          reason: 'tap engages hands-free; button reflects gate-open state');
     });
 
-    testWidgets('idle → tap → shows "Tap to stop" label', (tester) async {
+    testWidgets('idle → tap → shows "Listening — tap to suspend" label',
+        (tester) async {
       await pumpApp(tester);
 
       await tester.tap(find.byKey(const Key('record-button')));
       await tester.pumpAndSettle();
 
-      expect(find.text('Tap to stop'), findsOneWidget);
-      expect(find.text('Tap to record'), findsNothing);
+      expect(find.text('Listening — tap to suspend'), findsOneWidget);
+      expect(find.text('Tap to start listening'), findsNothing);
     });
   });
 
@@ -300,7 +310,7 @@ void main() {
 
       // silentOnEmpty → RecordingIdle, no error
       expect(find.byIcon(Icons.error), findsNothing);
-      expect(find.text('Tap to record'), findsOneWidget);
+      expect(find.text('Tap to start listening'), findsOneWidget);
     });
   });
 

--- a/test/features/recording/presentation/recording_screen_test.dart
+++ b/test/features/recording/presentation/recording_screen_test.dart
@@ -122,7 +122,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byIcon(Icons.mic), findsWidgets);
-    expect(find.text('Tap to record'), findsOneWidget);
+    expect(find.text('Tap to start listening'), findsOneWidget);
   });
 
   testWidgets('Record screen shows error when API URL not configured',


### PR DESCRIPTION
Mirror the Volume Up gesture on the on-screen mic button. Tap on idle now engages hands-free (opens the capture gate); button turns orange. Tap again suspends (closes gate, returns to green). Long-press still does push-to-talk manual recording.

| State | Color | Label |
|---|---|---|
| Idle | Green | Tap to start listening |
| Listening (quiet) | Orange | Listening — tap to suspend |
| Capturing / Recording | Red | Tap to stop / Release to stop |
| Paused (manual) | Orange | Paused — tap to resume |
| Transcribing | Grey | Transcribing... |

947/947 tests pass.