### PR TITLE
fix(ios): suppress spurious volume events during audio-session transitions

### DIFF
--- a/docs/manual-tests/p041-volume-button-suppression.md
+++ b/docs/manual-tests/p041-volume-button-suppression.md
@@ -1,0 +1,146 @@
+# Manual test: P041 — Suppress spurious volume events during audio-session transitions
+
+**Proposal:** [`docs/proposals/041-volume-button-spurious-event-on-session-start.md`](../proposals/041-volume-button-spurious-event-on-session-start.md)
+**Overall status:** **pending** — no case yet executed on a physical device.
+**Why now:** P041 fixes a flaky disengage caused by `AVAudioSession.outputVolume` KVO firing on category changes. The fix is native Swift (`VolumeButtonBridge` / `AudioSessionBridge`) and cannot be exercised by `flutter test` — KVO, audio-session category transitions and hardware volume buttons are device-only.
+**Time budget:** ~15 min, iPhone only (the bridge is iOS-only).
+**What we are testing:** that an audio-session category/route change no longer produces a phantom volume-button event, while real volume-button presses still work.
+
+## Status legend
+
+See the canonical legend in [`p040-agenda-notifications.md`](p040-agenda-notifications.md#status-legend).
+
+## Status summary
+
+| # | Case | Status |
+|---|---|---|
+| S1 | Install on iPhone | pending |
+| T1 | Tap mic → session stays engaged | pending |
+| T2 | Real Volume Down while engaged still suspends | pending |
+| T3 | Real Volume Up while idle still engages | pending |
+| T4 | Volume Down interrupts TTS (no regression) | pending |
+
+---
+
+## Setup
+
+### S1 — Install on iPhone
+
+**Status:** pending
+
+**Do:** install on a physical iPhone (per [[no_apple_developer_account]], personal cert + real device — the bridge is iOS-only, Simulator has no hardware volume buttons).
+
+```bash
+flutter run --flavor dev --target lib/main_dev.dart \
+  --dart-define=API_URL=https://<your-personal-agent>/api/v1 \
+  --dart-define=API_TOKEN=<token> \
+  --dart-define=GROQ_API_KEY=<groq-key> \
+  -d <ios-device-id>
+```
+
+Make sure mic permission, Groq key and API URL are all configured — otherwise `startSession()` lands in an error state instead of engaging.
+
+Keep a console attached: `[VolumeBtnDbg]` lines show raw KVO and suppression decisions; `[AudioSessionDbg]` lines show category switches.
+
+---
+
+## Tests
+
+### T1 — Tap mic → session stays engaged (~4 min)
+
+**Status:** pending
+
+**Do:**
+1. Launch the app; land on the Record tab (green mic).
+2. Tap the mic button once.
+3. Watch the button colour and the status strip for the next ~3 s.
+4. Repeat the tap-and-watch cycle ~10 times, varying the device media
+   volume (low / mid / high) between attempts.
+
+**Why:** verifies the P041 core fix — the `.playAndRecord` category
+switch on `startSession()` no longer emits a phantom `"down"` that
+`_onVolumeButtonEvent` turns into `suspendByUser()`.
+
+**Expected:** every tap engages and **stays** engaged — button goes
+green → orange and the "Listening..." strip remains visible. Console
+shows `[VolumeBtnDbg] volume change suppressed (audio-session
+transition)` around each engage, and no `branch=suspend` line. The
+pre-fix flaky disengage (orange flashes, then back to green) must not
+occur in any of the ~10 attempts.
+
+**On failure:** check the console ordering — if a `[VolumeBtnDbg] volume
+down` line appears *without* a preceding suppression window, the
+`AudioSessionBridge` pre-arm did not run before the KVO fired, or the
+KVO came from a route change whose notification arrived after the KVO.
+Consider widening `suppressionWindow` in `VolumeButtonBridge.swift`.
+
+---
+
+### T2 — Real Volume Down while engaged still suspends (~3 min)
+
+**Status:** pending
+
+**Do:**
+1. Tap the mic to engage (button orange, "Listening...").
+2. Wait ~2 s so any audio-session transition has settled.
+3. Press the hardware **Volume Down** button once.
+
+**Why:** confirms the suppression window does not swallow genuine
+presses — `suspendByUser()` must still fire.
+
+**Expected:** session suspends — button returns to green, "Paused"
+toast, light haptic. Console shows `[VolumeBtnDbg] volume down` and
+`branch=suspend`.
+
+**On failure:** if nothing happens, the suppression window is too long
+or is being re-armed by an unrelated route change — inspect the
+`[VolumeBtnDbg]` timestamps.
+
+---
+
+### T3 — Real Volume Up while idle still engages (~2 min)
+
+**Status:** pending
+
+**Do:**
+1. With the session idle (green mic), press hardware **Volume Up** once.
+
+**Why:** confirms the Volume Up engage gesture (P038) is unaffected.
+
+**Expected:** session engages — "Listening" toast, button orange.
+
+**On failure:** check the press was outside any suppression window —
+an idle screen should have no recent category change, so suppression
+should not be active.
+
+---
+
+### T4 — Volume Down interrupts TTS (no regression) (~3 min)
+
+**Status:** pending
+
+**Do:**
+1. Engage, speak a short utterance, wait for the agent's TTS reply.
+2. While the agent is speaking, press **Volume Down**.
+
+**Why:** TTS playback goes through `setPlayback` / `restoreAudioSession`,
+which also pre-arm the suppression window. The Volume-Down-interrupts-TTS
+path must still fire.
+
+**Expected:** TTS stops immediately on the press. Console shows
+`[VolumeBtnDbg] branch=stopTts`.
+
+**On failure:** the `setPlayback` pre-arm window overlapped the press —
+verify the press happened well after TTS audio actually started.
+
+---
+
+## When this plan is "done"
+
+- **T1, T2, T3 must PASS** — they are the core fix plus its two
+  no-regression guarantees. Any failure blocks shipping.
+- **T4** should PASS; a failure scoped to a tight press-during-transition
+  race may be documented in the proposal §Risks rather than blocking.
+
+Once the must-pass cases are green, P041 drops the
+`manual device verification pending` disclaimer.

--- a/docs/proposals/041-volume-button-spurious-event-on-session-start.md
+++ b/docs/proposals/041-volume-button-spurious-event-on-session-start.md
@@ -1,0 +1,117 @@
+# Proposal 041 — Suppress spurious volume events during audio-session transitions
+
+## Status: Implemented (lightweight; manual device verification pending). Hotfix follow-up to P038.
+
+## Problem
+
+Tapping the mic button to start a hands-free conversation is flaky: the
+screen flips green → orange and the recording indicator appears (the
+session engages), then the session immediately disengages back to idle
+(green, no indicator). It works sometimes, fails more often.
+
+This is a device-blocking bug — the primary "start a conversation"
+gesture is unreliable.
+
+## Research notes — root cause
+
+P038 introduced `VolumeButtonBridge.swift`, which detects hardware
+volume-button presses via KVO on `AVAudioSession.outputVolume`. Volume
+Down while engaged maps to `HandsFreeController.suspendByUser()`
+(`recording_screen.dart` `_onVolumeButtonEvent`).
+
+`AVAudioSession.outputVolume` is **tracked per audio-session category
+context** — iOS reports a different value once the category switches.
+Starting a session changes the category:
+
+1. `_onTap()` → `HandsFreeController.startSession()` →
+   `BackgroundService.startService()` (`hands_free_controller.dart`).
+2. On iOS, `startService()` invokes `setPlayAndRecord`
+   (`flutter_foreground_task_service.dart`).
+3. `AudioSessionBridge` runs `setCategory(.playAndRecord)` +
+   `setActive(true)` (`AudioSessionBridge.swift`).
+4. iOS reports a new `outputVolume` for the `.playAndRecord` context.
+   The KVO observer in `VolumeButtonBridge.observeValue` fires.
+5. `_stepThreshold` (0.001) is far below a real category-switch delta
+   (~0.06+), so the change is **not** filtered. If the new value is
+   lower than the old one, the bridge emits `"down"`.
+6. `_onVolumeButtonEvent(down)` sees `hfState is HandsFreeListening`
+   and calls `suspendByUser()` → the freshly engaged session is torn
+   back down to idle.
+
+`VolumeButtonBridge` has no way to distinguish a real button press from
+an `outputVolume` change caused by an audio-session category or route
+change.
+
+### Why it is flaky
+
+- **Delta direction**: the `.playAndRecord` context volume may be lower
+  than the prior media volume (→ `"down"` → `suspendByUser` → **fails**),
+  higher (→ `"up"` → `up-noop` while listening → **works**), or equal
+  (→ no event → **works**). It depends on the device's volume state.
+- **Delivery timing**: if the spurious event arrives before the state
+  reaches `HandsFreeListening`, it hits the `down-noop (not engaged)`
+  branch — harmless. If it arrives after, it triggers `suspendByUser`.
+
+The same class of spurious event also fires on AirPods connect/disconnect
+and on the `.playback` ⇄ `.playAndRecord` transitions around TTS.
+
+## Scope
+
+- **In scope**: stop audio-session category/route changes from being
+  misread as hardware volume-button presses.
+- **Out of scope**: programmatic volume restore after a real press
+  (P038 *Known Compromises*); the `_stepThreshold` value (left as-is —
+  a real category-switch delta can equal one genuine step, so a
+  threshold alone cannot fix this).
+
+## Approach
+
+Native-only fix, in the two iOS bridges. A short suppression window
+gates volume-button detection during any audio-session transition.
+
+1. **`VolumeButtonBridge.swift`**
+   - Add a `suppressUntil` timestamp and a public `suppressVolumeEvents()`
+     method that arms a short window (`suppressionWindow = 0.6 s`).
+   - In `observeValue`, while inside the window, update the running
+     baseline (`lastVolume`) but emit **no** direction event.
+   - Observe `AVAudioSession.routeChangeNotification` and call
+     `suppressVolumeEvents()` on every route change. This catches
+     category changes made outside `AudioSessionBridge` (e.g. the
+     `record` plugin's own session setup, AirPods route changes).
+
+2. **`AudioSessionBridge.swift`**
+   - Before any category-mutating method (`setPlayAndRecord`,
+     `setPlayback`, `setPlaybackOnly`, `restoreAudioSession`,
+     `setAmbient`), call `VolumeButtonBridge.shared.suppressVolumeEvents()`.
+   - This pre-arms the window *before* the KVO fires, covering the case
+     where the `outputVolume` KVO is delivered synchronously inside
+     `setActive(true)` — earlier than the route-change notification.
+
+A Dart-side debounce was considered and rejected: the correct layer to
+distinguish a real press from a context shift is the native bridge that
+owns the KVO observer; a second guard in Dart would be redundant.
+
+## Tasks
+
+- [x] T1 — `VolumeButtonBridge`: suppression window + `suppressVolumeEvents()`
+      + route-change observer.
+- [x] T2 — `AudioSessionBridge`: pre-arm suppression before every
+      category mutation.
+- [x] T3 — Manual test plan (`docs/manual-tests/p041-volume-button-suppression.md`).
+
+## Acceptance criteria
+
+1. Tapping the green mic button engages a session that **stays** engaged
+   (orange + recording indicator) — no immediate disengage.
+2. A real Volume Down press while engaged still suspends the session.
+3. A real Volume Up press while idle still engages a session.
+4. Interrupting TTS with Volume Down still works (no regression).
+
+## Verification
+
+- `make verify` — Dart analyzer + tests (no Dart code changed; confirms
+  no regression).
+- Native Swift changes are device-only contracts — see the manual test
+  plan `docs/manual-tests/p041-volume-button-suppression.md`. The
+  proposal stays `manual device verification pending` until the
+  must-pass cases there are green.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -54,6 +54,9 @@ Index of design proposals. Status is recorded in the `## Status:` line at the to
 | 036 | [Replay Last TTS Reply](036-replay-last-tts.md) | Implemented |
 | 037 | [Hardware-Button Control of Hands-Free Listening](037-airpods-listening-control.md) | Superseded by P038 (proposal PR #272 closed) |
 | 038 | [Always-On Capture with Volume-Button Engagement](038-always-on-capture-volume-button-engagement.md) | Implemented |
+| 039 | [OTel Dev Telemetry](039-otel-dev-telemetry.md) | Implemented |
+| 040 | [Agenda Notifications & Background Refresh](040-agenda-notifications-and-background-refresh.md) | Implemented (manual device verification pending) |
+| 041 | [Suppress Spurious Volume Events During Audio-Session Transitions](041-volume-button-spurious-event-on-session-start.md) | Implemented (manual device verification pending) |
 | — | [PoC: "Come back" notification](POC-come-back-notification.md) | PoC implemented (PR #288) |
 | — | [Backlog](P000-backlog.md) | — |
 

--- a/ios/Runner/AudioSessionBridge.swift
+++ b/ios/Runner/AudioSessionBridge.swift
@@ -36,6 +36,20 @@ class AudioSessionBridge {
 
     private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let session = AVAudioSession.sharedInstance()
+        // P041 — every category mutation below shifts the value iOS
+        // reports for `outputVolume` (volume is tracked per
+        // audio-session context). Pre-arm the volume-button bridge
+        // *before* the mutation so the resulting KVO change — which can
+        // be delivered synchronously inside setActive(true), earlier
+        // than routeChangeNotification — is not misread as a hardware
+        // volume-button press. See Proposal 041.
+        switch call.method {
+        case "setPlayback", "restoreAudioSession", "setPlayAndRecord",
+             "setPlaybackOnly", "setAmbient":
+            VolumeButtonBridge.shared.suppressVolumeEvents()
+        default:
+            break
+        }
         switch call.method {
         case "setPlayback":
             // P034 follow-up: during TTS playback, switch to .playback (no

--- a/ios/Runner/VolumeButtonBridge.swift
+++ b/ios/Runner/VolumeButtonBridge.swift
@@ -37,6 +37,14 @@ class VolumeButtonBridge: NSObject, FlutterStreamHandler {
     // increments). Anything smaller is noise / programmatic restore.
     private let _stepThreshold: Float = 0.001
 
+    // P041 — suppression window. `outputVolume` is tracked per
+    // audio-session category context, so a category/route change makes
+    // iOS report a different value with no button press involved. While
+    // `Date() < suppressUntil` the KVO observer re-baselines silently
+    // instead of emitting a phantom press.
+    private var suppressUntil = Date.distantPast
+    private let suppressionWindow: TimeInterval = 0.6
+
     private override init() {
         super.init()
     }
@@ -73,6 +81,32 @@ class VolumeButtonBridge: NSObject, FlutterStreamHandler {
         }
     }
 
+    // MARK: - Suppression (P041)
+
+    /// Suppresses volume-button detection for [suppressionWindow] seconds.
+    ///
+    /// Called by the app itself (`AudioSessionBridge`) before every
+    /// audio-session category change, and by the route-change observer
+    /// below. Both events shift the value iOS reports for `outputVolume`
+    /// without any hardware button press — this window stops that shift
+    /// from being emitted as a phantom `"up"` / `"down"`.
+    ///
+    /// Safe to call when not observing — it only moves a timestamp.
+    func suppressVolumeEvents() {
+        suppressUntil = Date().addingTimeInterval(suppressionWindow)
+        NSLog("[VolumeBtnDbg] suppressing volume events for \(suppressionWindow)s (audio-session transition)")
+    }
+
+    @objc private func handleAudioRouteChange(_ notification: Notification) {
+        // A route or category change (mic acquisition, AirPods connect,
+        // our own .playAndRecord switch) shifts `outputVolume` because
+        // volume is tracked per audio-session context. Suppress briefly
+        // so the shift is not misread as a press. Covers category
+        // changes made outside AudioSessionBridge (e.g. the `record`
+        // plugin's own session setup).
+        suppressVolumeEvents()
+    }
+
     // MARK: - KVO on AVAudioSession.outputVolume
 
     private func startObserving() {
@@ -85,6 +119,11 @@ class VolumeButtonBridge: NSObject, FlutterStreamHandler {
                             forKeyPath: "outputVolume",
                             options: [.new, .old],
                             context: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAudioRouteChange(_:)),
+            name: AVAudioSession.routeChangeNotification,
+            object: nil)
         observing = true
         NSLog("[VolumeBtnDbg] startObserving — initial volume=\(lastVolume)")
     }
@@ -93,6 +132,10 @@ class VolumeButtonBridge: NSObject, FlutterStreamHandler {
         guard observing else { return }
         AVAudioSession.sharedInstance().removeObserver(self,
                                                       forKeyPath: "outputVolume")
+        NotificationCenter.default.removeObserver(
+            self,
+            name: AVAudioSession.routeChangeNotification,
+            object: nil)
         observing = false
         NSLog("[VolumeBtnDbg] stopObserving")
     }
@@ -113,6 +156,14 @@ class VolumeButtonBridge: NSObject, FlutterStreamHandler {
         lastVolume = new
         if prev < 0 {
             // First observation since startObserving — no direction yet.
+            return
+        }
+        // P041 — inside a suppression window the change comes from an
+        // audio-session category/route transition, not a button press.
+        // `lastVolume` was already updated above, so the post-transition
+        // value becomes the new baseline; emit nothing.
+        if Date() < suppressUntil {
+            NSLog("[VolumeBtnDbg] volume change suppressed (audio-session transition): \(prev) → \(new)")
             return
         }
         let delta = new - prev


### PR DESCRIPTION
## Problem

Tapping the mic to start a hands-free conversation is flaky: the session engages (green → orange + recording indicator) then immediately disengages back to idle. Works sometimes, fails more often.

## Root cause

`AVAudioSession.outputVolume` is tracked **per audio-session category context**. `startSession()` switches the category to `.playAndRecord` (`AudioSessionBridge.setPlayAndRecord`), which makes iOS report a new `outputVolume` with **no button press involved**.

`VolumeButtonBridge`'s KVO observer read that shift as a hardware `"down"` press → `_onVolumeButtonEvent(down)` → `suspendByUser()` on the freshly engaged session.

Flaky because both the delta direction (lower vs. higher context volume) and the KVO delivery timing (before vs. after the state reaches `HandsFreeListening`) vary.

## Fix (native, iOS only)

- **`VolumeButtonBridge.swift`** — short suppression window (`suppressionWindow = 0.6s`). While armed, the KVO observer re-baselines `lastVolume` but emits no direction event. Also observes `AVAudioSession.routeChangeNotification` and arms the window on every route change (covers category changes made outside `AudioSessionBridge`, e.g. the `record` plugin's own setup, AirPods route changes).
- **`AudioSessionBridge.swift`** — pre-arms the suppression window before every category mutation (`setPlayAndRecord` / `setPlayback` / `setPlaybackOnly` / `restoreAudioSession` / `setAmbient`), covering KVO changes delivered synchronously inside `setActive(true)`.

A Dart-side debounce was considered and rejected as redundant — the correct layer is the native bridge that owns the KVO observer.

## Verification

- `make verify` — green, 1053 tests. **No Dart changes**, so no Flutter-side regression risk.
- Native Swift changes are device-only — see `docs/manual-tests/p041-volume-button-suppression.md` (must-pass: T1–T3).

## Trace

Lightweight proposal: `docs/proposals/041-volume-button-spurious-event-on-session-start.md` (follow-up to P038). README index updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
