### PR TITLE
feat(observability): P039 T3 — Telemetry facade + flavor entrypoints

### DIFF
--- a/lib/app_main.dart
+++ b/lib/app_main.dart
@@ -1,0 +1,50 @@
+// Shared boot used by both flavor entrypoints.
+//
+// `lib/main_dev.dart` wires `Telemetry.instance` to the OTel-backed
+// implementation and then calls `appMain()`. `lib/main_stable.dart`
+// (and the default `lib/main.dart`) call `appMain()` directly,
+// leaving the no-op default.
+//
+// See ADR-OBS-001 §2.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/app/app.dart';
+import 'package:voice_agent/core/background/flutter_foreground_task_service.dart';
+import 'package:voice_agent/core/notifications/come_back_notifier.dart';
+import 'package:voice_agent/core/session_control/session_control_provider.dart';
+import 'package:voice_agent/core/session_control/toaster.dart';
+import 'package:voice_agent/core/storage/sqlite_storage_service.dart';
+import 'package:voice_agent/core/storage/storage_provider.dart';
+import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+
+Future<void> appMain() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  FlutterForegroundTaskService.initForegroundTask();
+
+  await ComeBackNotifier.instance.init();
+
+  final storage = await SqliteStorageService.initialize();
+
+  final recovered = await storage.recoverStaleSending();
+  if (kDebugMode && recovered > 0) {
+    debugPrint('Recovered $recovered stale sending items');
+  }
+
+  final scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
+
+  runApp(
+    ProviderScope(
+      overrides: [
+        storageServiceProvider.overrideWithValue(storage),
+        toasterProvider.overrideWithValue(Toaster(scaffoldMessengerKey)),
+        handsFreeControlPortProvider.overrideWith(
+          (ref) => ref.watch(handsFreeControllerProvider.notifier),
+        ),
+      ],
+      child: App(scaffoldMessengerKey: scaffoldMessengerKey),
+    ),
+  );
+}

--- a/lib/core/observability/telemetry.dart
+++ b/lib/core/observability/telemetry.dart
@@ -1,0 +1,105 @@
+// Telemetry facade — abstract API used by call-sites across the app.
+//
+// The concrete subtype is selected at boot by the flavor-specific entrypoint
+// (see ADR-OBS-001 §2). `lib/main_stable.dart` leaves the no-op default;
+// `lib/main_dev.dart` reassigns `Telemetry.instance` to an OTel-backed
+// implementation that imports `package:opentelemetry`.
+//
+// Tests inherit the no-op default. No setUp is required.
+
+/// Abstract telemetry facade. Use [Telemetry.instance] from any layer.
+///
+/// The default implementation is [NoopTelemetry] — a zero-cost stand-in
+/// that compiles into the `stable` flavor without any OpenTelemetry
+/// dependency.
+abstract class Telemetry {
+  /// The process-wide singleton. Defaults to [NoopTelemetry] at static
+  /// initialisation.
+  ///
+  /// `lib/main_dev.dart` reassigns this *before* `runApp` to the
+  /// OTel-backed implementation. Tests do not need to reassign.
+  static Telemetry instance = const NoopTelemetry();
+
+  /// Record an instantaneous event. Events that should pin to a
+  /// currently-active long-lived span (e.g. `hf.attach_stream`) are
+  /// emitted as a span event when one is open; otherwise as a
+  /// stand-alone event in the trace timeline.
+  void event(String name, {Map<String, Object?> attrs});
+
+  /// Start a span. The returned [TelemetrySpan] must be ended via
+  /// [TelemetrySpan.end] for the span to be exported.
+  TelemetrySpan span(
+    String name, {
+    SpanKind kind = SpanKind.internal,
+    Map<String, Object?> attrs,
+  });
+
+  /// Increment a counter by [delta] (default 1).
+  void counter(String name, {int delta = 1, Map<String, Object?> attrs});
+
+  /// Record a histogram observation.
+  void histogram(String name, num value, {Map<String, Object?> attrs});
+
+  /// Flush any buffered telemetry. Call on app termination if possible
+  /// (best-effort).
+  Future<void> flush();
+}
+
+/// Span semantics. Maps to OTel `SpanKind`.
+enum SpanKind { internal, server, client, producer, consumer }
+
+/// A handle to an active span. Subclassed concretely by each backend.
+abstract class TelemetrySpan {
+  /// Add an attribute to the span.
+  void setAttr(String key, Object? value);
+
+  /// Add a discrete event onto this span's timeline.
+  void addEvent(String name, {Map<String, Object?> attrs});
+
+  /// Mark the span ended. After `end()` further setAttr/addEvent calls
+  /// are silently dropped.
+  void end({SpanStatus status = SpanStatus.unset, String? message});
+}
+
+enum SpanStatus { unset, ok, error }
+
+/// The default no-op implementation. Always tree-shakeable out of the
+/// `stable` AOT snapshot because it imports nothing observability-shaped.
+class NoopTelemetry implements Telemetry {
+  const NoopTelemetry();
+
+  @override
+  void event(String name, {Map<String, Object?> attrs = const {}}) {}
+
+  @override
+  TelemetrySpan span(
+    String name, {
+    SpanKind kind = SpanKind.internal,
+    Map<String, Object?> attrs = const {},
+  }) =>
+      const _NoopSpan();
+
+  @override
+  void counter(String name,
+      {int delta = 1, Map<String, Object?> attrs = const {}}) {}
+
+  @override
+  void histogram(String name, num value,
+      {Map<String, Object?> attrs = const {}}) {}
+
+  @override
+  Future<void> flush() async {}
+}
+
+class _NoopSpan implements TelemetrySpan {
+  const _NoopSpan();
+
+  @override
+  void setAttr(String key, Object? value) {}
+
+  @override
+  void addEvent(String name, {Map<String, Object?> attrs = const {}}) {}
+
+  @override
+  void end({SpanStatus status = SpanStatus.unset, String? message}) {}
+}

