### PR TITLE
docs(manual-tests): per-case status markers + convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,83 @@ test/
 - Platform behavior that can only be verified on a physical device (mark those
   acceptance criteria as "manual verification" in proposals).
 
+### Manual Test Plans
+
+When a proposal contains contracts that can only be verified on a physical
+device — push/local notification delivery, BGTask / WorkManager scheduling,
+permission prompts, deep-link routing, audio session ownership, OEM-specific
+Android behavior, hardware media buttons — write a **manual test plan**
+that captures the verification cold so anyone can run it without archaeology.
+
+**Location and naming**
+
+- One file per proposal slice that needs device verification.
+- Path: `docs/manual-tests/p{NNN}-{short-description}.md`
+- Reference it from the proposal's Status block once the proposal is marked
+  Implemented but device verification is still pending.
+
+**Required structure**
+
+Mirror the existing templates ([`p040-agenda-notifications.md`](docs/manual-tests/p040-agenda-notifications.md),
+[`p039-t5b-handsfree-telemetry.md`](docs/manual-tests/p039-t5b-handsfree-telemetry.md))
+so readers can pick up any plan without re-learning the format.
+
+1. **Header block** — proposal link, **Overall status** (`pending` /
+   `in-progress` / `passed` / `failed`), "Why now", time budget, "What we
+   are testing".
+2. **Status legend** — define the per-step status vocabulary (see below).
+   Newer plans link to the canonical legend in `p040-agenda-notifications.md`
+   rather than copying it.
+3. **Status summary table** — one row per case, current status.
+4. **Setup section** — `S1`, `S2`, … numbered prerequisites (backend state,
+   install command, inspector tools). Each gets its own `**Status:**`.
+5. **Test cases** — `T1`, `T2`, … each with:
+   - **Status:** marker (see legend).
+   - **Do:** numbered steps the runner executes verbatim.
+   - **Why:** which proposal/ADR contract this case actually verifies.
+     Without this, future readers will skip the case without realising what
+     they're skipping.
+   - **Expected:** the concrete observable outcome. Reference specific
+     log lines, OS UI elements, or `pendingNotificationRequests()` counts —
+     not vague "should work".
+   - **On failure:** the most likely root cause(s) and where to look first.
+     This is the diff between a usable runbook and a re-read of the source.
+6. **"When this plan is done" closing section** — clarify which cases are
+   must-pass (any failure blocks shipping) vs OEM-conditional (failures
+   acceptable when scoped to a documented device limitation).
+
+**Per-case status vocabulary**
+
+- `pending` — not yet attempted.
+- `in-progress` — execution started, not yet decided.
+- `passed (YYYY-MM-DD, <device + OS>)` — verified green; record the device
+  (e.g. `iPhone 12 Pro, iOS 18.3`) so future runs know the coverage baseline.
+- `failed (YYYY-MM-DD, <device + OS>): <one-line reason>` — verified red.
+  File a GitHub issue and reference both the case and this file.
+- `skipped (<reason>)` — case not applicable on the device (Android-only on
+  iPhone) or deliberately deferred (real-device stretch after Simulator pass).
+
+Update statuses **in-place during execution** and commit when the plan is
+fully run. Avoid re-running silently — the on-disk record is the source of
+truth for whether a contract has been verified.
+
+**When the proposal can drop the verification disclaimer**
+
+A proposal marked `Implemented (manual device verification pending)`
+becomes fully `Implemented` once every must-pass case in its manual plan
+is `passed`. OEM-conditional failures get documented in the proposal's
+§Risks rather than re-opening the proposal status.
+
+**When NOT to write a manual test plan**
+
+- Unit-testable contracts (covered by `make test`).
+- Behavior-preserving refactors (no new device contract introduced).
+- Docs / config / build changes that don't touch runtime behavior.
+
+If a Tier 2/3 proposal has *zero* device-only contracts, say so explicitly
+in the proposal's §Test Impact rather than leaving the reader wondering
+whether the plan was forgotten.
+
 ---
 
 ## Git Conventions

