### PR TITLE
feat(observability): P039 T6 (lifecycle) — app.foreground / background / terminate

### DIFF
--- a/lib/app/app_shell_scaffold.dart
+++ b/lib/app/app_shell_scaffold.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/network/connectivity_service.dart';
+import 'package:voice_agent/core/observability/telemetry.dart';
 import 'package:voice_agent/core/providers/app_foreground_provider.dart';
 import 'package:voice_agent/features/agenda/presentation/agenda_providers.dart';
 import 'package:voice_agent/features/api_sync/sync_provider.dart';
@@ -48,6 +49,25 @@ class _AppShellScaffoldState extends ConsumerState<AppShellScaffold>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     ref.read(appForegroundedProvider.notifier).state =
         state == AppLifecycleState.resumed;
+
+    // P039 T6 — emit lifecycle events so the Grafana timeline can
+    // correlate audio/sync activity with foreground/background
+    // transitions. Inactive/paused/hidden are background-ish; we
+    // collapse them into `app.background` for the dashboard with
+    // the precise state as an attr.
+    switch (state) {
+      case AppLifecycleState.resumed:
+        Telemetry.instance.event('app.foreground');
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.paused:
+      case AppLifecycleState.hidden:
+        Telemetry.instance.event('app.background', attrs: {
+          'state': state.name,
+        });
+      case AppLifecycleState.detached:
+        // Best-effort terminate notification before the engine tears down.
+        Telemetry.instance.event('app.terminate');
+    }
 
     // P040 §Reconciler Triggers #2: staleness-driven foreground refresh.
     if (state == AppLifecycleState.resumed) {


### PR DESCRIPTION
## Summary

Fourth slice of T6. Emits lifecycle events from `AppShellScaffold`'s WidgetsBindingObserver:
- `app.foreground` — on `AppLifecycleState.resumed`
- `app.background` — on inactive/paused/hidden, with the precise state collapsed into a `state` attribute (so the dashboard can still distinguish 'paused' from 'inactive')
- `app.terminate` — on `AppLifecycleState.detached` (best-effort)

The dashboard now has a continuous timeline of when the app was foregrounded. Cross-referenced with `hf.chunk_received` the mic-silent diagnosis chain finally tells the difference between 'app backgrounded' (legitimate silence) and 'mic dead in foreground' (the regression).

**No behaviour change.** Telemetry-only.

## Test plan
- [x] `flutter test` — 1038/1038 pass
- [x] `flutter analyze` — clean

## Remaining T6 slice
hardware-button (input.media_button / input.volume_button via the existing MediaButtonBridge consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)