### PR TITLE
feat(ops): P039 T0 — minimal OTel Collector for the spike

### DIFF
--- a/ops/dev/README.md
+++ b/ops/dev/README.md
@@ -1,0 +1,46 @@
+# ops/dev — local dev-flavor observability
+
+This directory holds operational config for the dev-flavor telemetry pipeline
+introduced by P039. Two files at the time of writing:
+
+- `collector-only.docker-compose.yml` — minimal OTel Collector for the **T1
+  spike**. Only an OTLP HTTP receiver + debug stdout exporter. ~30 LOC.
+- `otel-collector-config.yml` — Collector pipeline config used by the
+  spike compose.
+
+A full backend stack (Collector → Tempo → Prometheus remote-write + Grafana
+data sources) lands in T2 as `telemetry.docker-compose.yml`. Until that
+ships, only the spike compose is here.
+
+## Running the spike Collector locally
+
+```bash
+cd ops/dev
+docker compose -f collector-only.docker-compose.yml up
+```
+
+Verify it's listening:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" \
+    -X POST http://localhost:4318/v1/traces \
+    -H 'Content-Type: application/json' \
+    --data '{"resourceSpans":[]}'
+# expect: 200
+```
+
+The Collector logs every received OTLP request to stdout via the `debug`
+exporter, so you can watch it process spans live.
+
+## Stopping
+
+```bash
+docker compose -f collector-only.docker-compose.yml down
+```
+
+## Deploying to `laptop.lan`
+
+The Collector binds to `0.0.0.0`, so when this compose runs on the
+laptop host (the one resolved by `laptop.lan`) the phone on the same
+LAN can POST to `http://laptop.lan:4318/v1/traces` directly. No
+auth — see P039 §Wire format and transport for the rationale.

--- a/ops/dev/collector-only.docker-compose.yml
+++ b/ops/dev/collector-only.docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.131.0
+    container_name: voice-agent-otel-spike
+    command: ["--config=/etc/otelcol-config.yml"]
+    volumes:
+      - ./otel-collector-config.yml:/etc/otelcol-config.yml:ro
+    ports:
+      - "4317:4317"  # OTLP gRPC
+      - "4318:4318"  # OTLP HTTP
+    restart: unless-stopped

--- a/ops/dev/otel-collector-config.yml
+++ b/ops/dev/otel-collector-config.yml
@@ -1,0 +1,30 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+    timeout: 1s
+    send_batch_size: 100
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+  telemetry:
+    logs:
+      level: info


### PR DESCRIPTION
## Summary

P039 task T0 — drops a single-service docker-compose at `ops/dev/` for the OTel Collector that the T1 spike POSTs to.

- `ops/dev/collector-only.docker-compose.yml` — `otel/opentelemetry-collector-contrib:0.131.0`, ports 4317/4318, ~30 LOC of YAML
- `ops/dev/otel-collector-config.yml` — OTLP HTTP/gRPC receivers + batch processor + debug stdout exporter
- `ops/dev/README.md` — how to run + verify + laptop.lan deployment note

## Verification

Brought the Collector up locally and round-tripped a span:

```
$ curl -X POST http://localhost:4318/v1/traces ... HTTP 200
$ docker logs voice-agent-otel-spike
InstrumentationScope p039-t0-smoke
    Name           : hf.attach_stream
     -> smoke: Bool(true)
```

T2 will replace this with the full stack (Tempo + Prometheus remote-write + Grafana data sources).

## Test plan

- [x] `docker compose up` boots the container
- [x] POST `/v1/traces` with an empty payload returns 200
- [x] POST a non-empty span and the debug exporter logs it
- [ ] Reviewer: confirm the compose file is minimal enough to be retired by T2 cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)