### PR TITLE
feat(notifications): P040 T1 — notification service + reconciler

### DIFF
--- a/lib/core/notifications/agenda_notification_scheduler.dart
+++ b/lib/core/notifications/agenda_notification_scheduler.dart
@@ -1,0 +1,225 @@
+import 'package:timezone/timezone.dart' as tz;
+import 'package:voice_agent/core/models/agenda.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/models/routine.dart';
+import 'package:voice_agent/core/notifications/domain/notification_service.dart';
+
+/// Pure reconciler — turns an [AgendaResponse] into a desired set of OS
+/// notifications and diffs against the [NotificationService] snapshot.
+///
+/// See ADR-NOTIF-001 for the architectural contract (single writer,
+/// in-memory snapshot diff, reserved ID partitioning, session gating,
+/// permission revocation handling).
+///
+/// The reconciler is invoked only with **today's** [AgendaResponse]; the
+/// notifier enforces that gate (P040 §Reconciler Triggers). It does not
+/// re-verify the date.
+class AgendaNotificationScheduler {
+  AgendaNotificationScheduler({
+    required NotificationService service,
+    required tz.Location location,
+    required DateTime Function() clock,
+  })  : _service = service,
+        _location = location,
+        _clock = clock;
+
+  final NotificationService _service;
+  final tz.Location _location;
+  final DateTime Function() _clock;
+
+  /// Tracks the previous permission state to detect revocation
+  /// (granted → denied edge triggers cancelAll once, per ADR-NOTIF-001).
+  bool? _previouslyPermitted;
+
+  static const String _deepLinkAgenda = '/agenda';
+  static const String _summaryTitle = 'Agenda';
+
+  /// Reconcile the OS notification queue against [response].
+  ///
+  /// [sessionActive] gates routine-occurrence reminders (suppressed while a
+  /// hands-free session is running). Summaries are scheduled regardless.
+  Future<void> reconcile(
+    AgendaResponse response, {
+    required bool sessionActive,
+  }) async {
+    final permitted = await _service.isPermitted();
+
+    // Revocation edge: if we were permitted before and now we aren't, scrub
+    // the OS queue once so it doesn't diverge from our in-memory snapshot.
+    if (_previouslyPermitted == true && !permitted) {
+      await _service.cancelAll();
+    }
+    _previouslyPermitted = permitted;
+
+    if (!permitted) return;
+
+    final now = tz.TZDateTime.from(_clock(), _location);
+    final desired = _computeDesired(response, now, sessionActive);
+    final current = await _service.currentlyScheduled();
+
+    final desiredIds = desired.map((n) => n.id).toSet();
+    final toCancel =
+        current.keys.where((id) => !desiredIds.contains(id)).toList();
+    final toSchedule = desired
+        .where((n) => current[n.id] == null || current[n.id] != n)
+        .toList();
+
+    for (final id in toCancel) {
+      await _service.cancel(id);
+    }
+    for (final n in toSchedule) {
+      await _service.schedule(n);
+    }
+  }
+
+  List<ScheduledNotification> _computeDesired(
+    AgendaResponse response,
+    tz.TZDateTime now,
+    bool sessionActive,
+  ) {
+    final out = <ScheduledNotification>[];
+
+    // Four daily summaries — always scheduled, even during active session.
+    final counts = _SummaryCounts.from(response.items);
+    for (final slot in _SummarySlot.values) {
+      final fireAt = _nextSlotFireTime(now, slot.hour);
+      out.add(ScheduledNotification(
+        id: slot.id,
+        title: _summaryTitle,
+        body: _summaryBody(slot.label, counts),
+        fireAt: fireAt,
+        payload: _deepLinkAgenda,
+      ));
+    }
+
+    // Routine occurrences — gated by sessionActive.
+    if (!sessionActive) {
+      for (final r in response.routineItems) {
+        if (r.occurrenceId == null) continue;
+        if (r.startTime == null) continue;
+        if (r.status == OccurrenceStatus.skipped ||
+            r.status == OccurrenceStatus.done) {
+          continue;
+        }
+        final fireAt = _parseRoutineFireTime(r.scheduledFor, r.startTime!);
+        if (fireAt == null) continue;
+        if (!fireAt.isAfter(now)) continue;
+        out.add(ScheduledNotification(
+          id: _routineReminderId(r.occurrenceId!),
+          title: r.routineName,
+          body: r.startTime!,
+          fireAt: fireAt,
+          payload: _deepLinkAgenda,
+        ));
+      }
+    }
+    return out;
+  }
+
+  tz.TZDateTime _nextSlotFireTime(tz.TZDateTime now, int slotHour) {
+    final today = tz.TZDateTime(_location, now.year, now.month, now.day, slotHour);
+    if (today.isAfter(now)) return today;
+    return today.add(const Duration(days: 1));
+  }
+
+  tz.TZDateTime? _parseRoutineFireTime(String date, String hhmm) {
+    // date is YYYY-MM-DD; hhmm is HH:MM.
+    final dateParts = date.split('-');
+    if (dateParts.length != 3) return null;
+    final timeParts = hhmm.split(':');
+    if (timeParts.length != 2) return null;
+    final year = int.tryParse(dateParts[0]);
+    final month = int.tryParse(dateParts[1]);
+    final day = int.tryParse(dateParts[2]);
+    final hour = int.tryParse(timeParts[0]);
+    final minute = int.tryParse(timeParts[1]);
+    if (year == null ||
+        month == null ||
+        day == null ||
+        hour == null ||
+        minute == null) {
+      return null;
+    }
+    return tz.TZDateTime(_location, year, month, day, hour, minute);
+  }
+
+  String _summaryBody(String slotLabel, _SummaryCounts c) {
+    if (c.isEmpty) return '$slotLabel: nothing scheduled today';
+    final parts = <String>[];
+    if (c.open > 0) parts.add('${c.open} open');
+    if (c.done > 0) parts.add('${c.done} done');
+    if (c.dismissed > 0) parts.add('${c.dismissed} dismissed');
+    return '$slotLabel: ${parts.join(', ')}';
+  }
+}
+
+/// Fixed-time daily summary slots. IDs partitioned 1000–1003 per ADR-NOTIF-001.
+enum _SummarySlot {
+  morning(id: 1000, label: 'Morning', hour: 9),
+  noon(id: 1001, label: 'Noon', hour: 12),
+  afternoon(id: 1002, label: 'Afternoon', hour: 15),
+  evening(id: 1003, label: 'Evening', hour: 19);
+
+  const _SummarySlot({required this.id, required this.label, required this.hour});
+  final int id;
+  final String label;
+  final int hour;
+}
+
+class _SummaryCounts {
+  const _SummaryCounts({
+    required this.open,
+    required this.done,
+    required this.dismissed,
+  });
+
+  final int open;
+  final int done;
+  final int dismissed;
+
+  bool get isEmpty => open == 0 && done == 0 && dismissed == 0;
+
+  /// Status mapping (ADR-NOTIF-001 + P040 §Time Resolution):
+  ///   open      = active
+  ///   done      = done ∪ promoted (promoted is a positive resolution)
+  ///   dismissed = superseded
+  factory _SummaryCounts.from(List<AgendaItem> items) {
+    var open = 0, done = 0, dismissed = 0;
+    for (final item in items) {
+      switch (item.status) {
+        case RecordStatus.active:
+          open++;
+        case RecordStatus.done:
+        case RecordStatus.promoted:
+          done++;
+        case RecordStatus.superseded:
+          dismissed++;
+      }
+    }
+    return _SummaryCounts(open: open, done: done, dismissed: dismissed);
+  }
+}
+
+/// Routine reminder ID = 3_000_000 + (CRC32(occurrenceId) & 0x7FFFFFFF).
+/// Range reserved per ADR-NOTIF-001.
+int _routineReminderId(String occurrenceId) {
+  return 3000000 + (_crc32(occurrenceId) & 0x7FFFFFFF);
+}
+
+/// CRC-32/ISO-HDLC. Standalone implementation to avoid pulling a hash
+/// dependency just for this. Stable across runs and platforms.
+int _crc32(String input) {
+  final bytes = input.codeUnits;
+  var crc = 0xFFFFFFFF;
+  for (final b in bytes) {
+    crc ^= b & 0xFF;
+    for (var i = 0; i < 8; i++) {
+      if ((crc & 1) != 0) {
+        crc = (crc >> 1) ^ 0xEDB88320;
+      } else {
+        crc = crc >> 1;
+      }
+    }
+  }
+  return (crc ^ 0xFFFFFFFF) & 0xFFFFFFFF;
+}

