### PR TITLE
fix(ios): defer volume events so route changes can cancel phantom presses

### DIFF
--- a/docs/manual-tests/p041-volume-button-suppression.md
+++ b/docs/manual-tests/p041-volume-button-suppression.md
@@ -19,6 +19,7 @@ See the canonical legend in [`p040-agenda-notifications.md`](p040-agenda-notific
 | T2 | Real Volume Down while engaged still suspends | pending |
 | T3 | Real Volume Up while idle still engages | pending |
 | T4 | Volume Down interrupts TTS (no regression) | pending |
+| T5 | Headphone connect/disconnect does not disengage | pending |
 
 ---
 
@@ -135,9 +136,37 @@ verify the press happened well after TTS audio actually started.
 
 ---
 
+### T5 — Headphone connect/disconnect does not disengage (~4 min)
+
+**Status:** pending
+
+**Do:**
+1. Tap the mic to engage (button orange, "Listening...").
+2. Connect wired or Bluetooth headphones (or AirPods). Watch the button.
+3. With headphones connected, disconnect them. Watch the button.
+4. Repeat steps 2–3 a few times, varying the device media volume.
+
+**Why:** verifies the P041 §Follow-up fix — a headphone route change
+shifts `outputVolume`, and the `outputVolume` KVO can be delivered
+*before* the `routeChangeNotification`. Deferred emission must let the
+route change cancel the phantom press.
+
+**Expected:** the session **stays** engaged across every connect and
+disconnect — button stays orange, "Listening..." strip remains. Console
+shows `[VolumeBtnDbg] cancelled pending volume ... (route change)` (or
+`volume change suppressed`), and **no** `branch=suspend`.
+
+**On failure:** if `branch=suspend` still fires, inspect the
+`[VolumeBtnDbg]` timestamps — if the deferred `emitting deferred
+volume` line fires *before* `cancelled pending volume`, the route-change
+notification arrived later than `emitDelay` (0.25 s) after the KVO;
+widen `emitDelay` in `VolumeButtonBridge.swift`.
+
+---
+
 ## When this plan is "done"
 
-- **T1, T2, T3 must PASS** — they are the core fix plus its two
+- **T1, T2, T3, T5 must PASS** — the core fixes plus the two
   no-regression guarantees. Any failure blocks shipping.
 - **T4** should PASS; a failure scoped to a tight press-during-transition
   race may be documented in the proposal §Risks rather than blocking.

--- a/docs/proposals/041-volume-button-spurious-event-on-session-start.md
+++ b/docs/proposals/041-volume-button-spurious-event-on-session-start.md
@@ -1,6 +1,6 @@
 # Proposal 041 — Suppress spurious volume events during audio-session transitions
 
-## Status: Implemented (lightweight; manual device verification pending). Hotfix follow-up to P038.
+## Status: Implemented (lightweight; manual device verification pending). Hotfix follow-up to P038. Amended with a route-change timing-hole fix — see §Follow-up.
 
 ## Problem
 
@@ -115,3 +115,42 @@ owns the KVO observer; a second guard in Dart would be redundant.
   plan `docs/manual-tests/p041-volume-button-suppression.md`. The
   proposal stays `manual device verification pending` until the
   must-pass cases there are green.
+
+## Follow-up — route-change timing hole (headphone connect/disconnect)
+
+On-device testing of the original fix found that recording still
+disengages when **headphones connect or disconnect**. Same root cause
+(a route change shifts `outputVolume`), but the first fix did not fully
+close it:
+
+- The `AudioSessionBridge` pre-arm covers only **app-initiated**
+  category changes. A physical headphone plug/unplug has no pre-arm.
+- The `routeChangeNotification` observer only suppresses **forward**.
+  The `outputVolume` KVO can be delivered **before** the matching
+  `routeChangeNotification`, so the phantom event is emitted before the
+  suppression window is armed.
+
+### Fix — deferred emission
+
+A genuine hardware volume press **never** coincides with a route
+change; a context-induced volume shift **always** does. So
+`VolumeButtonBridge` no longer emits a direction immediately:
+
+- Each candidate press is held for `emitDelay` (0.25 s) on a
+  one-shot `Timer` (`.common` run-loop mode, so it fires while
+  backgrounded).
+- `handleAudioRouteChange` cancels any pending emission — if a route
+  change lands within the window, the KVO that scheduled the emission
+  was that route change, not a button.
+- This closes both orderings: KVO-before-notification (pending emission
+  cancelled) and notification-before-KVO (existing forward suppression).
+
+Trade-off: a real press is delayed by 0.25 s (imperceptible for an
+engage/suspend gesture), and a real press in the rare 0.25 s coincident
+with a route change is dropped — acceptable, since a lost press is far
+better than a phantom one tearing down the session.
+
+### Tasks (follow-up)
+
+- [x] T4 — `VolumeButtonBridge`: deferred emission + cancel-on-route-change.
+- [x] T5 — Manual test plan: headphone connect/disconnect case.

--- a/ios/Runner/VolumeButtonBridge.swift
+++ b/ios/Runner/VolumeButtonBridge.swift
@@ -45,6 +45,18 @@ class VolumeButtonBridge: NSObject, FlutterStreamHandler {
     private var suppressUntil = Date.distantPast
     private let suppressionWindow: TimeInterval = 0.6
 
+    // P041 follow-up — deferred emission. A genuine hardware press never
+    // coincides with a route change; a context-induced volume shift
+    // always does. But the `outputVolume` KVO can arrive *before* the
+    // matching routeChangeNotification (observed on headphone
+    // connect/disconnect), so forward-only suppression misses it. Every
+    // candidate press is therefore held for `emitDelay`; if a route
+    // change lands during that window the pending emission is cancelled
+    // — it was a route shift, not a button.
+    private var pendingEmitTimer: Timer?
+    private var pendingDirection: String?
+    private let emitDelay: TimeInterval = 0.25
+
     private override init() {
         super.init()
     }
@@ -98,13 +110,52 @@ class VolumeButtonBridge: NSObject, FlutterStreamHandler {
     }
 
     @objc private func handleAudioRouteChange(_ notification: Notification) {
-        // A route or category change (mic acquisition, AirPods connect,
-        // our own .playAndRecord switch) shifts `outputVolume` because
-        // volume is tracked per audio-session context. Suppress briefly
-        // so the shift is not misread as a press. Covers category
-        // changes made outside AudioSessionBridge (e.g. the `record`
-        // plugin's own session setup).
+        // A route or category change (headphone connect/disconnect, mic
+        // acquisition, AirPods, our own .playAndRecord switch) shifts
+        // `outputVolume` because volume is tracked per audio-session
+        // context. Two-sided defence:
+        //  • cancel any press scheduled in the last `emitDelay`s — the
+        //    KVO that scheduled it was this route change, delivered just
+        //    before this notification;
+        //  • suppress forward for `suppressionWindow`s for KVO changes
+        //    delivered just after.
+        cancelPendingEmit()
         suppressVolumeEvents()
+    }
+
+    /// Holds a candidate press for `emitDelay` before forwarding it to
+    /// Dart, so a routeChangeNotification arriving in that window can
+    /// cancel it. Latest direction wins if presses arrive in a burst.
+    private func scheduleDeferredEmit(_ direction: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.pendingDirection = direction
+            self.pendingEmitTimer?.invalidate()
+            // .common run-loop mode so the timer still fires while the
+            // app is backgrounded with an active audio session
+            // (lock-screen engagement, P038).
+            let timer = Timer(timeInterval: self.emitDelay, repeats: false) { [weak self] _ in
+                guard let self = self, let dir = self.pendingDirection else { return }
+                self.pendingDirection = nil
+                self.pendingEmitTimer = nil
+                NSLog("[VolumeBtnDbg] emitting deferred volume \(dir)")
+                self.eventSink?(dir)
+            }
+            RunLoop.main.add(timer, forMode: .common)
+            self.pendingEmitTimer = timer
+        }
+    }
+
+    private func cancelPendingEmit() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            if let pending = self.pendingDirection {
+                NSLog("[VolumeBtnDbg] cancelled pending volume \(pending) (route change)")
+            }
+            self.pendingEmitTimer?.invalidate()
+            self.pendingEmitTimer = nil
+            self.pendingDirection = nil
+        }
     }
 
     // MARK: - KVO on AVAudioSession.outputVolume
