### PR TITLE
feat(notifications): PoC come-back local notification (iOS)

### DIFF
--- a/docs/proposals/POC-come-back-notification.md
+++ b/docs/proposals/POC-come-back-notification.md
@@ -1,0 +1,92 @@
+# PoC — "Come back" notification on iOS
+
+> **This is not a proposal.** It's a throwaway proof-of-concept doc to record
+> what we tried, why, and what we learned. Do not run `/proposal-review` on it.
+> If the PoC graduates into real work, write a proper proposal then.
+
+## Status: Draft / not implemented
+
+## Goal
+
+Verify on a physical iPhone that the app can show a local notification 30
+seconds after going to background, and that it gets cancelled if the user
+returns sooner.
+
+This is purely a learning exercise — to confirm the iOS local-notification
+plumbing works for our stack before designing anything around it (e.g.
+re-engagement nudges, abandoned-recording reminders).
+
+## Non-goals
+
+- Not a re-engagement feature design. No copy, no analytics, no scheduling
+  rules.
+- Not Android. iOS only for the PoC; Android wiring (and `POST_NOTIFICATIONS`
+  runtime prompt) can come later if the PoC is promising.
+- Not background work. We are not waking the app, not running code in
+  background — just scheduling a local notification with the OS.
+
+## Approach
+
+Smallest path that exercises the real iOS APIs:
+
+1. Add `flutter_local_notifications` dependency.
+2. Create `lib/core/notifications/come_back_notifier.dart`:
+   - `init()` — initializes the plugin, requests `alert + badge + sound`
+     permission via the iOS-specific options.
+   - `scheduleComeBack({Duration delay = const Duration(seconds: 30)})` —
+     schedules a local notification with id `1`, title `"Come back"`,
+     body `"You left voice-agent 30s ago."`.
+   - `cancelComeBack()` — cancels id `1`.
+3. Hook into app lifecycle in `lib/app/app.dart` via `WidgetsBindingObserver`:
+   - `AppLifecycleState.paused` → `scheduleComeBack()`
+   - `AppLifecycleState.resumed` → `cancelComeBack()`
+4. Call `init()` once during app startup.
+
+## What this deliberately skips (PoC discipline)
+
+- No Riverpod provider. Direct singleton usage in the observer is fine for a
+  throwaway test; if it stays, refactor to a provider later.
+- No tests. Lifecycle-driven local notifications are device-only behavior;
+  unit tests would mock everything that matters and prove nothing.
+- No settings UI, no on/off toggle, no copy variants.
+- No Android manifest changes. iOS only.
+- No `Info.plist` changes — local notifications don't need an entitlement, the
+  permission prompt is enough.
+
+## Manual verification (the only verification that counts here)
+
+On a physical iPhone, debug build:
+
+1. First launch → permission prompt appears → tap **Allow**.
+2. Send app to background (home gesture). Wait 30s. → Notification appears.
+3. Tap notification → app returns to foreground (default behavior, no custom
+   handler).
+4. Repeat: send to background, return within ~10s. → No notification fires.
+5. Permission denied path: deny in Settings → no notification, no crash.
+6. Lock screen path: send to background, lock device, wait 30s. → Notification
+   shows on lock screen.
+
+## Open questions to answer with the PoC
+
+- Does iOS actually deliver close to 30s, or is there noticeable drift in
+  low-power mode?
+- Does it still fire if the app is force-quit (swiped away in the app
+  switcher) within the 30s window? Expected: yes — schedule is owned by the
+  OS.
+- Permission prompt timing: do we want to ask on first launch, or defer until
+  the first time the user backgrounds the app?
+
+## Decision after PoC
+
+After running the manual checks above, decide one of:
+
+- **Drop** — delete the branch and this file. Notifications aren't worth it
+  for our use cases.
+- **Promote** — write a real proposal (`039-…`) that defines the actual
+  re-engagement behavior, copy, settings, Android parity, ADR for permission
+  ownership, and tests for the controller logic.
+- **Park** — keep the code behind a debug-only flag while we figure out what
+  re-engagement should actually do.
+
+Until that decision is made, this doc is the only artifact. No ADR, no
+proposal review, no implementation review.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -7,6 +7,8 @@ PODS:
   - Flutter (1.0.0)
   - flutter_foreground_task (0.0.1):
     - Flutter
+  - flutter_local_notifications (0.0.1):
+    - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
   - flutter_tts (0.0.1):