--- a/lib/core/notifications/data/local_notification_service.dart
+++ b/lib/core/notifications/data/local_notification_service.dart
@@ -1,0 +1,148 @@
+import 'dart:async';
+
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:timezone/data/latest_all.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
+import 'package:voice_agent/core/notifications/domain/notification_service.dart';
+
+/// Concrete [NotificationService] backed by `flutter_local_notifications`.
+///
+/// Foreground: app-scoped singleton (one instance per process lifetime).
+/// Background isolate: constructed fresh per task spawn via `coreBoot()`
+/// (ADR-PLATFORM-007); the in-memory snapshot starts empty and the first
+/// reconcile re-schedules every desired entry — plugin replaces by ID, so
+/// no user-visible flicker (ADR-NOTIF-001 "Cold-start rebuild").
+class LocalNotificationService implements NotificationService {
+  LocalNotificationService({FlutterLocalNotificationsPlugin? plugin})
+      : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+
+  final FlutterLocalNotificationsPlugin _plugin;
+  final Map<int, ScheduledNotification> _scheduled = {};
+  final StreamController<String> _tapController =
+      StreamController<String>.broadcast();
+
+  bool _initialized = false;
+
+  /// Stream of notification-tap payloads. Wired to the warm-path channel
+  /// (`notificationTapStreamProvider`) by the provider layer in T3.
+  Stream<String> get tapStream => _tapController.stream;
+
+  @override
+  Future<void> init() async {
+    if (_initialized) return;
+
+    tz_data.initializeTimeZones();
+    final localName = await FlutterTimezone.getLocalTimezone();
+    tz.setLocalLocation(tz.getLocation(localName));
+
+    const initSettings = InitializationSettings(
+      iOS: DarwinInitializationSettings(
+        // Permission is requested separately via requestPermission().
+        // Init does not prompt — it just wires the callback.
+        requestAlertPermission: false,
+        requestBadgePermission: false,
+        requestSoundPermission: false,
+      ),
+      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+    );
+
+    await _plugin.initialize(
+      initSettings,
+      onDidReceiveNotificationResponse: (response) {
+        final payload = response.payload;
+        if (payload != null) _tapController.add(payload);
+      },
+    );
+
+    _initialized = true;
+  }
+
+  @override
+  Future<bool> requestPermission() async {
+    final iosGranted = await _plugin
+            .resolvePlatformSpecificImplementation<
+                IOSFlutterLocalNotificationsPlugin>()
+            ?.requestPermissions(alert: true, badge: true, sound: true) ??
+        false;
+
+    final androidGranted = await _plugin
+            .resolvePlatformSpecificImplementation<
+                AndroidFlutterLocalNotificationsPlugin>()
+            ?.requestNotificationsPermission() ??
+        false;
+
+    // Either platform-resolver returns non-null at runtime; the other is null
+    // (no-op). Granted-on-this-platform is the OR.
+    return iosGranted || androidGranted;
+  }
+
+  @override
+  Future<bool> isPermitted() async {
+    final iosCheck = await _plugin
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>()
+        ?.checkPermissions();
+    if (iosCheck != null) {
+      return iosCheck.isAlertEnabled;
+    }
+    final androidCheck = await _plugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.areNotificationsEnabled();
+    return androidCheck ?? false;
+  }
+
+  @override
+  Future<void> schedule(ScheduledNotification n) async {
+    // Summary IDs (1000–1003) use inexact scheduling (drift of minutes is
+    // fine for daily summaries). Routine occurrence IDs (3M+) use exact
+    // scheduling — the user expects the reminder near the appointment time.
+    final scheduleMode = (n.id >= 1000 && n.id <= 1003)
+        ? AndroidScheduleMode.inexactAllowWhileIdle
+        : AndroidScheduleMode.exactAllowWhileIdle;
+
+    await _plugin.zonedSchedule(
+      n.id,
+      n.title,
+      n.body,
+      n.fireAt,
+      const NotificationDetails(
+        iOS: DarwinNotificationDetails(
+          presentAlert: true,
+          presentBadge: true,
+          presentSound: true,
+        ),
+        android: AndroidNotificationDetails(
+          'agenda',
+          'Agenda',
+          channelDescription: 'Daily summaries and routine reminders',
+          importance: Importance.defaultImportance,
+        ),
+      ),
+      payload: n.payload,
+      androidScheduleMode: scheduleMode,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+    );
+
+    _scheduled[n.id] = n;
+  }
+
+  @override
+  Future<void> cancel(int id) async {
+    await _plugin.cancel(id);
+    _scheduled.remove(id);
+  }
+
+  @override
+  Future<Map<int, ScheduledNotification>> currentlyScheduled() async {
+    return Map<int, ScheduledNotification>.unmodifiable(_scheduled);
+  }
+
+  @override
+  Future<void> cancelAll() async {
+    await _plugin.cancelAll();
+    _scheduled.clear();
+  }
+}

