### PR TITLE
fix(p040): close-out — ADR-PLATFORM-008 ordering + missing notifier tests

### DIFF
--- a/docs/decisions/ADR-NOTIF-001-diff-based-reconciliation-with-id-partitioning.md
+++ b/docs/decisions/ADR-NOTIF-001-diff-based-reconciliation-with-id-partitioning.md
@@ -36,7 +36,9 @@ OS notification scheduling in voice-agent is governed by six rules.
    - `2_000_000–2_999_999` — reserved for per-item action-item reminders (P041 follow-up).
    - `3_000_000+` — routine-occurrence reminders, ID = `3_000_000 + (crc32(occurrenceId) & 0x7FFFFFFF)`.
    Future kinds claim a new range and amend this ADR.
-6. **Permission revocation handling.** On every reconcile, `LocalNotificationService.isPermitted()` is checked. If it returns false after previously returning true (revocation observed), the service calls `cancelAll()` once to clean the OS queue and clears the in-memory snapshot. Subsequent reconciles short-circuit until permission is re-granted.
+6. **Permission revocation handling.** On every reconcile, `LocalNotificationService.isPermitted()` is checked. If it returns false after previously returning true (revocation observed), `cancelAll()` is called once to clean the OS queue and clear the in-memory snapshot. Subsequent reconciles short-circuit until permission is re-granted.
+
+   *Implementation note:* the revocation-edge tracking (`previouslyPermitted` flag) lives in `AgendaNotificationScheduler`, not in `LocalNotificationService`. The scheduler observes `isPermitted()` and triggers `service.cancelAll()` upon detecting the false-after-true edge. The service remains the sole writer that *executes* the cancel; the scheduler is the sole writer of write *intent*. This split keeps `LocalNotificationService` stateless beyond its snapshot map.
 
 Session gating (`sessionActiveProvider == true` suppresses per-occurrence reminders; summaries always fire) is part of the reconciler's desired-set computation, not a separate writer. See P027 for the `sessionActiveProvider` contract.
 

--- a/lib/app_main.dart
+++ b/lib/app_main.dart
@@ -16,7 +16,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/app/app.dart';
 import 'package:voice_agent/app/background/register_agenda_refresh.dart';
@@ -46,6 +45,13 @@ typedef AfterStorageInit = Future<void> Function(StorageService storage);
 Future<void> appMain({AfterStorageInit? afterStorageInit}) async {
   WidgetsFlutterBinding.ensureInitialized();
 
+  // Read the cold-start deep-link payload BEFORE coreBoot() — per
+  // ADR-PLATFORM-008, the warm-path callback (registered inside
+  // LocalNotificationService.init() which coreBoot triggers) must NOT
+  // observe the launch tap. `getNotificationAppLaunchDetails` queries
+  // the platform channel directly and does not require plugin initialize.
+  final cold = await LocalNotificationService.readColdStartPayload();
+
   FlutterForegroundTaskService.initForegroundTask();
 
   // P040: single source of truth for core dep construction. Both this
@@ -60,12 +66,6 @@ Future<void> appMain({AfterStorageInit? afterStorageInit}) async {
   if (afterStorageInit != null) {
     await afterStorageInit(core.storage);
   }
-
-  // Read the cold-start deep-link payload BEFORE runApp, per ADR-PLATFORM-008.
-  // The plugin discards this after the warm-path callback is registered, so
-  // ordering is critical: read first, callback registered inside `init()`
-  // which already happened in coreBoot().
-  final cold = await _readColdStartDeepLink();
 
   // Prompt for notification permission once. Idempotent on subsequent
   // launches — OS handles the "already resolved" case. Fire-and-forget; the
@@ -131,16 +131,5 @@ Future<void> appMain({AfterStorageInit? afterStorageInit}) async {
       child: App(scaffoldMessengerKey: scaffoldMessengerKey),
     ),
   );
-}
-
-Future<String?> _readColdStartDeepLink() async {
-  try {
-    final details = await FlutterLocalNotificationsPlugin()
-        .getNotificationAppLaunchDetails();
-    if (details?.didNotificationLaunchApp != true) return null;
-    return details!.notificationResponse?.payload;
-  } catch (_) {
-    return null;
-  }
 }
 