--- a/docs/manual-tests/p039-t5b-handsfree-telemetry.md
+++ b/docs/manual-tests/p039-t5b-handsfree-telemetry.md
@@ -1,15 +1,34 @@
 # Manual test: P039 T5b — hands-free telemetry chain
 
 **Proposal:** [`docs/proposals/039-otel-dev-telemetry.md`](../proposals/039-otel-dev-telemetry.md) — T5b verification gate.
+**Overall status:** **passed** — all setup + 4 test cases executed green on iOS Simulator. T5b gate cleared; T2 / T4 / T5a / T6 / T7 / T8 unblocked (and most have since landed on main).
 **Why now:** This gate must clear before T2 / T4 / T5a / T6 / T7 / T8 proceed.
 **Time budget:** ~20 min.
 **What we are testing:** that the telemetry *plumbing* works on real Flutter — events, counters, spans reach the Collector. We are **not** trying to reproduce the mic-silent regression itself (that's iOS-device-specific and may not even fire today). If the plumbing works, we have an instrument that will catch the regression when it next happens.
+
+## Status legend
+
+Each step below has a `**Status:** ...` line. Allowed values: `pending` / `in-progress` / `passed (YYYY-MM-DD, <device + OS>)` / `failed (YYYY-MM-DD, <device + OS>): <reason>` / `skipped (<reason>)`. See [`p040-agenda-notifications.md`](p040-agenda-notifications.md#status-legend) for the canonical definition.
+
+## Status summary
+
+| # | Case | Status |
+|---|---|---|
+| S1 | Bring up the Collector locally | passed |
+| S2 | Run the dev flavor on iOS Simulator | passed |
+| T1 | `app.boot` lands within seconds | passed |
+| T2 | `hf.attach_stream` span + `hf.chunk_received` ticks | passed |
+| T3 | `hf.gate_changed` events with structured `reason` | passed |
+| T4 | `hf.segment_emitted` / no spurious errors | passed |
+| S3 | Re-run on the real iPhone (stretch) | skipped (iOS Simulator pass sufficient; real-device session deferred) |
 
 ---
 
 ## Setup (2 commands, ~2 min)
 
 ### S1 — Bring up the Collector locally
+
+**Status:** passed
 
 **Do:**
 ```bash
@@ -21,6 +40,8 @@ cd ops/dev && docker compose -f collector-only.docker-compose.yml up -d
 **Expected:** `docker ps` shows `voice-agent-otel-spike` as `Up`. `curl -X POST -o /dev/null -w "%{http_code}" http://localhost:4318/v1/traces -H 'Content-Type: application/json' -d '{}'` returns `200`.
 
 ### S2 — Run the dev flavor on iOS Simulator
+
+**Status:** passed
 
 **Do:**
 ```bash
@@ -47,6 +68,8 @@ docker logs -f voice-agent-otel-spike
 
 ### T1 — `app.boot` lands within seconds of launch
 
+**Status:** passed
+
 **Do:** nothing — this fires automatically on app start.
 
 **Why:** confirms `lib/main_dev.dart` wired `Telemetry.instance = OtelTelemetry.boot(...)` and the OTLP/HTTP pipeline reaches the Collector.
@@ -65,6 +88,8 @@ Name           : app.boot
 
 ### T2 — Engage hands-free → `hf.attach_stream` span starts + `hf.chunk_received` counter ticks
 
+**Status:** passed
+
 **Do:** in the Record tab, tap to engage hands-free. Let the mic run for ~5 s.
 
 **Why:** verifies the orchestrator-level instrumentation (T5b's diagnosis core). The long-lived attach span is the parent of every subsequent diagnosis event; the chunk counter is the heartbeat that, if it ever flatlines while the gate is open, means a dead mic.
@@ -78,6 +103,8 @@ Name           : app.boot
 **If chunks have `gate_open: false`:** capture failed; check microphone permissions in Simulator's Settings.
 
 ### T3 — Toggle the gate → `hf.gate_changed` events with structured `reason`
+
+**Status:** passed
 
 **Do:** while engaged, suspend by user (mic button tap to disengage), then re-engage.
 
@@ -98,6 +125,8 @@ Name : hf.gate_changed
 
 ### T4 — Provoke a teardown → segment_emitted counter / no spurious errors
 
+**Status:** passed
+
 **Do:** speak a short utterance, wait for it to be captured (you'll hear the audio-feedback chirp / see the segment in the UI). Then disengage cleanly.
 
 **Why:** confirms the happy-path emitters and that we are **not** producing `hf.stream_error` events during normal operation (false-positives would make the dashboard useless).
@@ -114,6 +143,8 @@ Name : hf.gate_changed
 ## Stretch (~5 min, only if everything above is green)
 
 ### S3 — Re-run on the real iPhone if Xcode signing works
+
+**Status:** skipped (iOS Simulator pass sufficient; real-device session deferred)
 
 **Do:** disconnect Simulator, plug in the wireless iPhone, accept any Xcode trust dialogs, re-run S2's flutter command with `-d 00008101-00025D103606001E` (the iPhone's id). On a fresh dev cert provisioning may need an Xcode "Run" first.
 

--- a/docs/manual-tests/p040-agenda-notifications.md
+++ b/docs/manual-tests/p040-agenda-notifications.md
@@ -1,9 +1,42 @@
 # Manual test: P040 — Agenda notifications & background refresh
 
 **Proposal:** [`docs/proposals/040-agenda-notifications-and-background-refresh.md`](../proposals/040-agenda-notifications-and-background-refresh.md)
+**Overall status:** **pending** — no case yet executed on a physical device.
 **Why now:** P040 is code-complete and review-clean, but 11 contracts can only be verified on physical devices (notification delivery, OS-level scheduling, permission prompts, BGAppRefresh, WorkManager). This plan exists so the device pass can be run cold by anyone — no archaeology required.
 **Time budget:** ~90 min total (60 min iOS + 30 min Android). Steps independent: skip any case the device can't exercise (e.g. Android-only on iPhone) without losing the rest.
 **What we are testing:** the **delivery chain** — does the OS fire what the reconciler scheduled, does the tap route correctly, does the permission flow degrade gracefully. Unit tests already cover the reconciler logic (1030 cases on main); this plan only covers what unit tests can't.
+
+## Status legend
+
+Each step below has a `**Status:** ...` line. Allowed values:
+
+- **`pending`** — not yet attempted.
+- **`in-progress`** — execution started, not yet decided.
+- **`passed (YYYY-MM-DD, <device + OS>)`** — verified green.
+- **`failed (YYYY-MM-DD, <device + OS>): <one-line reason>`** — verified red. File issue.
+- **`skipped (<reason>)`** — case not applicable on the device (e.g. Android-only on iPhone).
+
+Update statuses **in-place during execution** and commit when the plan is fully run. The proposal's `Implemented (manual device verification pending)` disclaimer comes off once every must-pass case is `passed`.
+
+## Status summary
+
+| # | Case | Status |
+|---|---|---|
+| S1 | Backend & accounts | pending |
+| S2 | Install on device | pending |
+| S3 | Inspector tools | pending |
+| T1 | First-launch permission prompt fires once | pending |
+| T2 | Open Agenda tab → 4 daily summaries scheduled | pending |
+| T3 | Tap notification → app launches on `/agenda` | pending |
+| T4 | Warm tap → routes to `/agenda` | pending |
+| T5 | Routine occurrence reminder fires at `start_time` | pending |
+| T6 | Timezone correctness in non-UTC zone | pending |
+| T7 | Permission denial path | pending |
+| T8 | Permission revocation between sessions | pending |
+| T9 | Workmanager BG task registers on Android | pending |
+| T10 | iOS BGTask registration succeeds | pending |
+| T11 | Foreground >1h staleness trigger | pending |
+| T12 | Session gating end-to-end | pending |
 
 ---
 
@@ -11,11 +44,15 @@
 
 ### S1 — Backend & accounts
 
+**Status:** pending
+
 **Do:** make sure your personal-agent has at least one **routine occurrence with `start_time`** scheduled for today plus 2–3 action items for today. Use the web UI to create these if not already present. Routine occurrences without `start_time` are *expected* not to produce per-occurrence reminders — they only show up in summaries (P040 §Time Resolution).
 
 **Why:** without a today routine with `start_time`, you can't verify T5 / T11 (per-occurrence reminder firing).
 
 ### S2 — Install on device
+
+**Status:** pending
 
 **iOS:**
 ```bash
@@ -43,6 +80,8 @@ Per [[no_apple_developer_account]]: iOS testing is always personal-cert + physic
 
 ### S3 — Inspector tools
 
+**Status:** pending
+
 - **iOS:** `xcrun simctl push` is irrelevant here (we're testing local notifications). Use Xcode's "Notifications" tab in Devices window to view delivered notifications. For schedule inspection, add a temporary debug screen reading `FlutterLocalNotificationsPlugin().pendingNotificationRequests()` — OR just observe delivery times.
 - **Android:** `adb logcat | grep -E "WM-WorkSpec|FlutterLocalNotifications"` for WorkManager + plugin diagnostics. Notification shade gives delivery confirmation.
 
@@ -53,6 +92,8 @@ Per [[no_apple_developer_account]]: iOS testing is always personal-cert + physic
 The cases below are ordered "fastest first" — quick smoke checks at top, longer waits at the bottom. Mark each `[ ] PASS / FAIL / N/A` as you go.
 
 ### T1 — First-launch permission prompt fires once (both platforms, ~2 min)
+
+**Status:** pending
 
 **Do:**
 1. Delete the app if previously installed (clean state).
@@ -69,6 +110,8 @@ The cases below are ordered "fastest first" — quick smoke checks at top, longe
 
 ### T2 — Open Agenda tab → 4 daily summaries scheduled (both platforms, ~2 min)
 
+**Status:** pending
+
 **Do:**
 1. Tap the **Agenda** tab (calendar icon, leftmost).
 2. Wait for the screen to populate (status: Loaded).
@@ -83,6 +126,8 @@ The cases below are ordered "fastest first" — quick smoke checks at top, longe
 ---
 
 ### T3 — Tap notification → app launches on `/agenda` (iOS + Android, ~3 min)
+
+**Status:** pending
 
 **Do:**
 1. Force-quit the app (swipe up in app switcher).
@@ -99,6 +144,8 @@ The cases below are ordered "fastest first" — quick smoke checks at top, longe
 
 ### T4 — Warm tap → routes to `/agenda` (both platforms, ~2 min)
 
+**Status:** pending
+
 **Do:**
 1. With the app running on a non-Agenda tab (e.g. Record), trigger a notification (wait for next summary at 09/12/15/19, or use Xcode Devices to deliver a custom one).
 2. Tap the banner / notification shade entry.
@@ -112,6 +159,8 @@ The cases below are ordered "fastest first" — quick smoke checks at top, longe
 ---
 
 ### T5 — Routine occurrence reminder fires at `start_time` (iOS + Android, time-of-day-dependent)
+
+**Status:** pending
 
 **Do:**
 1. Schedule (via personal-agent web UI) a routine occurrence for today at **3 minutes from now**, with `start_time` set.
@@ -130,6 +179,8 @@ The cases below are ordered "fastest first" — quick smoke checks at top, longe
 
 ### T6 — Timezone correctness in non-UTC zone (both platforms, ~5 min)
 
+**Status:** pending
+
 **Do:**
 1. With device set to a non-UTC zone (e.g. Europe/Warsaw, currently CEST = UTC+2): verify above tests fired at the *local* wall-clock time.
 2. Optional: change device timezone to America/New_York, reopen Agenda tab to re-reconcile, observe new summaries scheduled at the NEW zone's 09/12/15/19.
@@ -143,6 +194,8 @@ The cases below are ordered "fastest first" — quick smoke checks at top, longe
 ---
 
 ### T7 — Permission denial path (both platforms, ~3 min)
+
+**Status:** pending
 
 **Do:**
 1. Delete the app. Reinstall.
@@ -163,6 +216,8 @@ The cases below are ordered "fastest first" — quick smoke checks at top, longe
 
 ### T8 — Permission revocation between sessions (iOS, ~5 min)
 
+**Status:** pending
+
 **Do:**
 1. With permission GRANTED, open Agenda tab to schedule notifications.
 2. Confirm at least one item is in `pendingNotificationRequests()`.
@@ -180,6 +235,8 @@ The cases below are ordered "fastest first" — quick smoke checks at top, longe
 
 ### T9 — Workmanager BG task registers on Android (Android only, ~3 min)
 
+**Status:** pending
+
 **Do:**
 1. Launch the app on a real Android device.
 2. From shell: `adb logcat | grep -E "WM-(WorkSpec|WorkContinuationImpl|GreedyScheduler)"`.
@@ -194,6 +251,8 @@ The cases below are ordered "fastest first" — quick smoke checks at top, longe
 
 ### T10 — iOS BGTask registration succeeds (iOS only, ~3 min)
 
+**Status:** pending
+
 **Do:**
 1. Launch the app on a real iPhone (NOT Simulator — Simulator doesn't support BGTaskScheduler).
 2. Watch `flutter logs` or Xcode console.
@@ -207,6 +266,8 @@ The cases below are ordered "fastest first" — quick smoke checks at top, longe
 ---
 
 ### T11 — Foreground >1h staleness trigger (both platforms, requires 1h+ wait, ~5 min active)
+
+**Status:** pending
 
 **Do:**
 1. Open Agenda tab (loads, sets `lastAgendaFetchAt`).
@@ -224,6 +285,8 @@ The cases below are ordered "fastest first" — quick smoke checks at top, longe
 ---
 
 ### T12 — Session gating end-to-end (iOS preferred, ~10 min)
+
+**Status:** pending
 
 **Do:**
 1. Schedule a routine occurrence for **8 minutes from now** with `start_time` set. Open Agenda tab to register the reminder.


### PR DESCRIPTION
## Summary

Three docs-only changes, one PR:

1. **P040 manual test plan** — added per-case `**Status:** pending` markers plus a status legend and a summary table at the top.

2. **P039 T5b manual test plan** — marked every setup step + test case as `passed` (the gate cleared; T2 / T4 / T5a / T6 dependent work has since landed on main). The optional real-iPhone stretch (S3) marked `skipped` with explicit reason.

3. **CLAUDE.md — new "Manual Test Plans" subsection** under Testing Strategy. Codifies the convention so future plans don't reinvent the format:
   - Location: `docs/manual-tests/p{NNN}-{short-description}.md`
   - Required structure: header → legend → summary table → setup → cases (Do / Why / Expected / On-failure) → closing "when this plan is done"
   - Per-case status vocabulary (`pending` / `in-progress` / `passed (date, device)` / `failed (date, device): reason` / `skipped (reason)`)
   - Rule: update in-place during execution; the on-disk record is source of truth for whether a contract has been verified
   - Negative guidance: when NOT to write a manual plan

References the two existing plans as templates.

## Why

`/proposal-implementation-review` flagged manual device verification as the gating gap for P040. PR #312 added the P040 plan; this PR adds the convention so subsequent proposals (and re-runs of existing plans) follow a consistent shape. Per-case status markers also turn the plans from "documents to read" into "documents to actively check off as you execute" — the difference between a runbook and a wiki page.

## Test plan

- [x] Docs only — no `make verify` impact
- [x] Markdown renders on GitHub (status tables, links, code blocks)
- [x] Both existing manual-test docs cross-reference each other (the P039 plan links to the canonical legend in P040)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
