### PR TITLE
feat(043/t1): envelope-tolerant agent-reply reader

### DIFF
--- a/lib/features/api_sync/sync_worker.dart
+++ b/lib/features/api_sync/sync_worker.dart
@@ -301,7 +301,12 @@ class SyncWorker {
   Future<void> _handleReply(String? body) async {
     if (body == null) return;
     try {
-      final json = jsonDecode(body) as Map<String, dynamic>;
+      final decoded = jsonDecode(body) as Map<String, dynamic>;
+      // 043: P088 wraps the transcript reply in {"data": {...}} — unwrap it
+      // when present. The flat-shape fallback is permanent (keeps every
+      // client/server version pairing working).
+      final data = decoded['data'];
+      final json = data is Map<String, dynamic> ? data : decoded;
       final message = json['message'] as String?;
       if (message == null || message.isEmpty) return;
       final language = json['language'] as String?;

--- a/test/features/api_sync/sync_worker_test.dart
+++ b/test/features/api_sync/sync_worker_test.dart
@@ -1189,6 +1189,112 @@ void main() {
     });
   });
 
+  group('envelope-tolerant reply reader (043)', () {
+    test('flat shape (today\'s server) → speaks, adopts conversation_id, '
+        'dispatches session control', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody =
+          '{"message":"Hi","language":"en","conversation_id":"conv-1",'
+          '"session_control":{"stop_recording":true}}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(tts.log, ['stop', 'speak:Hi:en']);
+      expect(sessionIdCoordinator.currentConversationId, 'conv-1');
+      expect(dispatcher.dispatched, hasLength(1));
+      expect(dispatcher.dispatched.first.stopRecording, isTrue);
+    });
+
+    test('enveloped shape {"data":{...}} → same three behaviors, '
+        'identical values', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody =
+          '{"data":{"message":"Hi","language":"en","conversation_id":"conv-1",'
+          '"session_control":{"stop_recording":true}}}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(tts.log, ['stop', 'speak:Hi:en']);
+      expect(sessionIdCoordinator.currentConversationId, 'conv-1');
+      expect(dispatcher.dispatched, hasLength(1));
+      expect(dispatcher.dispatched.first.stopRecording, isTrue);
+    });
+
+    test('session_control inside data is dispatched', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody =
+          '{"data":{"message":"Bye","language":"en",'
+          '"session_control":{"reset_session":true,"stop_recording":true}}}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(dispatcher.dispatched, hasLength(1));
+      expect(dispatcher.dispatched.first.resetSession, isTrue);
+      expect(dispatcher.dispatched.first.stopRecording, isTrue);
+    });
+
+    test('{"data": null} with no sibling message → silent', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody = '{"data": null}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(tts.log, isEmpty);
+      expect(dispatcher.dispatched, isEmpty);
+    });
+
+    test('{"data": "str"} with no sibling message → silent', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody = '{"data": "str"}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(tts.log, isEmpty);
+      expect(dispatcher.dispatched, isEmpty);
+    });
+
+    test('precedence: data map wins over sibling message → speaks "inner"',
+        () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody = '{"data":{"message":"inner"},"message":"outer"}';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(tts.log, ['stop', 'speak:inner:null']);
+    });
+
+    test('malformed/non-JSON body → silent', () async {
+      await storage.saveTranscript(transcript);
+      await storage.enqueue('tx-1');
+      apiClient.nextBody = '{"data": broken';
+
+      worker.start();
+      await Future.delayed(const Duration(milliseconds: 200));
+      worker.stop();
+
+      expect(tts.log, isEmpty);
+      expect(dispatcher.dispatched, isEmpty);
+    });
+  });
+
   group('P036 replay-last (LocalCommandMatcher + TtsReplyBuffer)', () {
     Future<void> seedReplyAndDrain() async {
       // Seed: a normal agent reply that primes the buffer.


### PR DESCRIPTION
_handleReply unwraps {"data": {...}} when present (P088 server);
permanent flat-shape fallback keeps every client/server pairing
working. Seven-test group pins flat, enveloped, session-control-in-
data, data:null, non-map data, precedence, and malformed bodies.

Proposal: docs/proposals/043-envelope-tolerant-reply-reader.md
Deploy gate: this build must be on-device before personal-agent P088
deploys (journal-agent action item via P088 T4).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
