### PR TITLE
fix(chat): read 'label' from API for ModelInfo and BackendInfo

### DIFF
--- a/lib/features/chat/domain/chat_repository.dart
+++ b/lib/features/chat/domain/chat_repository.dart
@@ -16,7 +16,7 @@ class ModelInfo {
   factory ModelInfo.fromMap(Map<String, dynamic> map) {
     return ModelInfo(
       id: map['id'] as String,
-      name: map['name'] as String,
+      name: map['label'] as String,
       backendId: map['backend'] as String,
     );
   }
@@ -36,7 +36,7 @@ class BackendInfo {
   factory BackendInfo.fromMap(Map<String, dynamic> map) {
     return BackendInfo(
       id: map['id'] as String,
-      name: map['name'] as String,
+      name: map['label'] as String,
       available: map['available'] as bool,
     );
   }

--- a/test/features/chat/data/api_chat_repository_test.dart
+++ b/test/features/chat/data/api_chat_repository_test.dart
@@ -87,13 +87,13 @@ Map<String, dynamic> _sampleRecord() => {
 
 Map<String, dynamic> _sampleModel() => {
       'id': 'model-1',
-      'name': 'GPT-4',
+      'label': 'GPT-4',
       'backend': 'openai',
     };
 
 Map<String, dynamic> _sampleBackend({bool available = true}) => {
       'id': 'groq',
-      'name': 'Groq',
+      'label': 'Groq',
       'available': available,
     };
 


### PR DESCRIPTION
## Problem

After #289 unwrapped the data envelope, opening a thread now crashes with:

```
type Null is not a subtype of type 'String' in type cast
```

## Cause

Backend response for /chat/models and /chat/backends:

```json
{"id":"claude-sonnet-4-6","label":"Claude Sonnet 4.6","backend":"anthropic_api"}
{"id":"claude_cli","label":"Claude CLI","available":true}
```

`ModelInfo.fromMap` and `BackendInfo.fromMap` read `map['name']` — the field is absent, so `null as String` throws.

P024 §API Contracts documented `'name'` but backend always emitted `'label'`. This is the third in a row of P024-vs-reality contract drift bugs (#255, #289, this one).

## Fix

Read `map['label']` in both `fromMap` factories. Domain field name stays `name` so the picker UI in `thread_screen.dart` is untouched.

## Test plan

- [x] flutter test — all 947 tests pass
- [x] Test fixtures `_sampleModel` / `_sampleBackend` updated to use `label` (the real wire shape)
- [ ] Manual: rebuild voice-agent, open existing conversation — should load with model/backend picker populated