--- a/lib/core/notifications/data/local_notification_service.dart
+++ b/lib/core/notifications/data/local_notification_service.dart
@@ -28,6 +28,25 @@ class LocalNotificationService implements NotificationService {
   /// (`notificationTapStreamProvider`) by the provider layer in T3.
   Stream<String> get tapStream => _tapController.stream;
 
+  /// Reads the cold-start launch payload, if the app was launched by a
+  /// notification tap. Per ADR-PLATFORM-008, this MUST be called BEFORE
+  /// [init] (which registers the warm-path callback) to preserve the
+  /// "exactly one channel" invariant.
+  ///
+  /// Safe to call without prior [init] — `getNotificationAppLaunchDetails`
+  /// queries the platform channel directly and does not require the plugin
+  /// to be initialized.
+  static Future<String?> readColdStartPayload() async {
+    try {
+      final details = await FlutterLocalNotificationsPlugin()
+          .getNotificationAppLaunchDetails();
+      if (details?.didNotificationLaunchApp != true) return null;
+      return details!.notificationResponse?.payload;
+    } catch (_) {
+      return null;
+    }
+  }
+
   @override
   Future<void> init() async {
     if (_initialized) return;

--- a/test/features/agenda/presentation/agenda_notifier_test.dart
+++ b/test/features/agenda/presentation/agenda_notifier_test.dart
@@ -11,6 +11,7 @@ import 'package:voice_agent/core/models/routine.dart';
 import 'package:voice_agent/core/notifications/agenda_notification_scheduler.dart';
 import 'package:voice_agent/core/notifications/domain/notification_service.dart';
 import 'package:voice_agent/core/notifications/notification_providers.dart';
+import 'package:voice_agent/core/providers/session_active_provider.dart';
 import 'package:voice_agent/features/agenda/domain/agenda_repository.dart';
 import 'package:voice_agent/features/agenda/domain/agenda_state.dart';
 import 'package:voice_agent/features/agenda/presentation/agenda_notifier.dart';
@@ -105,6 +106,8 @@ class _FakeNotificationService implements NotificationService {
   final Map<int, ScheduledNotification> _snapshot = {};
   bool permitted = true;
 
+  Map<int, ScheduledNotification> get snapshot => Map.unmodifiable(_snapshot);
+
   @override
   Future<void> init() async {}
   @override
@@ -122,29 +125,6 @@ class _FakeNotificationService implements NotificationService {
   Future<void> cancelAll() async => _snapshot.clear();
 }
 
-/// Build a ProviderContainer with all deps needed by `agendaNotifierProvider`.
-/// Returns the container; tests read `agendaNotifierProvider.notifier` to get
-/// the notifier (same path production code uses).
-ProviderContainer _buildContainer(AgendaRepository repo) {
-  final notifications = _FakeNotificationService();
-  final scheduler = AgendaNotificationScheduler(
-    service: notifications,
-    location: tz.local,
-    clock: DateTime.now,
-  );
-  // AppConfigService writes to SharedPreferences; for unit tests we use the
-  // mock channel registered in setUpAll().
-  final configService = AppConfigService();
-  return ProviderContainer(
-    overrides: [
-      agendaRepositoryProvider.overrideWithValue(repo),
-      notificationServiceProvider.overrideWithValue(notifications),
-      agendaNotificationSchedulerProvider.overrideWithValue(scheduler),
-      appConfigServiceProvider.overrideWithValue(configService),
-    ],
-  );
-}
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -152,17 +132,31 @@ void main() {
     tz_data.initializeTimeZones();
   });
 
-  setUp(() {
-    // Mock SharedPreferences (no platform plugin in the unit harness).
-    SharedPreferences.setMockInitialValues({});
-  });
-
   late _MockRepository repo;
+  late _FakeNotificationService notifications;
+  late AppConfigService configService;
   late ProviderContainer container;
 
   setUp(() {
+    // Mock SharedPreferences (no platform plugin in the unit harness).
+    SharedPreferences.setMockInitialValues({});
+
     repo = _MockRepository();
-    container = _buildContainer(repo);
+    notifications = _FakeNotificationService();
+    configService = AppConfigService();
+    final scheduler = AgendaNotificationScheduler(
+      service: notifications,
+      location: tz.local,
+      clock: DateTime.now,
+    );
+    container = ProviderContainer(
+      overrides: [
+        agendaRepositoryProvider.overrideWithValue(repo),
+        notificationServiceProvider.overrideWithValue(notifications),
+        agendaNotificationSchedulerProvider.overrideWithValue(scheduler),
+        appConfigServiceProvider.overrideWithValue(configService),
+      ],
+    );
   });
 
   tearDown(() {
@@ -328,6 +322,108 @@ void main() {
 
       expect(repo.fetchCount, 1);
       expect(notifier.state, isA<AgendaLoaded>());
+    });
+  });
+
+  // ── P040: reconcile firing conditions and session-edge wiring ──────────
+  //
+  // The proposal (§Reconciler Triggers, §Session Gating) defines explicit
+  // rules for when the reconciler runs. These tests pin them down at the
+  // notifier level so a regression (e.g., firing on non-today, firing from
+  // error state) is caught at CI.
+
+  group('P040 reconcile firing conditions', () {
+    test('reconcile fires after loaded(today)', () async {
+      // Default _MockRepository.fetchAgenda returns today's date string from
+      // the notifier's _dateString getter, which uses DateTime.now → "today".
+      repo.nextFetchResult = _responseWithItems();
+      buildNotifier();
+      await Future<void>.delayed(Duration.zero);
+
+      // The pure scheduler always writes the 4 summary IDs at minimum.
+      expect(notifications.snapshot.keys, containsAll([1000, 1001, 1002, 1003]),
+          reason: 'reconciler should have scheduled the 4 daily summaries');
+    });
+
+    test('reconcile does NOT fire on error(cached)', () async {
+      final cached = CachedAgenda(
+        response: _responseWithItems(),
+        fetchedAt: DateTime(2026, 4, 19, 10, 0),
+      );
+      repo.nextCachedResult = cached;
+      repo.fetchError = Exception('Offline');
+
+      buildNotifier();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(notifications.snapshot, isEmpty,
+          reason: 'stale cache must not drive OS notification scheduling');
+    });
+
+    test('reconcile does NOT fire on loaded(non-today)', () async {
+      repo.nextFetchResult = _responseWithItems();
+      final notifier = buildNotifier();
+      await Future<void>.delayed(Duration.zero);
+
+      // Clear what initial today-load scheduled.
+      await notifications.cancelAll();
+
+      // Navigate to a non-today date.
+      notifier.selectDate(DateTime(2030, 1, 1));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(notifications.snapshot, isEmpty,
+          reason: 'non-today responses are for browsing, not scheduling');
+    });
+
+    test('lastAgendaFetchAt is persisted after loaded', () async {
+      final before = DateTime.now();
+      buildNotifier();
+      // Allow the fire-and-forget setLastAgendaFetchAt write to complete.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final saved = await configService.getLastAgendaFetchAt();
+      expect(saved, isNotNull,
+          reason: 'P040 §Reconciler Triggers #2 + bg 50-min skip guard '
+              'both depend on this timestamp');
+      expect(saved!.isAfter(before.subtract(const Duration(seconds: 1))),
+          isTrue);
+    });
+  });
+
+  group('P040 session-edge wiring', () {
+    test('session edge true→false triggers refresh (fetch + reconcile)',
+        () async {
+      buildNotifier();
+      await Future<void>.delayed(Duration.zero);
+
+      // Force the listener to observe a transition. ref.listen ignores the
+      // initial value but fires on subsequent changes.
+      container.read(sessionActiveProvider.notifier).state = true;
+      await Future<void>.delayed(Duration.zero);
+      repo.fetchCount = 0;
+
+      // The edge of interest:
+      container.read(sessionActiveProvider.notifier).state = false;
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(repo.fetchCount, greaterThan(0),
+          reason: 'true→false edge must call refresh() which re-fetches');
+    });
+
+    test('session edge false→true triggers reconcile-only (no fetch)',
+        () async {
+      repo.nextFetchResult = _responseWithItems();
+      buildNotifier();
+      await Future<void>.delayed(Duration.zero);
+      // Snapshot is now populated with summaries (and a routine reminder).
+      repo.fetchCount = 0;
+
+      container.read(sessionActiveProvider.notifier).state = true;
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(repo.fetchCount, 0,
+          reason: 'false→true edge must NOT re-fetch; it reconciles cached');
     });
   });
 }


