### PR TITLE
fix(chat): unwrap data envelope in getModels, getBackends, toggleEndorse

### DIFF
--- a/lib/features/chat/data/api_chat_repository.dart
+++ b/lib/features/chat/data/api_chat_repository.dart
@@ -106,7 +106,8 @@ class ApiChatRepository implements ChatRepository {
     );
     final body = _unwrap(result);
     final json = jsonDecode(body) as Map<String, dynamic>;
-    return (json['models'] as List)
+    final data = json['data'] as Map<String, dynamic>;
+    return (data['models'] as List)
         .map((e) => ModelInfo.fromMap(e as Map<String, dynamic>))
         .toList();
   }
@@ -116,12 +117,13 @@ class ApiChatRepository implements ChatRepository {
     final result = await _apiClient.get('/chat/backends');
     final body = _unwrap(result);
     final json = jsonDecode(body) as Map<String, dynamic>;
-    final backends = (json['backends'] as List)
+    final data = json['data'] as Map<String, dynamic>;
+    final backends = (data['backends'] as List)
         .map((e) => BackendInfo.fromMap(e as Map<String, dynamic>))
         .toList();
     return BackendOptions(
       backends: backends,
-      defaultBackend: json['default_backend'] as String?,
+      defaultBackend: data['default_backend'] as String?,
     );
   }
 
@@ -131,7 +133,8 @@ class ApiChatRepository implements ChatRepository {
         await _apiClient.postJson('/records/$recordId/endorse');
     final body = _unwrap(result);
     final json = jsonDecode(body) as Map<String, dynamic>;
-    return json['user_endorsed'] as bool;
+    final data = json['data'] as Map<String, dynamic>;
+    return data['user_endorsed'] as bool;
   }
 
   String _unwrap(ApiResult result) {

--- a/test/features/chat/data/api_chat_repository_test.dart
+++ b/test/features/chat/data/api_chat_repository_test.dart
@@ -238,9 +238,13 @@ void main() {
   });
 
   group('getModels', () {
-    test('fetches models from models key', () async {
+    test('fetches models from data envelope', () async {
       apiClient.nextGetResult = ApiSuccess(
-        body: jsonEncode({'models': [_sampleModel()]}),
+        body: jsonEncode({
+          'data': {
+            'models': [_sampleModel()],
+          },
+        }),
       );
 
       final models = await repo.getModels();
@@ -253,7 +257,9 @@ void main() {
 
     test('sends backend query parameter when specified', () async {
       apiClient.nextGetResult = ApiSuccess(
-        body: jsonEncode({'models': []}),
+        body: jsonEncode({
+          'data': {'models': []},
+        }),
       );
 
       await repo.getModels(backend: 'groq');
@@ -263,7 +269,9 @@ void main() {
 
     test('omits backend query parameter when null', () async {
       apiClient.nextGetResult = ApiSuccess(
-        body: jsonEncode({'models': []}),
+        body: jsonEncode({
+          'data': {'models': []},
+        }),
       );
 
       await repo.getModels();
@@ -279,11 +287,13 @@ void main() {
   });
 
   group('getBackends', () {
-    test('parses backends and defaultBackend', () async {
+    test('parses backends and defaultBackend from data envelope', () async {
       apiClient.nextGetResult = ApiSuccess(
         body: jsonEncode({
-          'backends': [_sampleBackend()],
-          'default_backend': 'groq',
+          'data': {
+            'backends': [_sampleBackend()],
+            'default_backend': 'groq',
+          },
         }),
       );
 
@@ -297,8 +307,10 @@ void main() {
     test('handles null default_backend', () async {
       apiClient.nextGetResult = ApiSuccess(
         body: jsonEncode({
-          'backends': [_sampleBackend()],
-          'default_backend': null,
+          'data': {
+            'backends': [_sampleBackend()],
+            'default_backend': null,
+          },
         }),
       );
 
@@ -310,8 +322,10 @@ void main() {
     test('parses available flag', () async {
       apiClient.nextGetResult = ApiSuccess(
         body: jsonEncode({
-          'backends': [_sampleBackend(available: false)],
-          'default_backend': null,
+          'data': {
+            'backends': [_sampleBackend(available: false)],
+            'default_backend': null,
+          },
         }),
       );
 
@@ -330,7 +344,7 @@ void main() {
   group('toggleEndorse', () {
     test('returns true when endorsed', () async {
       apiClient.nextPostResult = const ApiSuccess(
-        body: '{"user_endorsed": true}',
+        body: '{"data": {"user_endorsed": true}}',
       );
 
       final result = await repo.toggleEndorse('rec-1');
@@ -341,7 +355,7 @@ void main() {
 
     test('returns false when unendorsed', () async {
       apiClient.nextPostResult = const ApiSuccess(
-        body: '{"user_endorsed": false}',
+        body: '{"data": {"user_endorsed": false}}',
       );
 
       final result = await repo.toggleEndorse('rec-1');


### PR DESCRIPTION
## Problem

After merging mjarco/thought-agent#255 (backend stops dropping empty `data` field), tapping a conversation in the Chat tab still crashes with:

```
type Null is not a subtype of type 'List<dynamic>' in type cast
```

## Cause

`ThreadNotifier._loadExisting` runs five repository calls in parallel via `Future.wait`. Three of them — `getModels`, `getBackends`, `toggleEndorse` — read fields at the wrong nesting level:

```dart
// getModels (line 109)
return (json['models'] as List)        // null — actual shape is {"data": {"models": [...]}}

// getBackends (line 119, 124)
final backends = (json['backends'] as List)
defaultBackend: json['default_backend'] as String?

// toggleEndorse (line 134)
return json['user_endorsed'] as bool   // null — actual shape is {"data": {"user_endorsed": true}}
```

The personal-agent backend wraps every response in `{"data": ...}` via `writeJSON` in `response.go`. P024 §API Contracts mistakenly documented these three endpoints as flat (no envelope). The client was coded against that incorrect spec.

`Future.wait` rejects on first failure, so even though `getEvents`/`getRecords` succeed (they read `json['data']` correctly), the whole load fails on `getModels`/`getBackends`.

## Fix

Read fields under `json['data']` to match the actual envelope:

```dart
final data = json['data'] as Map<String, dynamic>;
return (data['models'] as List)...
```

Same change for `getBackends` and `toggleEndorse`.

## Test plan

- [x] `flutter test test/features/chat/` — all 102 tests pass
- [x] `flutter test` — all 947 tests pass
- [x] Mocks in `api_chat_repository_test.dart` updated to use the real envelope shape
- [ ] Manual: rebuild voice-agent on phone, open existing conversation thread — should load instead of crashing

Note: pre-existing analyze warnings in `hands_free_controller.dart` / `flutter_tts_service.dart` from #286 are not addressed here.