@@ -136,6 +187,7 @@ class VolumeButtonBridge: NSObject, FlutterStreamHandler {
             self,
             name: AVAudioSession.routeChangeNotification,
             object: nil)
+        cancelPendingEmit()
         observing = false
         NSLog("[VolumeBtnDbg] stopObserving")
     }
@@ -171,8 +223,8 @@ class VolumeButtonBridge: NSObject, FlutterStreamHandler {
             return
         }
         let direction = delta > 0 ? "up" : "down"
-        NSLog("[VolumeBtnDbg] volume \(direction): \(prev) → \(new)")
-        eventSink?(direction)
+        NSLog("[VolumeBtnDbg] volume \(direction): \(prev) → \(new) — deferring \(emitDelay)s")
+        scheduleDeferredEmit(direction)
     }
 
     // MARK: - FlutterStreamHandler


### PR DESCRIPTION
## Problem

After P041 (#320), recording still disengages when **headphones connect or disconnect** while a hands-free session is active.

## Root cause

Same family as P041 — a route change shifts `AVAudioSession.outputVolume`, which `VolumeButtonBridge`'s KVO observer reads as a hardware press. P041 had a timing hole:

- The `AudioSessionBridge` pre-arm covers only **app-initiated** category changes. A physical headphone plug/unplug has no pre-arm.
- The `routeChangeNotification` observer suppresses only **forward**. The `outputVolume` KVO can be delivered **before** the matching `routeChangeNotification`, so the phantom event fires before the suppression window is armed.

## Fix — deferred emission

A genuine hardware volume press **never** coincides with a route change; a context-induced volume shift **always** does. `VolumeButtonBridge` no longer emits a direction immediately:

- Each candidate press is held for `emitDelay` (0.25s) on a one-shot `Timer` (`.common` run-loop mode — fires while backgrounded).
- `handleAudioRouteChange` cancels any pending emission — a route change within the window means that KVO was the route change, not a button.
- Closes both orderings: KVO-before-notification (pending emission cancelled) and notification-before-KVO (existing forward suppression).

**Trade-off:** a real press is delayed 0.25s (imperceptible for an engage/suspend gesture); a real press in the rare window coincident with a route change is dropped — acceptable, a lost press beats a phantom one tearing down the session.

## Verification

- `make verify` — green, 1053 tests. **No Dart changes.**
- Device-only — manual test plan gains a headphone connect/disconnect case (T5): `docs/manual-tests/p041-volume-button-suppression.md`.

## Trace

Amends Proposal 041 (§Follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
