### PR TITLE
feat(chat): markdown rendering + collapsible knowledge-item badges

### DIFF
--- a/lib/features/chat/presentation/thread_screen.dart
+++ b/lib/features/chat/presentation/thread_screen.dart
@@ -370,7 +370,7 @@ class _TypingIndicator extends StatelessWidget {
   }
 }
 
-class _RecordBadges extends StatelessWidget {
+class _RecordBadges extends StatefulWidget {
   const _RecordBadges({
     required this.records,
     required this.onToggleEndorse,
@@ -380,21 +380,74 @@ class _RecordBadges extends StatelessWidget {
   final void Function(String recordId) onToggleEndorse;
 
   @override
+  State<_RecordBadges> createState() => _RecordBadgesState();
+}
+
+class _RecordBadgesState extends State<_RecordBadges> {
+  bool _expanded = false;
+
+  @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final n = widget.records.length;
+    final label = '$n knowledge item${n == 1 ? '' : 's'}';
+
     return Padding(
+      key: const Key('thread-record-badges'),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      child: Wrap(
-        key: const Key('thread-record-badges'),
-        spacing: 6,
-        runSpacing: 4,
-        children: records
-            .map(
-              (r) => _RecordBadge(
-                record: r,
-                onToggleEndorse: () => onToggleEndorse(r.recordId),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          InkWell(
+            key: const Key('thread-knowledge-toggle'),
+            onTap: () => setState(() => _expanded = !_expanded),
+            borderRadius: BorderRadius.circular(4),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 2),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    _expanded ? Icons.expand_less : Icons.expand_more,
+                    size: 16,
+                    color: theme.colorScheme.tertiary,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    label,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.tertiary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
               ),
-            )
-            .toList(),
+            ),
+          ),
+          AnimatedSize(
+            duration: const Duration(milliseconds: 150),
+            curve: Curves.easeOut,
+            alignment: Alignment.topLeft,
+            child: _expanded
+                ? Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Wrap(
+                      spacing: 6,
+                      runSpacing: 4,
+                      children: widget.records
+                          .map(
+                            (r) => _RecordBadge(
+                              record: r,
+                              onToggleEndorse: () =>
+                                  widget.onToggleEndorse(r.recordId),
+                            ),
+                          )
+                          .toList(),
+                    ),
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/chat/presentation/thread_screen.dart
+++ b/lib/features/chat/presentation/thread_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:voice_agent/core/models/conversation.dart';
@@ -220,6 +221,11 @@ class _ThreadScreenState extends ConsumerState<ThreadScreen> {
   }
 }
 
+final _ssmlLangStrip =
+    RegExp(r'<lang xml:lang="[a-z]{2,3}(?:-[A-Z]{2,4})?">|</lang>');
+
+String _stripSsmlLang(String text) => text.replaceAll(_ssmlLangStrip, '');
+
 class _MessageBubble extends StatelessWidget {
   const _MessageBubble({
     super.key,
@@ -234,31 +240,108 @@ class _MessageBubble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
     final isUser = role == EventRole.user;
+
+    final bubbleColor = isUser
+        ? cs.primary.withAlpha(pending ? 128 : 255)
+        : cs.surfaceContainerHighest;
+    final fgColor = isUser ? cs.onPrimary : cs.onSurface;
+
+    final Widget body;
+    if (isUser) {
+      body = SelectableText(
+        content,
+        key: Key('bubble-$role'),
+        style: TextStyle(color: fgColor, height: 1.4),
+      );
+    } else {
+      body = MarkdownBody(
+        key: Key('bubble-$role'),
+        data: _stripSsmlLang(content),
+        selectable: true,
+        styleSheet: _agentMarkdownStyle(theme),
+        softLineBreak: true,
+      );
+    }
+
     return Align(
       alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
       child: Container(
         margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        padding: EdgeInsets.symmetric(
+          horizontal: 14,
+          vertical: isUser ? 10 : 12,
+        ),
         constraints: BoxConstraints(
-          maxWidth: MediaQuery.of(context).size.width * 0.75,
+          maxWidth:
+              MediaQuery.of(context).size.width * (isUser ? 0.78 : 0.92),
         ),
         decoration: BoxDecoration(
-          color: isUser
-              ? Theme.of(context).colorScheme.primary.withAlpha(pending ? 128 : 255)
-              : Theme.of(context).colorScheme.surfaceContainerHighest,
-          borderRadius: BorderRadius.circular(12),
+          color: bubbleColor,
+          borderRadius: BorderRadius.circular(14),
         ),
-        child: Text(
-          content,
-          key: Key('bubble-$role'),
-          style: TextStyle(
-            color: isUser ? Theme.of(context).colorScheme.onPrimary : null,
-          ),
-        ),
+        child: body,
       ),
     );
   }
+}
+
+MarkdownStyleSheet _agentMarkdownStyle(ThemeData theme) {
+  final tt = theme.textTheme;
+  final cs = theme.colorScheme;
+  final base = tt.bodyMedium?.copyWith(height: 1.45, color: cs.onSurface);
+  final mono = TextStyle(
+    fontFamily: 'monospace',
+    fontSize: (base?.fontSize ?? 14) - 1,
+    color: cs.onSurface,
+  );
+  final codeBg = cs.surfaceContainerHigh;
+
+  return MarkdownStyleSheet(
+    p: base,
+    pPadding: const EdgeInsets.only(bottom: 4),
+    h1: tt.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+    h1Padding: const EdgeInsets.only(top: 8, bottom: 4),
+    h2: tt.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+    h2Padding: const EdgeInsets.only(top: 8, bottom: 4),
+    h3: tt.titleSmall?.copyWith(fontWeight: FontWeight.w700),
+    h3Padding: const EdgeInsets.only(top: 6, bottom: 2),
+    h4: tt.titleSmall,
+    h5: tt.titleSmall,
+    h6: tt.titleSmall,
+    strong: const TextStyle(fontWeight: FontWeight.w700),
+    em: const TextStyle(fontStyle: FontStyle.italic),
+    code: mono.copyWith(backgroundColor: codeBg),
+    codeblockDecoration: BoxDecoration(
+      color: codeBg,
+      borderRadius: BorderRadius.circular(8),
+    ),
+    codeblockPadding: const EdgeInsets.all(10),
+    blockquoteDecoration: BoxDecoration(
+      border: Border(
+        left: BorderSide(color: cs.primary, width: 3),
+      ),
+    ),
+    blockquotePadding: const EdgeInsets.only(left: 10, top: 2, bottom: 2),
+    blockquote: base?.copyWith(color: cs.onSurfaceVariant),
+    listBullet: base,
+    listIndent: 20,
+    a: TextStyle(
+      color: cs.primary,
+      decoration: TextDecoration.underline,
+    ),
+    tableBorder: TableBorder.all(color: cs.outlineVariant, width: 1),
+    tableHead: const TextStyle(fontWeight: FontWeight.w700),
+    tableCellsPadding:
+        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+    horizontalRuleDecoration: BoxDecoration(
+      border: Border(
+        top: BorderSide(color: cs.outlineVariant, width: 1),
+      ),
+    ),
+  );
 }
 
 class _TypingIndicator extends StatelessWidget {

--- a/lib/features/chat/presentation/thread_screen.dart
+++ b/lib/features/chat/presentation/thread_screen.dart
@@ -184,6 +184,9 @@ class _ThreadScreenState extends ConsumerState<ThreadScreen> {
                             .every((e) => e.role != EventRole.agent);
                     if (isLastAgent && records.isNotEmpty) {
                       widgets.add(_RecordBadges(
+                        key: ValueKey(
+                          'badges-${event.eventId}-${records.map((r) => r.recordId).join(',')}',
+                        ),
                         records: records,
                         onToggleEndorse: notifier.toggleEndorse,
                       ));
@@ -328,10 +331,6 @@ MarkdownStyleSheet _agentMarkdownStyle(ThemeData theme) {
     blockquote: base?.copyWith(color: cs.onSurfaceVariant),
     listBullet: base,
     listIndent: 20,
-    a: TextStyle(
-      color: cs.primary,
-      decoration: TextDecoration.underline,
-    ),
     tableBorder: TableBorder.all(color: cs.outlineVariant, width: 1),
     tableHead: const TextStyle(fontWeight: FontWeight.w700),
     tableCellsPadding:
@@ -372,6 +371,7 @@ class _TypingIndicator extends StatelessWidget {
 
 class _RecordBadges extends StatefulWidget {
   const _RecordBadges({
+    super.key,
     required this.records,
     required this.onToggleEndorse,
   });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -238,6 +238,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.0.0"
+  flutter_markdown_plus:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown_plus
+      sha256: "039177906850278e8fb1cd364115ee0a46281135932fa8ecea8455522166d2de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.7"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -400,6 +408,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   flutter_foreground_task: ^9.2.2
   flutter_local_notifications: ^18.0.1
   timezone: ^0.10.0
+  flutter_markdown_plus: ^1.0.4
 
 dev_dependencies:
   flutter_test:

--- a/test/features/chat/presentation/thread_screen_test.dart
+++ b/test/features/chat/presentation/thread_screen_test.dart
@@ -189,7 +189,7 @@ void main() {
         ..eventsResult = [_event(id: 'a1', role: EventRole.agent, content: 'Agent replies')];
       await _pumpScreen(tester, repository: repo);
 
-      expect(find.text('Agent replies'), findsOneWidget);
+      expect(find.text('Agent replies', findRichText: true), findsOneWidget);
     });
 
     testWidgets('shows record badges after last agent bubble', (tester) async {

--- a/test/features/chat/presentation/thread_screen_test.dart
+++ b/test/features/chat/presentation/thread_screen_test.dart
@@ -192,7 +192,8 @@ void main() {
       expect(find.text('Agent replies', findRichText: true), findsOneWidget);
     });
 
-    testWidgets('shows record badges after last agent bubble', (tester) async {
+    testWidgets('knowledge items hidden by default and toggle reveals them',
+        (tester) async {
       final repo = _StubRepository()
         ..conversationResult = _conv()
         ..eventsResult = [_event(id: 'a1', role: EventRole.agent, content: 'Reply')]
@@ -200,7 +201,27 @@ void main() {
       await _pumpScreen(tester, repository: repo);
 
       expect(find.byKey(const Key('thread-record-badges')), findsOneWidget);
+      expect(find.byKey(const Key('thread-knowledge-toggle')), findsOneWidget);
+      expect(find.text('1 knowledge item'), findsOneWidget);
+      expect(find.text('Decision badge'), findsNothing);
+
+      await tester.tap(find.byKey(const Key('thread-knowledge-toggle')));
+      await tester.pumpAndSettle();
+
       expect(find.text('Decision badge'), findsOneWidget);
+    });
+
+    testWidgets('toggle pluralises label for multiple items', (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [_event(id: 'a1', role: EventRole.agent)]
+        ..recordsResult = [
+          _record(id: 'rec-a', subjectRef: 'A'),
+          _record(id: 'rec-b', subjectRef: 'B'),
+        ];
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.text('2 knowledge items'), findsOneWidget);
     });
 
     testWidgets('record badge shows empty star when not endorsed', (tester) async {
@@ -209,6 +230,9 @@ void main() {
         ..eventsResult = [_event(id: 'a1', role: EventRole.agent)]
         ..recordsResult = [_record(id: 'rec-1', endorsed: false)];
       await _pumpScreen(tester, repository: repo);
+
+      await tester.tap(find.byKey(const Key('thread-knowledge-toggle')));
+      await tester.pumpAndSettle();
 
       final starIcon = find.byKey(const Key('badge-star-rec-1'));
       expect(starIcon, findsOneWidget);
@@ -223,6 +247,9 @@ void main() {
         ..recordsResult = [_record(id: 'rec-2', endorsed: true)];
       await _pumpScreen(tester, repository: repo);
 
+      await tester.tap(find.byKey(const Key('thread-knowledge-toggle')));
+      await tester.pumpAndSettle();
+
       final icon = tester.widget<Icon>(find.byKey(const Key('badge-star-rec-2')));
       expect(icon.icon, Icons.star);
     });
@@ -233,6 +260,9 @@ void main() {
         ..eventsResult = [_event(id: 'a1', role: EventRole.agent)]
         ..recordsResult = [_record(id: 'rec-tap')];
       await _pumpScreen(tester, repository: repo);
+
+      await tester.tap(find.byKey(const Key('thread-knowledge-toggle')));
+      await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const Key('badge-rec-tap')));
       await tester.pumpAndSettle();

--- a/test/features/chat/presentation/thread_screen_test.dart
+++ b/test/features/chat/presentation/thread_screen_test.dart
@@ -192,6 +192,38 @@ void main() {
       expect(find.text('Agent replies', findRichText: true), findsOneWidget);
     });
 
+    testWidgets('agent bubble renders markdown (asterisks stripped)',
+        (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [
+          _event(id: 'a1', role: EventRole.agent, content: '**bold word**'),
+        ];
+      await _pumpScreen(tester, repository: repo);
+
+      // Markdown processed: rendered text omits the asterisks.
+      expect(find.text('bold word', findRichText: true), findsOneWidget);
+      expect(find.text('**bold word**', findRichText: true), findsNothing);
+    });
+
+    testWidgets('agent bubble strips SSML lang wrappers', (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [
+          _event(
+            id: 'a1',
+            role: EventRole.agent,
+            content: 'Use the <lang xml:lang="en-US">API</lang> endpoint',
+          ),
+        ];
+      await _pumpScreen(tester, repository: repo);
+
+      expect(
+        find.text('Use the API endpoint', findRichText: true),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('knowledge items hidden by default and toggle reveals them',
         (tester) async {
       final repo = _StubRepository()


### PR DESCRIPTION
## Summary
- Render agent bubbles with `flutter_markdown_plus` (theme-matched styles for headings, code, blockquote, lists, tables, hr). User bubbles remain plain selectable text.
- Strip P054 SSML `<lang xml:lang="...">…</lang>` wrappers before rendering so they don't show up as literal text in the bubble.
- Collapse the knowledge-item badge row under the last agent reply behind a toggle: a single-line "N knowledge item(s)" summary expands to the existing badge wrap via a short `AnimatedSize` transition.

## Notes
- Two commits, intentionally separated:
  - `feat(chat): render agent bubbles as markdown and strip SSML lang tags`
  - `feat(chat): collapse knowledge-item badges behind a toggle`
- Adds dependency `flutter_markdown_plus: ^1.0.4`.
- Three pre-existing analyzer warnings remain on the branch — none introduced by this PR.

## Test plan
- [x] `flutter test test/features/chat/presentation/thread_screen_test.dart` — all 18 tests pass
- [x] UI verified on device
- [ ] Reviewer: verify markdown-heavy agent reply renders correctly
- [ ] Reviewer: verify knowledge-item toggle expand/collapse on a thread with several records

🤖 Generated with [Claude Code](https://claude.com/claude-code)