--- a/lib/core/observability/telemetry_otel.dart
+++ b/lib/core/observability/telemetry_otel.dart
@@ -1,0 +1,176 @@
+// OTel-backed Telemetry implementation. Imported ONLY from
+// `lib/main_dev.dart`. The `stable` flavor's entrypoint
+// (`lib/main_stable.dart`) does not reach this file, so
+// `package:opentelemetry` is tree-shaken out of the stable AOT
+// snapshot (verified in T1 spike: 466 KB delta, 0 `opentelemetry`
+// strings hits — see docs/spikes/p039-t1-otel-viability.md).
+
+import 'package:opentelemetry/api.dart' as otel_api;
+import 'package:opentelemetry/sdk.dart' as otel_sdk;
+
+import 'telemetry.dart';
+
+/// OTel-backed Telemetry. T3 wires the SDK with a synchronous
+/// [otel_sdk.SimpleSpanProcessor] pointing at a Collector at
+/// [collectorBaseUrl]. T4 replaces the processor with the durable
+/// outbox-backed one.
+class OtelTelemetry implements Telemetry {
+  OtelTelemetry._(this._provider, this._tracer);
+
+  /// Build and wire the OTel SDK. Call once from
+  /// `lib/main_dev.dart` before `runApp`.
+  ///
+  /// [serviceName] is the OTel resource attribute identifying this app.
+  /// [serviceVersion] is typically read from `pubspec.yaml`.
+  /// [collectorBaseUrl] is the Collector base URL (no trailing slash);
+  /// the SDK posts to `$collectorBaseUrl/v1/traces`.
+  factory OtelTelemetry.boot({
+    required String serviceName,
+    required String serviceVersion,
+    required Uri collectorBaseUrl,
+  }) {
+    final exporter = otel_sdk.CollectorExporter(
+      collectorBaseUrl.resolve('/v1/traces'),
+    );
+    final processor = otel_sdk.SimpleSpanProcessor(exporter);
+    final provider = otel_sdk.TracerProviderBase(
+      processors: [processor],
+      resource: otel_sdk.Resource([
+        otel_api.Attribute.fromString('service.name', serviceName),
+        otel_api.Attribute.fromString('service.version', serviceVersion),
+        otel_api.Attribute.fromString('deployment.environment', 'dev'),
+      ]),
+    );
+    final tracer = provider.getTracer(
+      'voice-agent',
+      schemaUrl: 'https://opentelemetry.io/schemas/1.21.0',
+    );
+    return OtelTelemetry._(provider, tracer);
+  }
+
+  final otel_sdk.TracerProviderBase _provider;
+  final otel_api.Tracer _tracer;
+
+  @override
+  void event(String name, {Map<String, Object?> attrs = const {}}) {
+    // Stand-alone event: open and immediately close a zero-duration span
+    // carrying the event name and attributes. T5a may route events as
+    // span events on the active long-lived span when one exists.
+    final span = _tracer.startSpan(
+      name,
+      attributes: _toOtelAttrs(attrs),
+    );
+    span.end();
+  }
+
+  @override
+  TelemetrySpan span(
+    String name, {
+    SpanKind kind = SpanKind.internal,
+    Map<String, Object?> attrs = const {},
+  }) {
+    final span = _tracer.startSpan(
+      name,
+      kind: _mapKind(kind),
+      attributes: _toOtelAttrs(attrs),
+    );
+    return _OtelSpan(span);
+  }
+
+  @override
+  void counter(String name,
+      {int delta = 1, Map<String, Object?> attrs = const {}}) {
+    // T3 renders counters as zero-duration spans tagged
+    // `telemetry.kind=counter`. T6 swaps this for the OTel metrics
+    // API once we exercise it.
+    final mergedAttrs = {
+      ...attrs,
+      'telemetry.kind': 'counter',
+      'delta': delta,
+    };
+    event(name, attrs: mergedAttrs);
+  }
+
+  @override
+  void histogram(String name, num value,
+      {Map<String, Object?> attrs = const {}}) {
+    final mergedAttrs = {
+      ...attrs,
+      'telemetry.kind': 'histogram',
+      'value': value,
+    };
+    event(name, attrs: mergedAttrs);
+  }
+
+  @override
+  Future<void> flush() async {
+    _provider.forceFlush();
+  }
+}
+
+class _OtelSpan implements TelemetrySpan {
+  _OtelSpan(this._span);
+  final otel_api.Span _span;
+  var _ended = false;
+
+  @override
+  void setAttr(String key, Object? value) {
+    if (_ended) return;
+    final attr = _toOtelAttr(key, value);
+    if (attr != null) _span.setAttributes([attr]);
+  }
+
+  @override
+  void addEvent(String name, {Map<String, Object?> attrs = const {}}) {
+    if (_ended) return;
+    _span.addEvent(name, attributes: _toOtelAttrs(attrs));
+  }
+
+  @override
+  void end({SpanStatus status = SpanStatus.unset, String? message}) {
+    if (_ended) return;
+    _ended = true;
+    switch (status) {
+      case SpanStatus.ok:
+        _span.setStatus(otel_api.StatusCode.ok, message ?? '');
+      case SpanStatus.error:
+        _span.setStatus(otel_api.StatusCode.error, message ?? '');
+      case SpanStatus.unset:
+        break;
+    }
+    _span.end();
+  }
+}
+
+otel_api.SpanKind _mapKind(SpanKind k) {
+  switch (k) {
+    case SpanKind.internal:
+      return otel_api.SpanKind.internal;
+    case SpanKind.server:
+      return otel_api.SpanKind.server;
+    case SpanKind.client:
+      return otel_api.SpanKind.client;
+    case SpanKind.producer:
+      return otel_api.SpanKind.producer;
+    case SpanKind.consumer:
+      return otel_api.SpanKind.consumer;
+  }
+}
+
+List<otel_api.Attribute> _toOtelAttrs(Map<String, Object?> attrs) {
+  final out = <otel_api.Attribute>[];
+  attrs.forEach((k, v) {
+    final attr = _toOtelAttr(k, v);
+    if (attr != null) out.add(attr);
+  });
+  return out;
+}
+
+otel_api.Attribute? _toOtelAttr(String key, Object? value) {
+  if (value == null) return null;
+  if (value is String) return otel_api.Attribute.fromString(key, value);
+  if (value is bool) return otel_api.Attribute.fromBoolean(key, value);
+  if (value is int) return otel_api.Attribute.fromInt(key, value);
+  if (value is double) return otel_api.Attribute.fromDouble(key, value);
+  return otel_api.Attribute.fromString(key, value.toString());
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,41 +1,11 @@
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:voice_agent/app/app.dart';
-import 'package:voice_agent/core/background/flutter_foreground_task_service.dart';
-import 'package:voice_agent/core/notifications/come_back_notifier.dart';
-import 'package:voice_agent/core/session_control/session_control_provider.dart';
-import 'package:voice_agent/core/session_control/toaster.dart';
-import 'package:voice_agent/core/storage/sqlite_storage_service.dart';
-import 'package:voice_agent/core/storage/storage_provider.dart';
-import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+// Default entrypoint, used by `flutter run` / `flutter test` when no
+// explicit `--target` is passed. Delegates to `main_stable.dart` so the
+// safe (no-telemetry) path is always the default.
+//
+// The dev-flavor build invokes `lib/main_dev.dart` directly via its
+// Xcode scheme / Gradle flavor; see ADR-OBS-001 §2 and the build
+// configs in `android/app/build.gradle.kts` and `ios/Flutter/*.xcconfig`.
 
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
+import 'package:voice_agent/main_stable.dart' as stable;
 
-  FlutterForegroundTaskService.initForegroundTask();
-
-  await ComeBackNotifier.instance.init();
-
-  final storage = await SqliteStorageService.initialize();
-
-  final recovered = await storage.recoverStaleSending();
-  if (kDebugMode && recovered > 0) {
-    debugPrint('Recovered $recovered stale sending items');
-  }
-
-  final scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
-
-  runApp(
-    ProviderScope(
-      overrides: [
-        storageServiceProvider.overrideWithValue(storage),
-        toasterProvider.overrideWithValue(Toaster(scaffoldMessengerKey)),
-        handsFreeControlPortProvider.overrideWith(
-          (ref) => ref.watch(handsFreeControllerProvider.notifier),
-        ),
-      ],
-      child: App(scaffoldMessengerKey: scaffoldMessengerKey),
-    ),
-  );
-}
+Future<void> main() => stable.main();

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,0 +1,33 @@
+// `dev` flavor entrypoint. Wires `Telemetry.instance` to the
+// OTel-backed implementation before `appMain` runs, so the very first
+// span emitted at app boot already lands in the Collector.
+//
+// `package:opentelemetry` is reachable from this file and from
+// `lib/core/observability/telemetry_otel.dart` only. The stable
+// entrypoint has no transitive import path here.
+
+import 'package:flutter/widgets.dart';
+import 'package:voice_agent/app_main.dart';
+import 'package:voice_agent/core/observability/telemetry.dart';
+import 'package:voice_agent/core/observability/telemetry_otel.dart';
+
+// Default Collector endpoint. Override with
+// `--dart-define=OTEL_COLLECTOR=http://other.host:4318` when needed.
+const _defaultCollector = 'http://laptop.lan:4318';
+const _collectorEndpoint = String.fromEnvironment(
+  'OTEL_COLLECTOR',
+  defaultValue: _defaultCollector,
+);
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  Telemetry.instance = OtelTelemetry.boot(
+    serviceName: 'voice-agent',
+    serviceVersion: '1.0.0+1', // T3: hard-coded; T6 reads pubspec at gen time.
+    collectorBaseUrl: Uri.parse(_collectorEndpoint),
+  );
+  Telemetry.instance.event('app.boot', attrs: const {
+    'phase': 'pre_runapp',
+  });
+  await appMain();
+}