--- a/lib/core/notifications/domain/notification_service.dart
+++ b/lib/core/notifications/domain/notification_service.dart
@@ -1,0 +1,70 @@
+import 'package:timezone/timezone.dart' as tz;
+
+/// One scheduled OS notification. Equality is structural so the reconciler
+/// (ADR-NOTIF-001) can diff value-stably against the in-memory snapshot.
+class ScheduledNotification {
+  const ScheduledNotification({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.fireAt,
+    required this.payload,
+  });
+
+  final int id;
+  final String title;
+  final String body;
+  final tz.TZDateTime fireAt;
+  final String payload;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScheduledNotification &&
+        other.id == id &&
+        other.title == title &&
+        other.body == body &&
+        other.fireAt.millisecondsSinceEpoch == fireAt.millisecondsSinceEpoch &&
+        other.payload == payload;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        title,
+        body,
+        fireAt.millisecondsSinceEpoch,
+        payload,
+      );
+
+  @override
+  String toString() =>
+      'ScheduledNotification(id: $id, title: "$title", fireAt: $fireAt)';
+}
+
+/// Sole writer to the OS notification queue (ADR-NOTIF-001).
+///
+/// Foreground: lifetime-scoped singleton via Riverpod.
+/// Background isolate: constructed per task spawn via coreBoot (ADR-PLATFORM-007);
+/// snapshot is fresh per spawn — first reconcile rewrites the OS queue, which is
+/// safe because the plugin's `schedule` replaces an existing entry by ID.
+abstract class NotificationService {
+  Future<void> init();
+
+  /// Triggers the OS permission prompt on first call. No-op when already
+  /// resolved (granted or denied). Returns true iff granted.
+  Future<bool> requestPermission();
+
+  Future<bool> isPermitted();
+
+  Future<void> schedule(ScheduledNotification n);
+
+  Future<void> cancel(int id);
+
+  /// Returns the in-memory snapshot of currently scheduled notifications
+  /// (NOT the plugin's pendingNotificationRequests — see ADR-NOTIF-001).
+  /// Used by the reconciler as the diff source.
+  Future<Map<int, ScheduledNotification>> currentlyScheduled();
+
+  Future<void> cancelAll();
+}