@@ -35,6 +37,7 @@ DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - Flutter (from `Flutter`)
   - flutter_foreground_task (from `.symlinks/plugins/flutter_foreground_task/ios`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - flutter_tts (from `.symlinks/plugins/flutter_tts/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
@@ -57,6 +60,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_foreground_task:
     :path: ".symlinks/plugins/flutter_foreground_task/ios"
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
   flutter_tts:
@@ -77,6 +82,7 @@ SPEC CHECKSUMS:
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_foreground_task: a159d2c2173b33699ddb3e6c2a067045d7cebb89
+  flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   flutter_tts: 35ac3c7d42412733e795ea96ad2d7e05d0a75113
   onnxruntime-c: 7f778680e96145956c0a31945f260321eed2611a

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:voice_agent/app/router.dart';
+import 'package:voice_agent/core/notifications/come_back_notifier.dart';
 
 class App extends StatefulWidget {
   const App({super.key, this.scaffoldMessengerKey});
@@ -17,8 +18,34 @@ class App extends StatefulWidget {
   State<App> createState() => _AppState();
 }
 
-class _AppState extends State<App> {
+class _AppState extends State<App> with WidgetsBindingObserver {
   late final _router = createRouter();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.paused:
+        ComeBackNotifier.instance.scheduleComeBack();
+      case AppLifecycleState.resumed:
+        ComeBackNotifier.instance.cancelComeBack();
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden:
+        break;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/core/notifications/come_back_notifier.dart
+++ b/lib/core/notifications/come_back_notifier.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/data/latest_all.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
+
+/// PoC notifier — see docs/proposals/POC-come-back-notification.md.
+/// iOS only for now. Singleton on purpose; if this graduates, refactor to a
+/// Riverpod provider.
+class ComeBackNotifier {
+  ComeBackNotifier._();
+  static final ComeBackNotifier instance = ComeBackNotifier._();
+
+  static const int _notificationId = 1;
+
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  bool _initialized = false;
+
+  Future<void> init() async {
+    if (_initialized) return;
+
+    tz_data.initializeTimeZones();
+    // PoC: stay on UTC. zonedSchedule treats `now(local).add(delay)` as an
+    // absolute instant, so the wall-clock offset is identical regardless of
+    // which IANA zone is "local".
+
+    const initSettings = InitializationSettings(
+      iOS: DarwinInitializationSettings(
+        requestAlertPermission: true,
+        requestBadgePermission: true,
+        requestSoundPermission: true,
+      ),
+    );
+
+    await _plugin.initialize(initSettings);
+    _initialized = true;
+
+    if (kDebugMode) {
+      debugPrint('[ComeBackNotifier] initialized');
+    }
+  }
+
+  Future<void> scheduleComeBack({
+    Duration delay = const Duration(seconds: 30),
+  }) async {
+    if (!_initialized) return;
+
+    final fireAt = tz.TZDateTime.now(tz.local).add(delay);
+
+    await _plugin.zonedSchedule(
+      _notificationId,
+      'Come back',
+      'You left voice-agent ${delay.inSeconds}s ago.',
+      fireAt,
+      const NotificationDetails(
+        iOS: DarwinNotificationDetails(
+          presentAlert: true,
+          presentBadge: true,
+          presentSound: true,
+        ),
+      ),
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+    );
+
+    if (kDebugMode) {
+      debugPrint('[ComeBackNotifier] scheduled for $fireAt');
+    }
+  }
+
+  Future<void> cancelComeBack() async {
+    if (!_initialized) return;
+    await _plugin.cancel(_notificationId);
+    if (kDebugMode) {
+      debugPrint('[ComeBackNotifier] cancelled');
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/app/app.dart';
 import 'package:voice_agent/core/background/flutter_foreground_task_service.dart';
+import 'package:voice_agent/core/notifications/come_back_notifier.dart';
 import 'package:voice_agent/core/session_control/session_control_provider.dart';
 import 'package:voice_agent/core/session_control/toaster.dart';
 import 'package:voice_agent/core/storage/sqlite_storage_service.dart';
@@ -13,6 +14,8 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   FlutterForegroundTaskService.initForegroundTask();
+
+  await ComeBackNotifier.instance.init();
 
   final storage = await SqliteStorageService.initialize();
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import audioplayers_darwin
 import connectivity_plus
+import flutter_local_notifications
 import flutter_secure_storage_macos
 import flutter_tts
 import record_macos
@@ -16,6 +17,7 @@ import sqflite_darwin
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FlutterTtsPlugin.register(with: registry.registrar(forPlugin: "FlutterTtsPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -214,6 +214,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      url: "https://pub.dev"
+    source: hosted
+    version: "18.0.1"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -821,6 +845,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  timezone:
+    dependency: "direct main"
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
   flutter_tts: ^4.2.5
   audioplayers: ^6.0.0
   flutter_foreground_task: ^9.2.2
+  flutter_local_notifications: ^18.0.1
+  timezone: ^0.10.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Proof-of-concept: shows a local notification "Come back" 30s after the app goes to background, cancels it on resume. iOS only. **Not a designed feature** — this is a deliberate PoC to validate the iOS local-notifications stack before deciding what re-engagement should actually do.

See `docs/proposals/POC-come-back-notification.md` for the PoC scope, non-goals, and post-PoC decision options (drop / promote / park).

## Changes

- `pubspec.yaml`: add `flutter_local_notifications ^18.0.1`, `timezone ^0.10.0`.
- `lib/core/notifications/come_back_notifier.dart`: singleton with `init()` / `scheduleComeBack()` / `cancelComeBack()` using `zonedSchedule` (OS-managed; survives Dart isolate suspension).
- `lib/main.dart`: `await ComeBackNotifier.instance.init()` at startup.
- `lib/app/app.dart`: `WidgetsBindingObserver` — `paused` → schedule, `resumed` → cancel.
- `docs/proposals/POC-come-back-notification.md`: PoC doc explaining intent.

## Verification

- `flutter analyze`: no new issues (3 pre-existing warnings unrelated).
- `flutter test`: 947 passed.
- Manual on physical iPhone (debug build): permission prompt, 30s delivery, cancel-on-resume all confirmed.

## Test plan

- [x] `make verify` passes
- [x] Schedule + cancel verified on device
- [x] 30s notification delivery verified on device
- [ ] Edge cases (lock screen, force-quit, low-power mode) — left for later if PoC graduates