### PR DESCRIPTION
## Summary

P040 close-out per `/proposal-implementation-review` findings (2026-05-17). Three issues addressed; one P1 left for a separate chore PR (pre-existing P039 warnings, out of P040 scope).

## Fixes

### P2 — ADR-PLATFORM-008 ordering invariant restored

ADR-PLATFORM-008 §Decision: *"Registered after the cold-start read has returned, ensuring the cold-start payload is never observed on this channel."*

Code reality (before): `coreBoot()` → `LocalNotificationService.init()` → registers the warm-path callback → THEN `getNotificationAppLaunchDetails()`. Opposite order.

Code reality (after): `LocalNotificationService.readColdStartPayload()` (new `static` method) called immediately after `WidgetsFlutterBinding.ensureInitialized()` and **before** `coreBoot()`. ADR contract restored. `getNotificationAppLaunchDetails` queries the platform channel directly and does not require plugin `initialize`, so the early read is safe.

Also addresses P3-1 (second `FlutterLocalNotificationsPlugin()` instance bypassing the abstraction) — the new static method is the canonical cold-start read path; removes the duplicate `_readColdStartDeepLink` helper and the unused `flutter_local_notifications` import in `app_main.dart`.

### P2 — Missing notifier tests for proposal-critical behaviors

Proposal §Test Impact listed 6 required notifier-level test cases. T3 refactored the test file's setUp but added no new assertions. This PR adds them:

- `reconcile fires after loaded(today)` — basic happy path.
- `reconcile does NOT fire on error(cached)` — stale-data guard.
- `reconcile does NOT fire on loaded(non-today)` — isToday gate.
- `lastAgendaFetchAt is persisted after loaded` — staleness trigger's data source.
- `session edge true→false triggers refresh (fetch + reconcile)` — per P040 §Session Gating.
- `session edge false→true triggers reconcile-only (no fetch)` — cancel-without-network path.

setUp refactored to expose the `FakeNotificationService` and `AppConfigService` to test bodies for assertion.

### P3 — ADR-NOTIF-001 revocation-tracking clarification

Rule 6 read *"the service calls cancelAll() once"* but the implementation places false-after-true tracking in `AgendaNotificationScheduler`. Internally consistent — the service is sole writer either way — but the wording could mislead.

Fix: ADR-NOTIF-001 Consequences amended with one paragraph clarifying the split: tracking lives in the scheduler (sole writer of *intent*), execution lives in the service (sole writer that *executes* `cancelAll()`). No code change.

## Tests

`flutter test` → **1030 passed** (1024 base + 6 new P040 cases).
`flutter analyze lib/` → clean for P040 code. Same 3 pre-existing P039 T5b warnings — addressed in a separate chore PR.

## Not addressed (deferred)

- **P1**: `make verify` red on pre-existing P039 T5b warnings (`flutter_tts_service.dart:46`, `hands_free_controller.dart:543`, `hands_free_controller_test.dart:20`). Out of P040 scope. Separate chore PR planned.
- **Open question**: manual device verification (timezone, BG refresh delivery, permission flows, deep-link routing, session gating end-to-end). Cannot be done in code review.

## Test plan

- [x] `flutter test` — 1030 passed
- [x] `flutter analyze lib/` — clean for changed code
- [ ] Manual: notification permission prompt order on first install
- [ ] Manual: cold-start tap routes to `/agenda` with cached snapshot

## Refs

- `/proposal-implementation-review` findings P2/P3 (2026-05-17)
- P040 §Test Impact, ADR-PLATFORM-008 §Decision, ADR-NOTIF-001 Consequences

🤖 Generated with [Claude Code](https://claude.com/claude-code)