--- a/lib/core/notifications/notification_providers.dart
+++ b/lib/core/notifications/notification_providers.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:timezone/timezone.dart' as tz;
+import 'package:voice_agent/core/notifications/agenda_notification_scheduler.dart';
+import 'package:voice_agent/core/notifications/data/local_notification_service.dart';
+import 'package:voice_agent/core/notifications/domain/notification_service.dart';
+
+/// **Service providers only** (per ADR-ARCH-008): ephemeral cross-feature
+/// state belongs in `core/providers/`. The deep-link / tap-stream providers
+/// live in `core/providers/deep_link_providers.dart` and are wired in T3.
+///
+/// In the foreground, `notificationServiceProvider` is overridden in
+/// `app_main.dart` after `coreBoot()` so the widget tree sees the same
+/// instance the bootstrap built (P040 §Background Refresh — "Foreground
+/// bundle injection"). The fallback constructor below is for tests that
+/// don't override; production wiring always overrides.
+final notificationServiceProvider = Provider<NotificationService>((ref) {
+  throw UnimplementedError(
+    'notificationServiceProvider must be overridden in main() '
+    'with the instance built by coreBoot(). Tests should override too.',
+  );
+});
+
+/// Provides the pure reconciler. Reads `notificationServiceProvider` and
+/// uses `tz.local` (set during `LocalNotificationService.init()`). Production
+/// wiring overrides this with an instance using the production clock; tests
+/// inject a fixed clock + location.
+final agendaNotificationSchedulerProvider =
+    Provider<AgendaNotificationScheduler>((ref) {
+  final service = ref.watch(notificationServiceProvider);
+  return AgendaNotificationScheduler(
+    service: service,
+    location: tz.local,
+    clock: DateTime.now,
+  );
+});
+
+/// Exposes the tap stream of [LocalNotificationService] as a typed
+/// `Stream<String>`. Consumers in T3 will read this via
+/// `notificationTapStreamProvider` placed in `core/providers/` (per
+/// ADR-ARCH-008 — ephemeral cross-feature state lives in `core/providers/`).
+/// This provider is internal plumbing exposed for that wiring step only.
+final localNotificationTapStreamProvider = Provider<Stream<String>>((ref) {
+  final service = ref.watch(notificationServiceProvider);
+  if (service is LocalNotificationService) {
+    return service.tapStream;
+  }
+  // Tests with FakeNotificationService get an empty stream.
+  return const Stream<String>.empty();
+});

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import audioplayers_darwin
 import connectivity_plus
 import flutter_local_notifications
 import flutter_secure_storage_macos
+import flutter_timezone
 import flutter_tts
 import record_macos
 import shared_preferences_foundation
