### PR TITLE
fix(boot): make registerAgendaRefresh failure non-fatal on iOS Simulator

### DIFF
--- a/lib/app_main.dart
+++ b/lib/app_main.dart
@@ -58,7 +58,19 @@ Future<void> appMain() async {
 
   // Register the periodic agenda-refresh task. Idempotent (KEEP policy).
   // Per ADR-NET-002 P040 amendment.
-  await registerAgendaRefresh();
+  //
+  // Best-effort: on iOS Simulator (and on physical iOS without
+  // `BGTaskSchedulerPermittedIdentifiers` in Info.plist) workmanager throws
+  // `unhandledMethod("registerPeriodicTask")`. Background agenda refresh
+  // simply will not run there — that's the expected platform behaviour. Boot
+  // must not depend on it.
+  try {
+    await registerAgendaRefresh();
+  } catch (e, st) {
+    if (kDebugMode) {
+      debugPrint('registerAgendaRefresh failed (continuing): $e\n$st');
+    }
+  }
 
   final recovered = await core.storage.recoverStaleSending();
   if (kDebugMode && recovered > 0) {


### PR DESCRIPTION
## Summary

`Workmanager.registerPeriodicTask` throws `PlatformException(unhandledMethod("registerPeriodicTask"))` on iOS Simulator and on any physical iOS without `BGTaskSchedulerPermittedIdentifiers` in Info.plist + Background Modes capability. The exception escapes `appMain` and kills the app boot — the user sees a permanently white screen.

Wrap the call in a defensive try/catch with a `kDebugMode` debugPrint. Background agenda refresh is best-effort (idempotent `ExistingWorkPolicy.keep`); failing to register it must not block boot.

## Context

Discovered during the P039 T5b manual verification today (see `docs/manual-tests/p039-t5b-handsfree-telemetry.md`). The crash blocked the test entirely; this fix unblocked it and the T5b chain verified green end-to-end on iOS Simulator.

Proper iOS Workmanager wiring (BGTaskScheduler identifier registration + Info.plist + Background Modes) is a separate concern tracked under P040. This PR is the **graceful failure path** for the platforms where workmanager genuinely cannot run.

## Test plan

- [x] `flutter analyze` — clean (3 pre-existing warnings, none new)
- [x] `flutter test` — 994/994 pass
- [x] Manual: iOS Simulator boot reaches first frame post-fix (white-screen → orange UI)
- [ ] Reviewer: confirm `kDebugMode` guard is the right log gate (we want the trace visible on the dev flavor but silent in release builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)