### PR TITLE
chore(p039): remove dead code from P037/P038 cleanups (unblocks make verify)

### DIFF
--- a/lib/core/tts/flutter_tts_service.dart
+++ b/lib/core/tts/flutter_tts_service.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 import 'package:voice_agent/core/tts/ssml_lang_splitter.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
@@ -11,11 +10,8 @@ class FlutterTtsService implements TtsService {
   FlutterTtsService({
     FlutterTts? tts,
     bool? isIOS,
-    MethodChannel? audioSessionChannel,
   })  : _tts = tts ?? FlutterTts(),
-        _isIOS = isIOS ?? Platform.isIOS,
-        _audioSession = audioSessionChannel ??
-            const MethodChannel('com.voiceagent/audio_session') {
+        _isIOS = isIOS ?? Platform.isIOS {
     _tts.setStartHandler(_onStart);
     _tts.setCompletionHandler(_onCompletion);
     _tts.setCancelHandler(_onCancel);
@@ -43,7 +39,6 @@ class FlutterTtsService implements TtsService {
 
   final FlutterTts _tts;
   final bool _isIOS;
-  final MethodChannel _audioSession;
   final ValueNotifier<bool> _speaking = ValueNotifier(false);
 
   /// P034 follow-up: switch the iOS audio session to .playback for the

--- a/lib/features/recording/presentation/hands_free_controller.dart
+++ b/lib/features/recording/presentation/hands_free_controller.dart
@@ -5,7 +5,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 import 'package:voice_agent/core/audio/audio_feedback_provider.dart';
-import 'package:voice_agent/core/background/background_service.dart';
 import 'package:voice_agent/core/background/background_service_provider.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/providers/session_active_provider.dart';
@@ -538,21 +537,6 @@ class HandsFreeController extends StateNotifier<HandsFreeSessionState>
     _phase = HandsFreeListeningPhase.listening;
     _pendingConversationResume = true;
     state = HandsFreeIdle(jobs: List.unmodifiable(_jobs));
-  }
-
-  Future<void> _closeEngagement({
-    required AudioSessionTarget toAmbientFor,
-  }) async {
-    _ref.read(sessionActiveProvider.notifier).state = false;
-    await _ref
-        .read(backgroundServiceProvider)
-        .stopService(target: toAmbientFor);
-    _engagement.disengage();
-    await _engineSub?.cancel();
-    _engineSub = null;
-    await _engine?.stop();
-    _engine = null;
-    _phase = HandsFreeListeningPhase.listening;
   }
 
   @override

--- a/test/features/recording/presentation/hands_free_controller_test.dart
+++ b/test/features/recording/presentation/hands_free_controller_test.dart
@@ -17,7 +17,6 @@ import 'package:voice_agent/core/providers/session_active_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
 import 'package:voice_agent/core/config/vad_config.dart';
-import 'package:voice_agent/features/recording/domain/engagement_controller.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_engine.dart';
 import 'package:voice_agent/features/recording/domain/hands_free_session_state.dart';
 import 'package:voice_agent/features/recording/domain/recording_result.dart';


### PR DESCRIPTION
## Summary

Removes three dead-code warnings blocking `make verify` since #296 was merged.

All three are leftovers from earlier P037/P038 cleanups — verified safe via git-blame:

| File | Warning | Origin |
|---|---|---|
| `lib/core/tts/flutter_tts_service.dart:46` | `unused_field` `_audioSession` | Field's only consumer (`_acquirePlaybackFocus`) was no-op'd by `8b733a6` (P038 "EXPERIMENT volume-button gate model"). |
| `lib/features/recording/presentation/hands_free_controller.dart:543` | `unused_element` `_closeEngagement` | Method became unreachable after `e29b1de` (P038 addendum "remove 30s auto-disengage timer"). |
| `test/features/recording/presentation/hands_free_controller_test.dart:20` | `unused_import` | Trailing import from prior refactor. |

Also drops two now-orphan imports: `package:flutter/services.dart` in `flutter_tts_service.dart` and `package:voice_agent/core/background/background_service.dart` in `hands_free_controller.dart` (the latter provided `AudioSessionTarget`, used only by the removed `_closeEngagement`).

## Verification

- `make verify` — **green** (was red since 2026-05-15). 1030 tests pass, zero analyzer issues.
- No test signatures changed; no production behavior changed.

## Test plan

- [x] `make verify` passes
- [x] No new imports added; only removals
- [x] Verified no test passes `audioSessionChannel:` kwarg to `FlutterTtsService(...)` (would break the constructor signature change)

## Refs

- Unblocks `make verify` gate for P040 close-out (#307) and any subsequent PR.
- `/proposal-implementation-review` flagged this as P1 (auto-promoted per skill spec) but the root cause was P039 T5b, not P040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