@@ -19,6 +20,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   FlutterTtsPlugin.register(with: registry.registrar(forPlugin: "FlutterTtsPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -307,6 +307,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: "direct main"
+    description:
+      name: flutter_timezone
+      sha256: ea53c61c9152f271a5e30624a624184804947b6a733ff2b64186bb2579446892
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   flutter_tts:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   flutter_foreground_task: ^9.2.2
   flutter_local_notifications: ^18.0.1
   timezone: ^0.10.0
+  flutter_timezone: ^3.0.1
   flutter_markdown_plus: ^1.0.4
   opentelemetry: ^0.18.11
 

--- a/test/core/notifications/agenda_notification_scheduler_test.dart
+++ b/test/core/notifications/agenda_notification_scheduler_test.dart
@@ -1,0 +1,551 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timezone/data/latest_all.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
+import 'package:voice_agent/core/models/agenda.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/models/routine.dart';
+import 'package:voice_agent/core/notifications/agenda_notification_scheduler.dart';
+import 'package:voice_agent/core/notifications/domain/notification_service.dart';
+
+/// In-memory fake that records all calls and maintains its own snapshot.
+class FakeNotificationService implements NotificationService {
+  final Map<int, ScheduledNotification> _snapshot = {};
+  final List<String> calls = [];
+  bool permitted = true;
+
+  @override
+  Future<void> init() async {
+    calls.add('init');
+  }
+
+  @override
+  Future<bool> requestPermission() async {
+    calls.add('requestPermission');
+    return permitted;
+  }
+
+  @override
+  Future<bool> isPermitted() async => permitted;
+
+  @override
+  Future<void> schedule(ScheduledNotification n) async {
+    calls.add('schedule(${n.id})');
+    _snapshot[n.id] = n;
+  }
+
+  @override
+  Future<void> cancel(int id) async {
+    calls.add('cancel($id)');
+    _snapshot.remove(id);
+  }
+
+  @override
+  Future<Map<int, ScheduledNotification>> currentlyScheduled() async =>
+      Map.unmodifiable(_snapshot);
+
+  @override
+  Future<void> cancelAll() async {
+    calls.add('cancelAll');
+    _snapshot.clear();
+  }
+
+  int get scheduleCount => calls.where((c) => c.startsWith('schedule(')).length;
+  int get cancelCount =>
+      calls.where((c) => c.startsWith('cancel(') && c != 'cancelAll').length;
+}
+
+void main() {
+  late tz.Location warsaw;
+  late FakeNotificationService service;
+
+  setUpAll(() {
+    tz_data.initializeTimeZones();
+    warsaw = tz.getLocation('Europe/Warsaw');
+  });
+
+  setUp(() {
+    service = FakeNotificationService();
+  });
+
+  AgendaNotificationScheduler buildScheduler({
+    required DateTime now,
+  }) {
+    return AgendaNotificationScheduler(
+      service: service,
+      location: warsaw,
+      clock: () => now,
+    );
+  }
+
+  AgendaResponse responseFor(
+    String date, {
+    List<AgendaItem> items = const [],
+    List<AgendaRoutineItem> routineItems = const [],
+  }) =>
+      AgendaResponse(
+        date: date,
+        granularity: 'day',
+        from: '${date}T00:00:00Z',
+        to: '${date}T23:59:59Z',
+        items: items,
+        routineItems: routineItems,
+      );
+
+  AgendaItem actionItem(
+    String id, {
+    required RecordStatus status,
+    String scheduledFor = '2026-05-17',
+  }) =>
+      AgendaItem(
+        recordId: id,
+        text: 'Item $id',
+        scheduledFor: scheduledFor,
+        timeWindow: TimeWindow.day,
+        originRole: OriginRole.user,
+        status: status,
+        linkedConversationCount: 0,
+      );
+
+  AgendaRoutineItem routine(
+    String routineId, {
+    required String name,
+    String scheduledFor = '2026-05-17',
+    String? startTime = '14:30',
+    String? occurrenceId = 'occ-001',
+    OccurrenceStatus status = OccurrenceStatus.pending,
+  }) =>
+      AgendaRoutineItem(
+        routineId: routineId,
+        routineName: name,
+        scheduledFor: scheduledFor,
+        startTime: startTime,
+        overdue: false,
+        status: status,
+        occurrenceId: occurrenceId,
+        templates: const [],
+      );
+
+  group('summaries', () {
+    test('empty response → 4 summary slots scheduled for today', () async {
+      // 2026-05-17 08:00 Warsaw — all 4 slots still in future
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17'),
+        sessionActive: false,
+      );
+      expect(service.scheduleCount, 4);
+      expect(service.cancelCount, 0);
+      // IDs 1000-1003
+      final snapshot = await service.currentlyScheduled();
+      expect(snapshot.keys, containsAll([1000, 1001, 1002, 1003]));
+    });
+
+    test('past slot is scheduled for tomorrow', () async {
+      // 13:00 — Morning (09:00) and Noon (12:00) are past
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 13, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17'),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      final morning = snapshot[1000]!;
+      final noon = snapshot[1001]!;
+      final afternoon = snapshot[1002]!;
+      expect(morning.fireAt.day, 18); // tomorrow
+      expect(morning.fireAt.hour, 9);
+      expect(noon.fireAt.day, 18);
+      expect(noon.fireAt.hour, 12);
+      expect(afternoon.fireAt.day, 17); // still today
+      expect(afternoon.fireAt.hour, 15);
+    });
+
+    test('body: all-zero counts → "nothing scheduled today"', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17'),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      expect(snapshot[1000]!.body, 'Morning: nothing scheduled today');
+    });
+
+    test('body: counts grouped by status with zero-elision', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', items: [
+          actionItem('a1', status: RecordStatus.active),
+          actionItem('a2', status: RecordStatus.active),
+          actionItem('a3', status: RecordStatus.active),
+          actionItem('d1', status: RecordStatus.done),
+          actionItem('p1', status: RecordStatus.promoted), // counted as done
+          actionItem('s1', status: RecordStatus.superseded), // dismissed
+        ]),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      // open=3, done=2 (1 done + 1 promoted), dismissed=1
+      expect(snapshot[1000]!.body, 'Morning: 3 open, 2 done, 1 dismissed');
+    });
+
+    test('body: zero terms elided', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', items: [
+          actionItem('a1', status: RecordStatus.active),
+          actionItem('a2', status: RecordStatus.active),
+        ]),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      expect(snapshot[1000]!.body, 'Morning: 2 open');
+    });
+
+    test('slot labels are Morning/Noon/Afternoon/Evening', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17'),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      expect(snapshot[1000]!.body, startsWith('Morning:'));
+      expect(snapshot[1001]!.body, startsWith('Noon:'));
+      expect(snapshot[1002]!.body, startsWith('Afternoon:'));
+      expect(snapshot[1003]!.body, startsWith('Evening:'));
+    });
+
+    test('payload is /agenda for all summaries', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17'),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      for (final id in [1000, 1001, 1002, 1003]) {
+        expect(snapshot[id]!.payload, '/agenda');
+      }
+    });
+
+    test('summaries fire in Warsaw local time, not UTC', () async {
+      // 2026-05-17 08:00 local Warsaw is 06:00 UTC (summer time, CEST = UTC+2).
+      // Verify Morning summary fires at 09:00 *Warsaw*, not 09:00 UTC.
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17'),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      final morning = snapshot[1000]!;
+      expect(morning.fireAt.location.name, 'Europe/Warsaw');
+      expect(morning.fireAt.hour, 9);
+    });
+  });
+
+  group('routine occurrences', () {
+    test('future occurrence is scheduled with id in 3M+ range', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1', name: 'Take the dog out', startTime: '14:30'),
+        ]),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      final routineIds = snapshot.keys.where((id) => id >= 3000000);
+      expect(routineIds.length, 1);
+      final reminder = snapshot[routineIds.first]!;
+      expect(reminder.title, 'Take the dog out');
+      expect(reminder.fireAt.hour, 14);
+      expect(reminder.fireAt.minute, 30);
+      expect(reminder.payload, '/agenda');
+    });
+
+    test('past start_time is not scheduled', () async {
+      // 15:00 — 14:30 is past
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 15, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1', name: 'Past routine', startTime: '14:30'),
+        ]),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      final routineIds = snapshot.keys.where((id) => id >= 3000000);
+      expect(routineIds, isEmpty);
+    });
+
+    test('null occurrenceId is not scheduled', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1', name: 'No occurrence', occurrenceId: null),
+        ]),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      expect(snapshot.keys.where((id) => id >= 3000000), isEmpty);
+    });
+
+    test('null start_time is not scheduled', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1', name: 'No time', startTime: null),
+        ]),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      expect(snapshot.keys.where((id) => id >= 3000000), isEmpty);
+    });
+
+    test('skipped occurrence is not scheduled', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1',
+              name: 'Skipped', status: OccurrenceStatus.skipped),
+        ]),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      expect(snapshot.keys.where((id) => id >= 3000000), isEmpty);
+    });
+
+    test('done occurrence is not scheduled (already complete)', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1', name: 'Done', status: OccurrenceStatus.done),
+        ]),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      expect(snapshot.keys.where((id) => id >= 3000000), isEmpty);
+    });
+  });
+
+  group('session gating', () {
+    test('sessionActive=true → summaries scheduled, occurrences skipped',
+        () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1', name: 'X', startTime: '14:30'),
+          routine('r2',
+              name: 'Y', startTime: '16:00', occurrenceId: 'occ-002'),
+        ]),
+        sessionActive: true,
+      );
+      final snapshot = await service.currentlyScheduled();
+      expect(
+        snapshot.keys.where((id) => id < 2000000).toSet(),
+        {1000, 1001, 1002, 1003},
+      );
+      expect(snapshot.keys.where((id) => id >= 3000000), isEmpty);
+    });
+
+    test('session edge true→false: occurrences re-added on next reconcile',
+        () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      final response = responseFor('2026-05-17', routineItems: [
+        routine('r1', name: 'Recovery', startTime: '14:30'),
+      ]);
+      await scheduler.reconcile(response, sessionActive: true);
+      service.calls.clear();
+      await scheduler.reconcile(response, sessionActive: false);
+      expect(service.scheduleCount, 1); // one routine reminder added
+      expect(service.cancelCount, 0);
+    });
+
+    test('session edge false→true: occurrences canceled, summaries kept',
+        () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      final response = responseFor('2026-05-17', routineItems: [
+        routine('r1', name: 'Suppress me', startTime: '14:30'),
+      ]);
+      await scheduler.reconcile(response, sessionActive: false);
+      service.calls.clear();
+      await scheduler.reconcile(response, sessionActive: true);
+      expect(service.cancelCount, 1);
+      expect(service.scheduleCount, 0);
+      final snapshot = await service.currentlyScheduled();
+      expect(snapshot.keys.where((id) => id >= 3000000), isEmpty);
+      // summaries still present
+      expect(snapshot.keys, containsAll([1000, 1001, 1002, 1003]));
+    });
+  });
+
+  group('diff invariants', () {
+    test('identical re-run is a no-op', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      final response = responseFor('2026-05-17', routineItems: [
+        routine('r1', name: 'X', startTime: '14:30'),
+      ]);
+      await scheduler.reconcile(response, sessionActive: false);
+      service.calls.clear();
+      await scheduler.reconcile(response, sessionActive: false);
+      expect(service.scheduleCount, 0);
+      expect(service.cancelCount, 0);
+    });
+
+    test('removed occurrence is canceled, others untouched', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1',
+              name: 'Keep', startTime: '14:30', occurrenceId: 'occ-001'),
+          routine('r2',
+              name: 'Remove', startTime: '16:00', occurrenceId: 'occ-002'),
+        ]),
+        sessionActive: false,
+      );
+      service.calls.clear();
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1',
+              name: 'Keep', startTime: '14:30', occurrenceId: 'occ-001'),
+        ]),
+        sessionActive: false,
+      );
+      expect(service.cancelCount, 1);
+      expect(service.scheduleCount, 0);
+    });
+
+    test('body drift (count change) triggers cancel+reschedule for summary',
+        () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      // First call: 1 active item
+      await scheduler.reconcile(
+        responseFor('2026-05-17', items: [
+          actionItem('a1', status: RecordStatus.active),
+        ]),
+        sessionActive: false,
+      );
+      service.calls.clear();
+      // Second call: 2 active items — summary body changes from "1 open" to "2 open"
+      await scheduler.reconcile(
+        responseFor('2026-05-17', items: [
+          actionItem('a1', status: RecordStatus.active),
+          actionItem('a2', status: RecordStatus.active),
+        ]),
+        sessionActive: false,
+      );
+      // All 4 summary bodies change. Diff should re-schedule all 4 (plugin's
+      // schedule replaces on existing id, so cancel is not strictly needed,
+      // but reschedule must happen for each changed body).
+      expect(service.scheduleCount, 4);
+    });
+  });
+
+  group('permission', () {
+    test('denied permission short-circuits with zero writes', () async {
+      service.permitted = false;
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1', name: 'X', startTime: '14:30'),
+        ]),
+        sessionActive: false,
+      );
+      expect(service.scheduleCount, 0);
+      expect(service.cancelCount, 0);
+    });
+
+    test('permission revoked between runs: cancelAll once', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1', name: 'X', startTime: '14:30'),
+        ]),
+        sessionActive: false,
+      );
+      service.permitted = false;
+      service.calls.clear();
+      await scheduler.reconcile(
+        responseFor('2026-05-17'),
+        sessionActive: false,
+      );
+      expect(service.calls, contains('cancelAll'));
+      final snapshot = await service.currentlyScheduled();
+      expect(snapshot, isEmpty);
+    });
+  });
+
+  group('id stability', () {
+    test('same occurrenceId produces same id across runs', () async {
+      final scheduler1 = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler1.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1',
+              name: 'X',
+              startTime: '14:30',
+              occurrenceId: 'stable-uuid-123'),
+        ]),
+        sessionActive: false,
+      );
+      final id1 = (await service.currentlyScheduled())
+          .keys
+          .firstWhere((k) => k >= 3000000);
+
+      final service2 = FakeNotificationService();
+      final scheduler2 = AgendaNotificationScheduler(
+        service: service2,
+        location: warsaw,
+        clock: () => DateTime(2026, 5, 17, 8, 0),
+      );
+      await scheduler2.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1',
+              name: 'X',
+              startTime: '14:30',
+              occurrenceId: 'stable-uuid-123'),
+        ]),
+        sessionActive: false,
+      );
+      final id2 = (await service2.currentlyScheduled())
+          .keys
+          .firstWhere((k) => k >= 3000000);
+
+      expect(id1, id2);
+    });
+
+    test('different occurrenceIds produce different ids', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1',
+              name: 'X', startTime: '14:30', occurrenceId: 'occ-aaa'),
+          routine('r2',
+              name: 'Y', startTime: '16:00', occurrenceId: 'occ-bbb'),
+        ]),
+        sessionActive: false,
+      );
+      final routineIds = (await service.currentlyScheduled())
+          .keys
+          .where((id) => id >= 3000000)
+          .toSet();
+      expect(routineIds.length, 2);
+    });
+
+    test('reserved ID ranges respected', () async {
+      final scheduler = buildScheduler(now: DateTime(2026, 5, 17, 8, 0));
+      await scheduler.reconcile(
+        responseFor('2026-05-17', routineItems: [
+          routine('r1', name: 'X', startTime: '14:30'),
+        ]),
+        sessionActive: false,
+      );
+      final snapshot = await service.currentlyScheduled();
+      for (final id in snapshot.keys) {
+        // Summaries 1000-1003, action items 2M-2.999M reserved (P041), routines 3M+ (CRC32-derived).
+        // No id should fall in 1004-1999999 (gap) or 2000000-2999999 (P041 reserved, not used by T1).
+        final isSummary = id >= 1000 && id <= 1003;
+        final isRoutine = id >= 3000000;
+        expect(
+          isSummary || isRoutine,
+          isTrue,
+          reason: 'id $id outside reserved ranges',
+        );
+      }
+    });
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <audioplayers_windows/audioplayers_windows_plugin.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <flutter_timezone/flutter_timezone_plugin_c_api.h>
 #include <flutter_tts/flutter_tts_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <record_windows/record_windows_plugin_c_api.h>
