### PR TITLE
chore: fix install-ios / install-ios-dev (build + install, not flutter run)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,16 +123,20 @@ install-ios:
 	@DEVICE_ID=$$($(IOS_DEVICE_ID)); \
 	if [ -z "$$DEVICE_ID" ]; then $(IOS_NOT_FOUND); fi; \
 	DEVICE_NAME=$$($(IOS_DEVICE_NAME)); \
-	echo "Installing stable (release) on: $$DEVICE_NAME ($$DEVICE_ID)"; \
-	flutter run -d "$$DEVICE_ID" --flavor stable --release $(DART_DEFINE_FLAG)
+	echo "Building stable (release)..."; \
+	flutter build ios --flavor stable --release $(DART_DEFINE_FLAG) && \
+	echo "Installing on: $$DEVICE_NAME ($$DEVICE_ID)" && \
+	flutter install -d "$$DEVICE_ID" --flavor stable --release
 
 ## install-ios-dev: Build and install dev (release) on a physical iOS device
 install-ios-dev:
 	@DEVICE_ID=$$($(IOS_DEVICE_ID)); \
 	if [ -z "$$DEVICE_ID" ]; then $(IOS_NOT_FOUND); fi; \
 	DEVICE_NAME=$$($(IOS_DEVICE_NAME)); \
-	echo "Installing dev (release) on: $$DEVICE_NAME ($$DEVICE_ID)"; \
-	flutter run -d "$$DEVICE_ID" --flavor dev --release $(DART_DEFINE_FLAG)
+	echo "Building dev (release)..."; \
+	flutter build ios --flavor dev --release $(DART_DEFINE_FLAG) && \
+	echo "Installing on: $$DEVICE_NAME ($$DEVICE_ID)" && \
+	flutter install -d "$$DEVICE_ID" --flavor dev --release
 
 ## install-ios-dev-debug: Build and install dev (debug, hot reload) on a physical iOS device
 install-ios-dev-debug:


### PR DESCRIPTION
`install-ios` and `install-ios-dev` used `flutter run --release`, which attaches to the app and waits — the attach times out (notably over wireless: "Timed out waiting for CONFIGURATION_BUILD_DIR"), so the install never completes.

Both now use `flutter build ios` + `flutter install` — install the release app and exit. A release build opens standalone from the home screen, no tooling attach needed.

`install-ios-dev-debug` keeps `flutter run` (a debug build needs the tooling connection to run).

Verified by equivalence — the build+install pair was run manually against the device this session (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)