--- a/lib/main_stable.dart
+++ b/lib/main_stable.dart
@@ -1,0 +1,11 @@
+// `stable` flavor entrypoint. No telemetry — `Telemetry.instance`
+// keeps its no-op default. This file MUST NOT import
+// `package:opentelemetry` directly or transitively. The dev-flavor
+// entrypoint (`lib/main_dev.dart`) is the only file in this repo that
+// reaches `package:opentelemetry`.
+//
+// Verified by `ops/scripts/verify-stable-tree-shake.sh`.
+
+import 'package:voice_agent/app_main.dart';
+
+Future<void> main() => appMain();

--- a/ops/scripts/verify-stable-tree-shake.sh
+++ b/ops/scripts/verify-stable-tree-shake.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# P039 / ADR-OBS-001 acceptance script.
+#
+# Builds both flavors as iOS --release --no-codesign and asserts:
+#   1. The dev/stable App binary size delta is >= MIN_DELTA_BYTES.
+#   2. `strings` on the stable build returns zero `opentelemetry` hits.
+#
+# Run from voice-agent repo root:
+#
+#   ./ops/scripts/verify-stable-tree-shake.sh
+#
+# Exit codes:
+#   0 — both gates pass
+#   1 — size delta too small
+#   2 — opentelemetry symbols leaked into stable
+#   3 — build failure
+
+set -euo pipefail
+
+MIN_DELTA_BYTES="${MIN_DELTA_BYTES:-153600}"  # 150 KB
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "==> building dev flavor (--target lib/main_dev.dart) ..."
+flutter build ios --release --no-codesign --flavor dev \
+    --target lib/main_dev.dart >/dev/null || exit 3
+DEV_BIN="build/ios/iphoneos/Runner.app/Frameworks/App.framework/App"
+cp "$DEV_BIN" /tmp/voice-agent-app-dev.bin
+
+echo "==> building stable flavor (--target lib/main_stable.dart) ..."
+flutter build ios --release --no-codesign --flavor stable \
+    --target lib/main_stable.dart >/dev/null || exit 3
+STABLE_BIN="build/ios/iphoneos/Runner.app/Frameworks/App.framework/App"
+cp "$STABLE_BIN" /tmp/voice-agent-app-stable.bin
+
+DEV_SZ=$(stat -f%z /tmp/voice-agent-app-dev.bin)
+STABLE_SZ=$(stat -f%z /tmp/voice-agent-app-stable.bin)
+DELTA=$((DEV_SZ - STABLE_SZ))
+DELTA_KB=$((DELTA / 1024))
+
+echo ""
+echo "  dev binary:    $DEV_SZ bytes"
+echo "  stable binary: $STABLE_SZ bytes"
+echo "  delta:         $DELTA bytes ($DELTA_KB KB)"
+echo "  threshold:     $MIN_DELTA_BYTES bytes ($((MIN_DELTA_BYTES / 1024)) KB)"
+
+# Gate 1: size delta
+if [[ $DELTA -lt $MIN_DELTA_BYTES ]]; then
+    echo ""
+    echo "FAIL: delta is below threshold. The OTel package may not be"
+    echo "      tree-shaking out of the stable build. Check that"
+    echo "      lib/main_stable.dart has no transitive import of"
+    echo "      package:opentelemetry."
+    exit 1
+fi
+
+# Gate 2: strings smoke check
+STABLE_HITS=$(strings /tmp/voice-agent-app-stable.bin | grep -ic opentelemetry || true)
+DEV_HITS=$(strings /tmp/voice-agent-app-dev.bin | grep -ic opentelemetry || true)
+echo ""
+echo "  opentelemetry strings hits: dev=$DEV_HITS stable=$STABLE_HITS"
+
+if [[ $STABLE_HITS -ne 0 ]]; then
+    echo ""
+    echo "FAIL: 'opentelemetry' appears $STABLE_HITS time(s) in the stable"
+    echo "      binary. Investigate which import path is reaching the OTel"
+    echo "      package from lib/main_stable.dart."
+    exit 2
+fi
+
+echo ""
+echo "PASS: stable build is OTel-clean."
+exit 0