@@ -20,6 +21,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  FlutterTimezonePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterTimezonePluginCApi"));
   FlutterTtsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterTtsPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   audioplayers_windows
   connectivity_plus
   flutter_secure_storage_windows
+  flutter_timezone
   flutter_tts
   permission_handler_windows
   record_windows


### PR DESCRIPTION
## Summary

First slice of **P040** (agenda notifications & background refresh): pure-Dart domain types, a `flutter_local_notifications`-backed service, and the agenda reconciler with full unit-test coverage.

- `core/notifications/domain/notification_service.dart` — `NotificationService` interface + `ScheduledNotification` value type (structural equality so the diff is value-stable per **ADR-NOTIF-001**).
- `core/notifications/data/local_notification_service.dart` — concrete impl. Timezone init via `flutter_timezone` + `tz.setLocalLocation` (replaces the PoC's UTC-only init). In-memory `_scheduled` snapshot as the diff source. Exposes `tapStream` for T3's deep-link wiring.
- `core/notifications/agenda_notification_scheduler.dart` — pure reconciler. 4 daily summaries (09/12/15/19) + per-occurrence routine reminders. Session gating, permission revocation handling, reserved ID partitioning (summaries 1000–1003, routines 3M+ via CRC-32).
- `core/notifications/notification_providers.dart` — service-only providers per **ADR-ARCH-008**. `notificationServiceProvider` throws unless overridden (production wires it in `app_main` after `coreBoot()` — T2).

Deps: `flutter_timezone: ^3.0.1`.

## What this PR is NOT doing

- **PoC removal** — `come_back_notifier.dart` stays until T3.
- **Background isolate** (`coreBoot` + workmanager) — T2.
- **AgendaNotifier wiring**, **app-resume staleness trigger**, **deep-link routing** — all T3.

## Tests

`test/core/notifications/agenda_notification_scheduler_test.dart` — **25 cases, all green**:

- summaries (8): empty response, past-slot tomorrow-scheduling, copy variants (zero / full / elision), slot labels, payload, Warsaw-local timezone correctness
- routine occurrences (5): future scheduled, past start_time skipped, null occurrenceId / startTime / done / skipped — all skipped
- session gating (3): active suppresses occurrences, edge `true→false` re-adds, edge `false→true` cancels (summaries kept)
- diff invariants (3): identical re-run is no-op, removed occurrence canceled, body drift (count change) triggers re-schedule via value-equality
- permission (2): denied short-circuits, revocation `cancelAll`-once
- id stability (3): same `occurrenceId` → same id across runs, different `occurrenceId`s → different ids, reserved ranges respected

Full suite: `flutter test` → **984 passed**.

## `make verify` status

**`flutter test` passes.** `flutter analyze` is **red on `main`** due to 3 pre-existing warnings introduced by P039 T5b (#296) — none from this PR:

| File | Line | Warning |
|---|---|---|
| `lib/core/tts/flutter_tts_service.dart` | 46 | `unused_field` (`_audioSession`) |
| `lib/features/recording/presentation/hands_free_controller.dart` | 515 | `unused_element` (`_closeEngagement`) |
| `test/features/recording/presentation/hands_free_controller_test.dart` | 20 | `unused_import` |

P040 code itself analyzes clean: `flutter analyze lib/core/notifications/` → **No issues found.**

Suggested handling: address these in a separate chore PR (out of P040 scope per CLAUDE.md "don't refactor beyond what the task requires"), or fold into P039 T5b's verification close-out.

## Test plan

- [x] `flutter test` — 984 passed
- [x] `flutter analyze lib/core/notifications/` — clean
- [x] Manual review of reconciler logic against ADR-NOTIF-001 invariants
- [ ] Manual device verification — deferred to T3 (this PR has no UI / no platform behavior)

## Refs

- Proposal: `docs/proposals/040-agenda-notifications-and-background-refresh.md` (§Tasks T1)
- ADRs: ADR-NOTIF-001 (diff-based reconciliation + ID partitioning), ADR-PLATFORM-007 (shared core boot helper — sets up T2), ADR-ARCH-008 (ephemeral cross-feature state placement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