--- a/test/core/observability/telemetry_test.dart
+++ b/test/core/observability/telemetry_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/observability/telemetry.dart';
+
+void main() {
+  group('Telemetry facade — default behaviour', () {
+    test('Telemetry.instance defaults to NoopTelemetry at static init', () {
+      expect(Telemetry.instance, isA<NoopTelemetry>());
+    });
+
+    test('NoopTelemetry.event is a tolerant no-op', () {
+      const t = NoopTelemetry();
+      expect(() => t.event('anything'), returnsNormally);
+      expect(() => t.event('with-attrs', attrs: const {'k': 'v'}),
+          returnsNormally);
+    });
+
+    test('NoopTelemetry.span returns a span whose lifecycle is a no-op', () {
+      const t = NoopTelemetry();
+      final span = t.span('test', attrs: const {'a': 1});
+      expect(() {
+        span.setAttr('b', 'x');
+        span.addEvent('mid', attrs: const {'k': true});
+        span.end();
+        // Calls after end are silently ignored.
+        span.setAttr('c', 2);
+        span.addEvent('post-end');
+        span.end(status: SpanStatus.error, message: 'noop');
+      }, returnsNormally);
+    });
+
+    test('NoopTelemetry.counter and histogram are no-ops', () {
+      const t = NoopTelemetry();
+      expect(() => t.counter('chunks', delta: 7), returnsNormally);
+      expect(() => t.histogram('latency_ms', 42.5), returnsNormally);
+    });
+
+    test('NoopTelemetry.flush resolves immediately', () async {
+      const t = NoopTelemetry();
+      await expectLater(t.flush(), completes);
+    });
+  });
+
+  group('Telemetry facade — test-only recording subtype', () {
+    test('a recording subtype can be injected for assertions', () {
+      final recording = _RecordingTelemetry();
+      Telemetry.instance = recording;
+      addTearDown(() => Telemetry.instance = const NoopTelemetry());
+
+      Telemetry.instance.event('mic-silent', attrs: const {'reason': 'test'});
+      Telemetry.instance.counter('hf.chunk_received');
+
+      expect(recording.events, hasLength(1));
+      expect(recording.events.single.name, 'mic-silent');
+      expect(recording.events.single.attrs, containsPair('reason', 'test'));
+      expect(recording.counters, hasLength(1));
+      expect(recording.counters.single.name, 'hf.chunk_received');
+      expect(recording.counters.single.delta, 1);
+    });
+  });
+}
+
+class _RecordingTelemetry implements Telemetry {
+  final List<_Event> events = [];
+  final List<_Counter> counters = [];
+
+  @override
+  void event(String name, {Map<String, Object?> attrs = const {}}) {
+    events.add(_Event(name, attrs));
+  }
+
+  @override
+  TelemetrySpan span(String name,
+      {SpanKind kind = SpanKind.internal,
+      Map<String, Object?> attrs = const {}}) {
+    return const NoopTelemetry().span(name, kind: kind, attrs: attrs);
+  }
+
+  @override
+  void counter(String name,
+      {int delta = 1, Map<String, Object?> attrs = const {}}) {
+    counters.add(_Counter(name, delta, attrs));
+  }
+
+  @override
+  void histogram(String name, num value,
+      {Map<String, Object?> attrs = const {}}) {}
+
+  @override
+  Future<void> flush() async {}
+}
+
+class _Event {
+  _Event(this.name, this.attrs);
+  final String name;
+  final Map<String, Object?> attrs;
+}
+
+class _Counter {
+  _Counter(this.name, this.delta, this.attrs);
+  final String name;
+  final int delta;
+  final Map<String, Object?> attrs;
+}


### PR DESCRIPTION
## Summary

P039 task T3. Lands the abstract `Telemetry` facade and the two flavor-specific entrypoints. Per ADR-OBS-001, this is the architectural plumbing on top of which T4–T6 add the durable outbox, native bridges, and the actual instrumentation.

- `lib/core/observability/telemetry.dart` — abstract facade, `NoopTelemetry` default, `Telemetry.instance` static field
- `lib/core/observability/telemetry_otel.dart` — `OtelTelemetry` backed by `package:opentelemetry`
- `lib/main_stable.dart` / `lib/main_dev.dart` — two entrypoints sharing a common `lib/app_main.dart`
- `lib/main.dart` — collapsed to a delegate to `main_stable.dart`
- `ops/scripts/verify-stable-tree-shake.sh` — the AC #2 enforcement script

## Verification

`./ops/scripts/verify-stable-tree-shake.sh`:

```
dev binary:    8962048 bytes
stable binary: 8797264 bytes
delta:         164784 bytes (160 KB)
threshold:     153600 bytes (150 KB)
opentelemetry strings hits: dev=46 stable=0
PASS: stable build is OTel-clean.
```

6 new facade tests under `test/core/observability/`. All 956 existing tests still pass. Analyzer clean (3 pre-existing warnings).

## Test plan

- [x] `flutter test test/core/observability/telemetry_test.dart` — 6/6 pass
- [x] `flutter test` — 956/956 pass
- [x] `flutter analyze` — 0 new issues
- [x] `./ops/scripts/verify-stable-tree-shake.sh` — PASS (160 KB delta, 0 stable hits)
- [ ] Reviewer: confirm `lib/main_stable.dart` import graph has no path to `package:opentelemetry`

## Next

T2 (full backend stack on laptop.lan) and T4 (DurableSpanProcessor + outbox) can land in parallel from this point. T5a/b is where the mic-silent diagnosis instrumentation finally happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)