### PR TITLE
feat(pins): browse saved references from the Chat screen (P045)

### DIFF
--- a/docs/proposals/045-pins-screen.md
+++ b/docs/proposals/045-pins-screen.md
@@ -1,6 +1,6 @@
 # Proposal 045 — Pins (Saved References) Screen
 
-## Status: Draft
+## Status: Implemented
 
 ## Prerequisites
 - P024 (Chat Screen) — provides the `/chat` branch and the pattern for fetching backend data via SSE/HTTP; the Pins screen hangs off Chat as a child route

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -58,7 +58,7 @@ Index of design proposals. Status is recorded in the `## Status:` line at the to
 | 040 | [Agenda Notifications & Background Refresh](040-agenda-notifications-and-background-refresh.md) | Implemented (manual device verification pending) |
 | 041 | [Suppress Spurious Volume Events During Audio-Session Transitions](041-volume-button-spurious-event-on-session-start.md) | Reverted — fixed a non-bug (see P042 §Relationship to P041) |
 | 042 | [Recover Hands-Free Capture Across Audio Route Changes](042-recover-hands-free-capture-across-route-changes.md) | Implemented (device-verified 2026-05-22; T3 wired outstanding) |
-| 045 | [Pins (Saved References) Screen](045-pins-screen.md) | Draft |
+| 045 | [Pins (Saved References) Screen](045-pins-screen.md) | Implemented |
 | — | [PoC: "Come back" notification](POC-come-back-notification.md) | PoC implemented (PR #288) |
 | — | [Backlog](P000-backlog.md) | — |
 

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -3,6 +3,8 @@ import 'package:voice_agent/app/app_shell_scaffold.dart';
 import 'package:voice_agent/features/agenda/presentation/agenda_screen.dart';
 import 'package:voice_agent/features/chat/presentation/conversations_screen.dart';
 import 'package:voice_agent/features/chat/presentation/thread_screen.dart';
+import 'package:voice_agent/features/pins/presentation/pin_detail_screen.dart';
+import 'package:voice_agent/features/pins/presentation/pins_screen.dart';
 import 'package:voice_agent/features/plan/presentation/plan_screen.dart';
 import 'package:voice_agent/features/routines/presentation/routine_detail_screen.dart';
 import 'package:voice_agent/features/routines/presentation/routines_screen.dart';
@@ -89,6 +91,21 @@ GoRouter createRouter() => GoRouter(
               path: '/chat',
               builder: (_, _) => const ConversationsScreen(),
               routes: [
+                // Static 'pins' MUST precede the dynamic ':id' route so
+                // '/chat/pins' is not captured as a conversation id (P045).
+                GoRoute(
+                  path: 'pins',
+                  builder: (_, _) => const PinsScreen(),
+                  routes: [
+                    GoRoute(
+                      path: ':id',
+                      builder: (_, state) {
+                        final id = state.pathParameters['id']!;
+                        return PinDetailScreen(recordId: id);
+                      },
+                    ),
+                  ],
+                ),
                 GoRoute(
                   path: ':id',
                   builder: (_, state) {

--- a/lib/core/models/pin.dart
+++ b/lib/core/models/pin.dart
@@ -1,0 +1,68 @@
+// Read-only DTOs for the personal-agent pins API (proposal 045).
+//
+// Two DTOs share this file — matching `agenda.dart`'s several-related-classes
+// layout — because they are a single read contract: the lean list row
+// (`PinSummary`) and the full reference (`PinDetail`). Pins are created only by
+// voice in chat; the client never writes them, so there is no `toMap`.
+
+class PinSummary {
+  const PinSummary({
+    required this.recordId,
+    required this.pinName,
+    this.topicLabel,
+    required this.createdAt,
+  });
+
+  final String recordId;
+  final String pinName;
+  final String? topicLabel;
+  final DateTime createdAt;
+
+  factory PinSummary.fromMap(Map<String, dynamic> map) {
+    return PinSummary(
+      recordId: map['record_id'] as String,
+      pinName: map['pin_name'] as String,
+      topicLabel: map['topic_label'] as String?,
+      createdAt: DateTime.parse(map['created_at'] as String),
+    );
+  }
+}
+
+class PinDetail {
+  const PinDetail({
+    required this.recordId,
+    required this.pinName,
+    this.topicLabel,
+    required this.text,
+    this.aliases = const [],
+    this.sourceEventIds = const [],
+    required this.createdAt,
+  });
+
+  final String recordId;
+  final String pinName;
+  final String? topicLabel;
+
+  /// Verbatim markdown body of the saved reference.
+  final String text;
+  final List<String> aliases;
+  final List<String> sourceEventIds;
+  final DateTime createdAt;
+
+  factory PinDetail.fromMap(Map<String, dynamic> map) {
+    return PinDetail(
+      recordId: map['record_id'] as String,
+      pinName: map['pin_name'] as String,
+      topicLabel: map['topic_label'] as String?,
+      text: map['text'] as String,
+      aliases: _stringList(map['aliases']),
+      sourceEventIds: _stringList(map['source_event_ids']),
+      createdAt: DateTime.parse(map['created_at'] as String),
+    );
+  }
+}
+
+List<String> _stringList(dynamic value) {
+  if (value == null) return const [];
+  return (value as List<dynamic>).map((e) => e as String).toList();
+}

--- a/lib/features/chat/presentation/conversations_screen.dart
+++ b/lib/features/chat/presentation/conversations_screen.dart
@@ -27,6 +27,12 @@ class ConversationsScreen extends ConsumerWidget {
             },
           ),
           IconButton(
+            key: const Key('conversations-pins-icon'),
+            icon: const Icon(Icons.push_pin_outlined),
+            tooltip: 'Pins',
+            onPressed: () => context.push('/chat/pins'),
+          ),
+          IconButton(
             key: const Key('conversations-settings-icon'),
             icon: const Icon(Icons.settings),
             onPressed: () => context.push('/settings'),

--- a/lib/features/pins/data/api_pins_repository.dart
+++ b/lib/features/pins/data/api_pins_repository.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+
+import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+
+/// `ApiClient`-backed pins repository.
+///
+/// Unwraps the `{"data": ...}` envelope in feature code (P025 convention,
+/// matching `api_agenda_repository.dart` / `api_plan_repository.dart`);
+/// ADR-NET-001 governs only the dio -> [ApiResult] error classification reused
+/// here, not the envelope.
+class ApiPinsRepository implements PinsRepository {
+  ApiPinsRepository(this._apiClient);
+
+  final ApiClient _apiClient;
+
+  @override
+  Future<List<PinSummary>> fetchPins(PinView view) async {
+    final result = await _apiClient.get(
+      '/pins',
+      queryParameters: {'view': view.queryValue},
+    );
+    return switch (result) {
+      ApiSuccess(body: final body) => _parseList(body),
+      ApiPermanentFailure(message: final msg, statusCode: final code) =>
+        throw PinsGeneralException('Server error $code: $msg'),
+      ApiTransientFailure(reason: final reason) =>
+        throw PinsGeneralException(reason),
+      ApiNotConfigured() => throw PinsGeneralException('API not configured'),
+    };
+  }
+
+  @override
+  Future<PinDetail> fetchPin(String recordId) async {
+    final result = await _apiClient.get('/pins/$recordId');
+    switch (result) {
+      case ApiSuccess(body: final body):
+        return _parseDetail(body);
+      case ApiPermanentFailure(statusCode: 404):
+        throw PinNotFoundException();
+      case ApiPermanentFailure(message: final msg, statusCode: final code):
+        throw PinsGeneralException('Server error $code: $msg');
+      case ApiTransientFailure(reason: final reason):
+        throw PinsGeneralException(reason);
+      case ApiNotConfigured():
+        throw PinsGeneralException('API not configured');
+    }
+  }
+
+  @override
+  Future<void> unpin(String recordId) async {
+    final result = await _apiClient.delete('/pins/$recordId');
+    switch (result) {
+      case ApiSuccess():
+        return;
+      case ApiPermanentFailure(statusCode: 404):
+        throw PinNotFoundException();
+      case ApiPermanentFailure(message: final msg, statusCode: final code):
+        throw PinsGeneralException('Server error $code: $msg');
+      case ApiTransientFailure(reason: final reason):
+        throw PinsGeneralException(reason);
+      case ApiNotConfigured():
+        throw PinsGeneralException('API not configured');
+    }
+  }
+
+  List<PinSummary> _parseList(String? body) {
+    if (body == null) throw PinsGeneralException('Empty response');
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final data = json['data'];
+    if (data == null) throw PinsGeneralException('Missing data envelope');
+    return (data as List<dynamic>)
+        .map((e) => PinSummary.fromMap(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  PinDetail _parseDetail(String? body) {
+    if (body == null) throw PinsGeneralException('Empty response');
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final data = json['data'] as Map<String, dynamic>?;
+    if (data == null) throw PinsGeneralException('Missing data envelope');
+    return PinDetail.fromMap(data);
+  }
+}

--- a/lib/features/pins/data/api_pins_repository.dart
+++ b/lib/features/pins/data/api_pins_repository.dart
@@ -69,8 +69,8 @@ class ApiPinsRepository implements PinsRepository {
     if (body == null) throw PinsGeneralException('Empty response');
     final json = jsonDecode(body) as Map<String, dynamic>;
     final data = json['data'];
-    if (data == null) throw PinsGeneralException('Missing data envelope');
-    return (data as List<dynamic>)
+    if (data is! List) throw PinsGeneralException('Missing data envelope');
+    return data
         .map((e) => PinSummary.fromMap(e as Map<String, dynamic>))
         .toList();
   }
@@ -78,8 +78,10 @@ class ApiPinsRepository implements PinsRepository {
   PinDetail _parseDetail(String? body) {
     if (body == null) throw PinsGeneralException('Empty response');
     final json = jsonDecode(body) as Map<String, dynamic>;
-    final data = json['data'] as Map<String, dynamic>?;
-    if (data == null) throw PinsGeneralException('Missing data envelope');
+    final data = json['data'];
+    if (data is! Map<String, dynamic>) {
+      throw PinsGeneralException('Missing data envelope');
+    }
     return PinDetail.fromMap(data);
   }
 }

--- a/lib/features/pins/domain/pins_repository.dart
+++ b/lib/features/pins/domain/pins_repository.dart
@@ -1,0 +1,36 @@
+import 'package:voice_agent/core/models/pin.dart';
+
+/// List ordering for `GET /api/v1/pins?view=...`.
+enum PinView {
+  recent,
+  topic;
+
+  /// The `?view=` query value (`recent` | `topic`).
+  String get queryValue => name;
+}
+
+sealed class PinsException implements Exception {
+  String get message;
+
+  @override
+  String toString() => message;
+}
+
+class PinsGeneralException extends PinsException {
+  PinsGeneralException(this.message);
+  @override
+  final String message;
+}
+
+/// Pin does not exist or is already unpinned (backend 404).
+class PinNotFoundException extends PinsException {
+  PinNotFoundException([this.message = 'Pin not found']);
+  @override
+  final String message;
+}
+
+abstract class PinsRepository {
+  Future<List<PinSummary>> fetchPins(PinView view);
+  Future<PinDetail> fetchPin(String recordId);
+  Future<void> unpin(String recordId);
+}

--- a/lib/features/pins/domain/pins_state.dart
+++ b/lib/features/pins/domain/pins_state.dart
@@ -1,0 +1,43 @@
+import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+
+sealed class PinsListState {
+  const PinsListState();
+}
+
+class PinsListInitial extends PinsListState {
+  const PinsListInitial();
+}
+
+class PinsListLoading extends PinsListState {
+  const PinsListLoading();
+}
+
+class PinsListLoaded extends PinsListState {
+  const PinsListLoaded({required this.pins, required this.view});
+  final List<PinSummary> pins;
+  final PinView view;
+}
+
+class PinsListError extends PinsListState {
+  const PinsListError({required this.message});
+  final String message;
+}
+
+sealed class PinDetailState {
+  const PinDetailState();
+}
+
+class PinDetailLoading extends PinDetailState {
+  const PinDetailLoading();
+}
+
+class PinDetailLoaded extends PinDetailState {
+  const PinDetailLoaded({required this.pin});
+  final PinDetail pin;
+}
+
+class PinDetailError extends PinDetailState {
+  const PinDetailError({required this.message});
+  final String message;
+}

--- a/lib/features/pins/presentation/pin_detail_notifier.dart
+++ b/lib/features/pins/presentation/pin_detail_notifier.dart
@@ -33,8 +33,8 @@ class PinDetailNotifier extends StateNotifier<PinDetailState> {
     try {
       await _repository.unpin(_recordId);
       return true;
-    } on PinsException catch (e) {
-      lastActionError = e.message;
+    } catch (e) {
+      lastActionError = e is PinsException ? e.message : e.toString();
       return false;
     }
   }

--- a/lib/features/pins/presentation/pin_detail_notifier.dart
+++ b/lib/features/pins/presentation/pin_detail_notifier.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+import 'package:voice_agent/features/pins/domain/pins_state.dart';
+
+class PinDetailNotifier extends StateNotifier<PinDetailState> {
+  PinDetailNotifier(this._repository, this._recordId)
+      : super(const PinDetailLoading()) {
+    load();
+  }
+
+  final PinsRepository _repository;
+  final String _recordId;
+  String? lastActionError;
+
+  Future<void> load() async {
+    state = const PinDetailLoading();
+    lastActionError = null;
+    try {
+      final pin = await _repository.fetchPin(_recordId);
+      state = PinDetailLoaded(pin: pin);
+    } catch (e) {
+      state = PinDetailError(message: e.toString());
+    }
+  }
+
+  Future<void> refresh() => load();
+
+  /// Unpin this reference. Returns true on success; on failure records
+  /// [lastActionError] and returns false. The list refreshes on return per
+  /// ADR-ARCH-011, so this notifier does not mutate list state.
+  Future<bool> unpin() async {
+    lastActionError = null;
+    try {
+      await _repository.unpin(_recordId);
+      return true;
+    } on PinsException catch (e) {
+      lastActionError = e.message;
+      return false;
+    }
+  }
+}

--- a/lib/features/pins/presentation/pin_detail_screen.dart
+++ b/lib/features/pins/presentation/pin_detail_screen.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/features/pins/domain/pins_state.dart';
+import 'package:voice_agent/features/pins/presentation/pins_providers.dart';
+
+/// Full verbatim view of a single saved reference (proposal 045).
+/// Renders the markdown body with `flutter_markdown_plus`, mirroring how the
+/// Chat thread screen renders agent messages.
+class PinDetailScreen extends ConsumerWidget {
+  const PinDetailScreen({super.key, required this.recordId});
+
+  final String recordId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(pinDetailNotifierProvider(recordId));
+    final notifier = ref.read(pinDetailNotifierProvider(recordId).notifier);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(state is PinDetailLoaded ? state.pin.pinName : 'Pin'),
+        actions: [
+          if (state is PinDetailLoaded) ...[
+            IconButton(
+              key: const Key('pin-detail-copy'),
+              icon: const Icon(Icons.copy),
+              tooltip: 'Copy',
+              onPressed: () => _copy(context, state.pin.text),
+            ),
+            IconButton(
+              key: const Key('pin-detail-unpin'),
+              icon: const Icon(Icons.delete_outline),
+              tooltip: 'Unpin',
+              onPressed: () => _confirmUnpin(context, ref),
+            ),
+          ],
+        ],
+      ),
+      body: switch (state) {
+        PinDetailLoading() =>
+          const Center(child: CircularProgressIndicator()),
+        PinDetailLoaded(pin: final pin) => _Body(pin: pin),
+        PinDetailError(message: final message) =>
+          _ErrorState(message: message, onRetry: notifier.refresh),
+      },
+    );
+  }
+
+  void _copy(BuildContext context, String text) {
+    Clipboard.setData(ClipboardData(text: text));
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Copied to clipboard')),
+    );
+  }
+
+  Future<void> _confirmUnpin(BuildContext context, WidgetRef ref) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        key: const Key('pin-detail-unpin-dialog'),
+        title: const Text('Unpin reference?'),
+        content: const Text('This removes it from your pins.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            key: const Key('pin-detail-unpin-confirm'),
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Unpin'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    final notifier = ref.read(pinDetailNotifierProvider(recordId).notifier);
+    final ok = await notifier.unpin();
+    if (!context.mounted) return;
+    if (ok) {
+      context.pop();
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(notifier.lastActionError ?? 'Unpin failed')),
+      );
+    }
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.pin});
+
+  final PinDetail pin;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: MarkdownBody(
+        key: const Key('pin-detail-markdown'),
+        data: pin.text,
+        selectable: true,
+        softLineBreak: true,
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.error_outline, size: 64, color: Colors.red),
+          const SizedBox(height: 16),
+          Text(message, textAlign: TextAlign.center),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            key: const Key('pin-detail-retry-button'),
+            onPressed: onRetry,
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/pins/presentation/pins_notifier.dart
+++ b/lib/features/pins/presentation/pins_notifier.dart
@@ -48,8 +48,8 @@ class PinsNotifier extends StateNotifier<PinsListState> {
         );
       }
       return true;
-    } on PinsException catch (e) {
-      lastActionError = e.message;
+    } catch (e) {
+      lastActionError = e is PinsException ? e.message : e.toString();
       return false;
     }
   }

--- a/lib/features/pins/presentation/pins_notifier.dart
+++ b/lib/features/pins/presentation/pins_notifier.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+import 'package:voice_agent/features/pins/domain/pins_state.dart';
+
+class PinsNotifier extends StateNotifier<PinsListState> {
+  PinsNotifier(this._repository) : super(const PinsListInitial()) {
+    load();
+  }
+
+  final PinsRepository _repository;
+  PinView _view = PinView.recent;
+  String? lastActionError;
+
+  PinView get view => _view;
+
+  Future<void> load() async {
+    state = const PinsListLoading();
+    lastActionError = null;
+    try {
+      final pins = await _repository.fetchPins(_view);
+      state = PinsListLoaded(pins: pins, view: _view);
+    } catch (e) {
+      state = PinsListError(message: e.toString());
+    }
+  }
+
+  Future<void> refresh() => load();
+
+  Future<void> setView(PinView view) {
+    if (view == _view) return Future.value();
+    _view = view;
+    return load();
+  }
+
+  /// Unpin a reference. On success removes the row from the loaded list and
+  /// returns true; on failure records [lastActionError] and returns false
+  /// (the screen surfaces it via a SnackBar — no state change on failure).
+  Future<bool> unpin(String recordId) async {
+    lastActionError = null;
+    try {
+      await _repository.unpin(recordId);
+      final current = state;
+      if (current is PinsListLoaded) {
+        state = PinsListLoaded(
+          pins:
+              current.pins.where((p) => p.recordId != recordId).toList(),
+          view: current.view,
+        );
+      }
+      return true;
+    } on PinsException catch (e) {
+      lastActionError = e.message;
+      return false;
+    }
+  }
+}

--- a/lib/features/pins/presentation/pins_providers.dart
+++ b/lib/features/pins/presentation/pins_providers.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/providers/api_client_provider.dart';
+import 'package:voice_agent/features/pins/data/api_pins_repository.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+import 'package:voice_agent/features/pins/domain/pins_state.dart';
+import 'package:voice_agent/features/pins/presentation/pin_detail_notifier.dart';
+import 'package:voice_agent/features/pins/presentation/pins_notifier.dart';
+
+final pinsRepositoryProvider = Provider<PinsRepository>((ref) {
+  final apiClient = ref.watch(apiClientProvider);
+  return ApiPinsRepository(apiClient);
+});
+
+final pinsNotifierProvider =
+    StateNotifierProvider<PinsNotifier, PinsListState>((ref) {
+  final repository = ref.watch(pinsRepositoryProvider);
+  return PinsNotifier(repository);
+});
+
+final pinDetailNotifierProvider = StateNotifierProvider.family<
+    PinDetailNotifier, PinDetailState, String>((ref, recordId) {
+  final repository = ref.watch(pinsRepositoryProvider);
+  return PinDetailNotifier(repository, recordId);
+});

--- a/lib/features/pins/presentation/pins_screen.dart
+++ b/lib/features/pins/presentation/pins_screen.dart
@@ -1,0 +1,296 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+import 'package:voice_agent/features/pins/domain/pins_state.dart';
+import 'package:voice_agent/features/pins/presentation/pins_notifier.dart';
+import 'package:voice_agent/features/pins/presentation/pins_providers.dart';
+
+/// Browse saved references (pins) from the personal-agent pinboard.
+/// Reached from the Chat list screen's app bar (proposal 045).
+class PinsScreen extends ConsumerWidget {
+  const PinsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(pinsNotifierProvider);
+    final notifier = ref.read(pinsNotifierProvider.notifier);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Pins')),
+      body: Column(
+        children: [
+          _ViewToggle(
+            view: state is PinsListLoaded ? state.view : notifier.view,
+            onChanged: notifier.setView,
+          ),
+          Expanded(
+            child: switch (state) {
+              PinsListInitial() =>
+                const Center(child: CircularProgressIndicator()),
+              PinsListLoading() =>
+                const Center(child: CircularProgressIndicator()),
+              PinsListLoaded(pins: final pins, view: final view) =>
+                _buildList(context, ref, notifier, pins, view),
+              PinsListError(message: final message) =>
+                _ErrorState(message: message, onRetry: notifier.refresh),
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildList(
+    BuildContext context,
+    WidgetRef ref,
+    PinsNotifier notifier,
+    List<PinSummary> pins,
+    PinView view,
+  ) {
+    if (pins.isEmpty) return const _EmptyState();
+    return RefreshIndicator(
+      onRefresh: notifier.refresh,
+      child: ListView(
+        children: view == PinView.topic
+            ? _topicGrouped(context, ref, notifier, pins)
+            : [for (final p in pins) _tile(context, ref, notifier, p)],
+      ),
+    );
+  }
+
+  /// Preserve the backend's topic ordering, inserting a header on each label
+  /// change. Pins with no topic label are collected into a single trailing
+  /// "No topic" section so they are never dropped.
+  List<Widget> _topicGrouped(
+    BuildContext context,
+    WidgetRef ref,
+    PinsNotifier notifier,
+    List<PinSummary> pins,
+  ) {
+    final byLabel = <String, List<PinSummary>>{};
+    final order = <String>[];
+    final untitled = <PinSummary>[];
+    for (final p in pins) {
+      final label = p.topicLabel;
+      if (label == null || label.isEmpty) {
+        untitled.add(p);
+      } else {
+        if (!byLabel.containsKey(label)) {
+          byLabel[label] = [];
+          order.add(label);
+        }
+        byLabel[label]!.add(p);
+      }
+    }
+
+    final widgets = <Widget>[];
+    for (final label in order) {
+      widgets.add(_SectionHeader(label: label));
+      widgets.addAll(
+        byLabel[label]!.map((p) => _tile(context, ref, notifier, p)),
+      );
+    }
+    if (untitled.isNotEmpty) {
+      widgets.add(const _SectionHeader(label: 'No topic'));
+      widgets.addAll(untitled.map((p) => _tile(context, ref, notifier, p)));
+    }
+    return widgets;
+  }
+
+  Widget _tile(
+    BuildContext context,
+    WidgetRef ref,
+    PinsNotifier notifier,
+    PinSummary pin,
+  ) {
+    return _PinTile(
+      key: Key('pin-tile-${pin.recordId}'),
+      pin: pin,
+      onTap: () async {
+        await context.push('/chat/pins/${pin.recordId}');
+        // ADR-ARCH-011: refresh on return so an unpin done from the detail
+        // screen is reflected in the list.
+        notifier.refresh();
+      },
+      onUnpin: () => _confirmUnpin(context, ref, pin.recordId),
+    );
+  }
+
+  Future<void> _confirmUnpin(
+    BuildContext context,
+    WidgetRef ref,
+    String recordId,
+  ) async {
+    final confirmed = await _showUnpinDialog(context);
+    if (confirmed != true) return;
+    final notifier = ref.read(pinsNotifierProvider.notifier);
+    final ok = await notifier.unpin(recordId);
+    if (!ok && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(notifier.lastActionError ?? 'Unpin failed')),
+      );
+    }
+  }
+}
+
+Future<bool?> _showUnpinDialog(BuildContext context) {
+  return showDialog<bool>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      key: const Key('pin-unpin-dialog'),
+      title: const Text('Unpin reference?'),
+      content: const Text('This removes it from your pins.'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(ctx, false),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          key: const Key('pin-unpin-confirm'),
+          onPressed: () => Navigator.pop(ctx, true),
+          child: const Text('Unpin'),
+        ),
+      ],
+    ),
+  );
+}
+
+class _ViewToggle extends StatelessWidget {
+  const _ViewToggle({required this.view, required this.onChanged});
+
+  final PinView view;
+  final ValueChanged<PinView> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: SegmentedButton<PinView>(
+        segments: const [
+          ButtonSegment(
+            value: PinView.recent,
+            label: Text('Recent'),
+            icon: Icon(Icons.schedule),
+          ),
+          ButtonSegment(
+            value: PinView.topic,
+            label: Text('By topic'),
+            icon: Icon(Icons.folder_outlined),
+          ),
+        ],
+        selected: {view},
+        onSelectionChanged: (selection) => onChanged(selection.first),
+      ),
+    );
+  }
+}
+
+class _PinTile extends StatelessWidget {
+  const _PinTile({
+    super.key,
+    required this.pin,
+    required this.onTap,
+    required this.onUnpin,
+  });
+
+  final PinSummary pin;
+  final VoidCallback onTap;
+  final VoidCallback onUnpin;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: const Icon(Icons.push_pin_outlined),
+      title: Text(pin.pinName),
+      subtitle: Text(_subtitle()),
+      onTap: onTap,
+      trailing: PopupMenuButton<String>(
+        key: Key('pin-menu-${pin.recordId}'),
+        onSelected: (value) {
+          if (value == 'unpin') onUnpin();
+        },
+        itemBuilder: (_) => const [
+          PopupMenuItem(value: 'unpin', child: Text('Unpin')),
+        ],
+      ),
+    );
+  }
+
+  String _subtitle() {
+    final label = pin.topicLabel;
+    final date = _formatDate(pin.createdAt);
+    if (label != null && label.isNotEmpty) return '$label · $date';
+    return date;
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              color: Theme.of(context).colorScheme.primary,
+            ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 32),
+        child: Text(
+          'No pins yet. Say "zapamiętaj ..." in a chat to save a reference.',
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.error_outline, size: 64, color: Colors.red),
+          const SizedBox(height: 16),
+          Text(message, textAlign: TextAlign.center),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            key: const Key('pins-retry-button'),
+            onPressed: onRetry,
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _formatDate(DateTime date) {
+  final local = date.toLocal();
+  String two(int v) => v.toString().padLeft(2, '0');
+  return '${local.year}-${two(local.month)}-${two(local.day)}';
+}

--- a/lib/features/pins/presentation/pins_screen.dart
+++ b/lib/features/pins/presentation/pins_screen.dart
@@ -55,7 +55,10 @@ class PinsScreen extends ConsumerWidget {
       child: ListView(
         children: view == PinView.topic
             ? _topicGrouped(context, ref, notifier, pins)
-            : [for (final p in pins) _tile(context, ref, notifier, p)],
+            : [
+                for (final p in pins)
+                  _tile(context, ref, notifier, p, showTopic: true),
+              ],
       ),
     );
   }
@@ -85,16 +88,21 @@ class PinsScreen extends ConsumerWidget {
       }
     }
 
+    // In the by-topic view the section header already names the topic, so the
+    // tile subtitle omits it to avoid duplication.
     final widgets = <Widget>[];
     for (final label in order) {
       widgets.add(_SectionHeader(label: label));
       widgets.addAll(
-        byLabel[label]!.map((p) => _tile(context, ref, notifier, p)),
+        byLabel[label]!
+            .map((p) => _tile(context, ref, notifier, p, showTopic: false)),
       );
     }
     if (untitled.isNotEmpty) {
       widgets.add(const _SectionHeader(label: 'No topic'));
-      widgets.addAll(untitled.map((p) => _tile(context, ref, notifier, p)));
+      widgets.addAll(
+        untitled.map((p) => _tile(context, ref, notifier, p, showTopic: false)),
+      );
     }
     return widgets;
   }
@@ -103,11 +111,13 @@ class PinsScreen extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     PinsNotifier notifier,
-    PinSummary pin,
-  ) {
+    PinSummary pin, {
+    required bool showTopic,
+  }) {
     return _PinTile(
       key: Key('pin-tile-${pin.recordId}'),
       pin: pin,
+      showTopic: showTopic,
       onTap: () async {
         await context.push('/chat/pins/${pin.recordId}');
         // ADR-ARCH-011: refresh on return so an unpin done from the detail
@@ -191,11 +201,13 @@ class _PinTile extends StatelessWidget {
   const _PinTile({
     super.key,
     required this.pin,
+    required this.showTopic,
     required this.onTap,
     required this.onUnpin,
   });
 
   final PinSummary pin;
+  final bool showTopic;
   final VoidCallback onTap;
   final VoidCallback onUnpin;
 
@@ -221,7 +233,9 @@ class _PinTile extends StatelessWidget {
   String _subtitle() {
     final label = pin.topicLabel;
     final date = _formatDate(pin.createdAt);
-    if (label != null && label.isNotEmpty) return '$label · $date';
+    if (showTopic && label != null && label.isNotEmpty) {
+      return '$label · $date';
+    }
     return date;
   }
 }

--- a/test/core/models/pin_test.dart
+++ b/test/core/models/pin_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/pin.dart';
+
+void main() {
+  group('PinSummary.fromMap', () {
+    test('parses a full row', () {
+      final pin = PinSummary.fromMap({
+        'record_id': 'abc123',
+        'pin_name': 'garage pinout',
+        'topic_label': 'Electronics',
+        'created_at': '2026-06-15T10:30:00Z',
+      });
+
+      expect(pin.recordId, 'abc123');
+      expect(pin.pinName, 'garage pinout');
+      expect(pin.topicLabel, 'Electronics');
+      expect(pin.createdAt, DateTime.utc(2026, 6, 15, 10, 30));
+    });
+
+    test('tolerates a missing topic_label (omitempty)', () {
+      final pin = PinSummary.fromMap({
+        'record_id': 'abc123',
+        'pin_name': 'no topic',
+        'created_at': '2026-06-15T10:30:00Z',
+      });
+
+      expect(pin.topicLabel, isNull);
+    });
+  });
+
+  group('PinDetail.fromMap', () {
+    test('parses a full detail with aliases and source events', () {
+      final pin = PinDetail.fromMap({
+        'record_id': 'abc123',
+        'pin_name': 'garage pinout',
+        'topic_label': 'Electronics',
+        'text': '# Pinout\n\n| Pin | Signal |',
+        'aliases': ['pinout', 'wiring'],
+        'source_event_ids': ['event-456'],
+        'created_at': '2026-06-15T10:30:00Z',
+      });
+
+      expect(pin.recordId, 'abc123');
+      expect(pin.pinName, 'garage pinout');
+      expect(pin.topicLabel, 'Electronics');
+      expect(pin.text, '# Pinout\n\n| Pin | Signal |');
+      expect(pin.aliases, ['pinout', 'wiring']);
+      expect(pin.sourceEventIds, ['event-456']);
+      expect(pin.createdAt, DateTime.utc(2026, 6, 15, 10, 30));
+    });
+
+    test('defaults optional lists to empty and topic to null', () {
+      final pin = PinDetail.fromMap({
+        'record_id': 'abc123',
+        'pin_name': 'minimal',
+        'text': 'body',
+        'created_at': '2026-06-15T10:30:00Z',
+      });
+
+      expect(pin.topicLabel, isNull);
+      expect(pin.aliases, isEmpty);
+      expect(pin.sourceEventIds, isEmpty);
+    });
+  });
+}

--- a/test/features/chat/presentation/conversations_screen_test.dart
+++ b/test/features/chat/presentation/conversations_screen_test.dart
@@ -144,11 +144,15 @@ void main() {
       );
     });
 
-    testWidgets('renders add and settings icons', (tester) async {
+    testWidgets('renders add, pins, and settings icons', (tester) async {
       await _pumpScreen(tester);
 
       expect(
         find.byKey(const Key('conversations-new-icon')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('conversations-pins-icon')),
         findsOneWidget,
       );
       expect(

--- a/test/features/pins/data/api_pins_repository_test.dart
+++ b/test/features/pins/data/api_pins_repository_test.dart
@@ -1,0 +1,181 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/features/pins/data/api_pins_repository.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+
+class _StubApiClient extends ApiClient {
+  _StubApiClient() : super(baseUrl: 'https://test.com/api/v1');
+
+  ApiResult nextGetResult = const ApiSuccess(body: '{"data":[]}');
+  ApiResult nextDeleteResult = const ApiSuccess();
+
+  String? lastGetPath;
+  Map<String, dynamic>? lastGetParams;
+  String? lastDeletePath;
+
+  @override
+  Future<ApiResult> get(String path,
+      {Map<String, dynamic>? queryParameters}) async {
+    lastGetPath = path;
+    lastGetParams = queryParameters;
+    return nextGetResult;
+  }
+
+  @override
+  Future<ApiResult> delete(String path) async {
+    lastDeletePath = path;
+    return nextDeleteResult;
+  }
+}
+
+Map<String, dynamic> _summaryJson({String? topicLabel = 'Electronics'}) {
+  final map = <String, dynamic>{
+    'record_id': 'abc123',
+    'pin_name': 'garage pinout',
+    'created_at': '2026-06-15T10:30:00Z',
+  };
+  if (topicLabel != null) map['topic_label'] = topicLabel;
+  return map;
+}
+
+Map<String, dynamic> _detailJson() => {
+      'data': {
+        'record_id': 'abc123',
+        'pin_name': 'garage pinout',
+        'topic_label': 'Electronics',
+        'text': '# Pinout',
+        'aliases': ['pinout'],
+        'source_event_ids': ['event-456'],
+        'created_at': '2026-06-15T10:30:00Z',
+      },
+    };
+
+void main() {
+  late _StubApiClient apiClient;
+  late ApiPinsRepository repo;
+
+  setUp(() {
+    apiClient = _StubApiClient();
+    repo = ApiPinsRepository(apiClient);
+  });
+
+  group('fetchPins', () {
+    test('parses the list envelope', () async {
+      apiClient.nextGetResult = ApiSuccess(
+        body: jsonEncode({
+          'data': [_summaryJson(), _summaryJson(topicLabel: null)],
+        }),
+      );
+
+      final pins = await repo.fetchPins(PinView.recent);
+
+      expect(pins, hasLength(2));
+      expect(pins.first.pinName, 'garage pinout');
+      expect(pins[1].topicLabel, isNull);
+    });
+
+    test('sends the view query parameter', () async {
+      apiClient.nextGetResult = const ApiSuccess(body: '{"data":[]}');
+
+      await repo.fetchPins(PinView.topic);
+
+      expect(apiClient.lastGetPath, '/pins');
+      expect(apiClient.lastGetParams, {'view': 'topic'});
+    });
+
+    test('throws on missing data envelope', () async {
+      apiClient.nextGetResult = const ApiSuccess(body: '{"other":1}');
+
+      expect(
+        () => repo.fetchPins(PinView.recent),
+        throwsA(isA<PinsGeneralException>()),
+      );
+    });
+
+    test('throws on transient failure', () async {
+      apiClient.nextGetResult =
+          const ApiTransientFailure(reason: 'Timeout: connectionTimeout');
+
+      expect(
+        () => repo.fetchPins(PinView.recent),
+        throwsA(isA<PinsGeneralException>()
+            .having((e) => e.message, 'message', contains('Timeout'))),
+      );
+    });
+
+    test('throws on not configured', () async {
+      apiClient.nextGetResult = const ApiNotConfigured();
+
+      expect(
+        () => repo.fetchPins(PinView.recent),
+        throwsA(isA<PinsGeneralException>()
+            .having((e) => e.message, 'message', contains('not configured'))),
+      );
+    });
+  });
+
+  group('fetchPin', () {
+    test('parses the detail envelope', () async {
+      apiClient.nextGetResult = ApiSuccess(body: jsonEncode(_detailJson()));
+
+      final pin = await repo.fetchPin('abc123');
+
+      expect(apiClient.lastGetPath, '/pins/abc123');
+      expect(pin.text, '# Pinout');
+      expect(pin.aliases, ['pinout']);
+    });
+
+    test('throws PinNotFoundException on 404', () async {
+      apiClient.nextGetResult =
+          const ApiPermanentFailure(statusCode: 404, message: 'not found');
+
+      expect(
+        () => repo.fetchPin('missing'),
+        throwsA(isA<PinNotFoundException>()),
+      );
+    });
+
+    test('throws PinsGeneralException on other permanent failure', () async {
+      apiClient.nextGetResult =
+          const ApiPermanentFailure(statusCode: 400, message: 'bad');
+
+      expect(
+        () => repo.fetchPin('abc123'),
+        throwsA(isA<PinsGeneralException>()
+            .having((e) => e.message, 'message', contains('400'))),
+      );
+    });
+  });
+
+  group('unpin', () {
+    test('sends DELETE to the pin path', () async {
+      apiClient.nextDeleteResult = const ApiSuccess();
+
+      await repo.unpin('abc123');
+
+      expect(apiClient.lastDeletePath, '/pins/abc123');
+    });
+
+    test('throws PinNotFoundException on 404', () async {
+      apiClient.nextDeleteResult =
+          const ApiPermanentFailure(statusCode: 404, message: 'not found');
+
+      expect(
+        () => repo.unpin('missing'),
+        throwsA(isA<PinNotFoundException>()),
+      );
+    });
+
+    test('throws PinsGeneralException on transient failure', () async {
+      apiClient.nextDeleteResult =
+          const ApiTransientFailure(reason: 'Connection error');
+
+      expect(
+        () => repo.unpin('abc123'),
+        throwsA(isA<PinsGeneralException>()),
+      );
+    });
+  });
+}

--- a/test/features/pins/presentation/pin_detail_notifier_test.dart
+++ b/test/features/pins/presentation/pin_detail_notifier_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+import 'package:voice_agent/features/pins/domain/pins_state.dart';
+import 'package:voice_agent/features/pins/presentation/pin_detail_notifier.dart';
+
+class _MockRepository implements PinsRepository {
+  PinDetail? pin;
+  Exception? fetchError;
+  Exception? unpinError;
+
+  String? lastFetchId;
+  String? lastUnpinId;
+
+  @override
+  Future<List<PinSummary>> fetchPins(PinView view) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<PinDetail> fetchPin(String recordId) async {
+    lastFetchId = recordId;
+    if (fetchError != null) throw fetchError!;
+    return pin ?? _detail(recordId);
+  }
+
+  @override
+  Future<void> unpin(String recordId) async {
+    lastUnpinId = recordId;
+    if (unpinError != null) throw unpinError!;
+  }
+}
+
+PinDetail _detail(String id) => PinDetail(
+      recordId: id,
+      pinName: 'pin $id',
+      text: '# Body',
+      createdAt: DateTime.utc(2026, 6, 15),
+    );
+
+void main() {
+  test('loads the pin on construction', () async {
+    final repo = _MockRepository()..pin = _detail('abc');
+    final notifier = PinDetailNotifier(repo, 'abc');
+
+    expect(notifier.state, isA<PinDetailLoading>());
+    await Future<void>.delayed(Duration.zero);
+
+    expect(notifier.state, isA<PinDetailLoaded>());
+    expect((notifier.state as PinDetailLoaded).pin.text, '# Body');
+    expect(repo.lastFetchId, 'abc');
+  });
+
+  test('emits error when the fetch throws', () async {
+    final repo = _MockRepository()..fetchError = PinNotFoundException();
+    final notifier = PinDetailNotifier(repo, 'missing');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(notifier.state, isA<PinDetailError>());
+  });
+
+  test('unpin success returns true', () async {
+    final repo = _MockRepository()..pin = _detail('abc');
+    final notifier = PinDetailNotifier(repo, 'abc');
+    await Future<void>.delayed(Duration.zero);
+
+    final ok = await notifier.unpin();
+
+    expect(ok, isTrue);
+    expect(repo.lastUnpinId, 'abc');
+  });
+
+  test('unpin failure returns false and records the error', () async {
+    final repo = _MockRepository()
+      ..pin = _detail('abc')
+      ..unpinError = PinsGeneralException('nope');
+    final notifier = PinDetailNotifier(repo, 'abc');
+    await Future<void>.delayed(Duration.zero);
+
+    final ok = await notifier.unpin();
+
+    expect(ok, isFalse);
+    expect(notifier.lastActionError, 'nope');
+  });
+}

--- a/test/features/pins/presentation/pin_detail_screen_test.dart
+++ b/test/features/pins/presentation/pin_detail_screen_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+import 'package:voice_agent/features/pins/presentation/pins_providers.dart';
+import 'package:voice_agent/features/pins/presentation/pin_detail_screen.dart';
+
+class _StubRepository implements PinsRepository {
+  PinDetail? pin;
+  Exception? fetchError;
+  Exception? unpinError;
+  String? lastUnpinId;
+
+  @override
+  Future<List<PinSummary>> fetchPins(PinView view) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<PinDetail> fetchPin(String recordId) async {
+    if (fetchError != null) throw fetchError!;
+    return pin ??
+        PinDetail(
+          recordId: recordId,
+          pinName: 'pin $recordId',
+          text: '# Heading\n\nbody text',
+          createdAt: DateTime.utc(2026, 6, 15),
+        );
+  }
+
+  @override
+  Future<void> unpin(String recordId) async {
+    lastUnpinId = recordId;
+    if (unpinError != null) throw unpinError!;
+  }
+}
+
+Future<void> _pump(WidgetTester tester, PinsRepository repo) async {
+  final router = GoRouter(
+    initialLocation: '/chat/pins/abc',
+    routes: [
+      GoRoute(
+        path: '/chat/pins',
+        builder: (context, state) => const Scaffold(body: Text('Pins list')),
+        routes: [
+          GoRoute(
+            path: ':id',
+            builder: (context, state) =>
+                PinDetailScreen(recordId: state.pathParameters['id']!),
+          ),
+        ],
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [pinsRepositoryProvider.overrideWithValue(repo)],
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('PinDetailScreen', () {
+    testWidgets('renders the pin name and markdown body', (tester) async {
+      await _pump(tester, _StubRepository());
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text('pin abc'),
+        ),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('pin-detail-markdown')), findsOneWidget);
+      expect(find.byType(MarkdownBody), findsOneWidget);
+    });
+
+    testWidgets('copy action puts the verbatim text on the clipboard',
+        (tester) async {
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      String? copied;
+      messenger.setMockMethodCallHandler(SystemChannels.platform,
+          (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied = (call.arguments as Map)['text'] as String;
+        }
+        return null;
+      });
+
+      await _pump(tester, _StubRepository());
+
+      await tester.tap(find.byKey(const Key('pin-detail-copy')));
+      await tester.pumpAndSettle();
+
+      expect(copied, '# Heading\n\nbody text');
+
+      messenger.setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    testWidgets('unpin confirmation calls the repository and pops',
+        (tester) async {
+      final repo = _StubRepository();
+      await _pump(tester, repo);
+
+      await tester.tap(find.byKey(const Key('pin-detail-unpin')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('pin-detail-unpin-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(repo.lastUnpinId, 'abc');
+      expect(find.text('Pins list'), findsOneWidget);
+    });
+
+    testWidgets('shows the error state with retry on fetch failure',
+        (tester) async {
+      await _pump(tester, _StubRepository()..fetchError = PinNotFoundException());
+
+      expect(
+        find.byKey(const Key('pin-detail-retry-button')),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/test/features/pins/presentation/pins_notifier_test.dart
+++ b/test/features/pins/presentation/pins_notifier_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+import 'package:voice_agent/features/pins/domain/pins_state.dart';
+import 'package:voice_agent/features/pins/presentation/pins_notifier.dart';
+
+class _MockRepository implements PinsRepository {
+  List<PinSummary> pins;
+  Exception? fetchError;
+  Exception? unpinError;
+
+  int fetchCount = 0;
+  PinView? lastView;
+  String? lastUnpinId;
+
+  _MockRepository({this.pins = const []});
+
+  @override
+  Future<List<PinSummary>> fetchPins(PinView view) async {
+    fetchCount++;
+    lastView = view;
+    if (fetchError != null) throw fetchError!;
+    return pins;
+  }
+
+  @override
+  Future<PinDetail> fetchPin(String recordId) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> unpin(String recordId) async {
+    lastUnpinId = recordId;
+    if (unpinError != null) throw unpinError!;
+  }
+}
+
+PinSummary _pin(String id, {String? topic}) => PinSummary(
+      recordId: id,
+      pinName: 'pin $id',
+      topicLabel: topic,
+      createdAt: DateTime.utc(2026, 6, 15),
+    );
+
+void main() {
+  test('loads pins on construction (initial -> loading -> loaded)', () async {
+    final repo = _MockRepository(pins: [_pin('a'), _pin('b')]);
+    final notifier = PinsNotifier(repo);
+
+    expect(notifier.state, isA<PinsListLoading>());
+    await Future<void>.delayed(Duration.zero);
+
+    final state = notifier.state;
+    expect(state, isA<PinsListLoaded>());
+    expect((state as PinsListLoaded).pins, hasLength(2));
+    expect(state.view, PinView.recent);
+  });
+
+  test('emits error when the fetch throws', () async {
+    final repo = _MockRepository()..fetchError = Exception('boom');
+    final notifier = PinsNotifier(repo);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(notifier.state, isA<PinsListError>());
+  });
+
+  test('setView switches view and refetches', () async {
+    final repo = _MockRepository(pins: [_pin('a')]);
+    final notifier = PinsNotifier(repo);
+    await Future<void>.delayed(Duration.zero);
+
+    await notifier.setView(PinView.topic);
+
+    expect(repo.lastView, PinView.topic);
+    expect((notifier.state as PinsListLoaded).view, PinView.topic);
+  });
+
+  test('setView to the current view does not refetch', () async {
+    final repo = _MockRepository(pins: [_pin('a')]);
+    final notifier = PinsNotifier(repo);
+    await Future<void>.delayed(Duration.zero);
+    final countAfterLoad = repo.fetchCount;
+
+    await notifier.setView(PinView.recent);
+
+    expect(repo.fetchCount, countAfterLoad);
+  });
+
+  test('unpin success removes the row from the loaded list', () async {
+    final repo = _MockRepository(pins: [_pin('a'), _pin('b')]);
+    final notifier = PinsNotifier(repo);
+    await Future<void>.delayed(Duration.zero);
+
+    final ok = await notifier.unpin('a');
+
+    expect(ok, isTrue);
+    expect(repo.lastUnpinId, 'a');
+    final pins = (notifier.state as PinsListLoaded).pins;
+    expect(pins.map((p) => p.recordId), ['b']);
+  });
+
+  test('unpin failure keeps the list and records the error', () async {
+    final repo = _MockRepository(pins: [_pin('a')])
+      ..unpinError = PinsGeneralException('nope');
+    final notifier = PinsNotifier(repo);
+    await Future<void>.delayed(Duration.zero);
+
+    final ok = await notifier.unpin('a');
+
+    expect(ok, isFalse);
+    expect(notifier.lastActionError, 'nope');
+    expect((notifier.state as PinsListLoaded).pins, hasLength(1));
+  });
+}

--- a/test/features/pins/presentation/pins_screen_test.dart
+++ b/test/features/pins/presentation/pins_screen_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+import 'package:voice_agent/features/pins/presentation/pins_providers.dart';
+import 'package:voice_agent/features/pins/presentation/pins_screen.dart';
+
+class _StubRepository implements PinsRepository {
+  List<PinSummary> pins;
+  Exception? fetchError;
+  Exception? unpinError;
+  String? lastUnpinId;
+
+  _StubRepository({this.pins = const []});
+
+  @override
+  Future<List<PinSummary>> fetchPins(PinView view) async {
+    if (fetchError != null) throw fetchError!;
+    return pins;
+  }
+
+  @override
+  Future<PinDetail> fetchPin(String recordId) async => PinDetail(
+        recordId: recordId,
+        pinName: 'pin $recordId',
+        text: '# Detail $recordId',
+        createdAt: DateTime.utc(2026, 6, 15),
+      );
+
+  @override
+  Future<void> unpin(String recordId) async {
+    lastUnpinId = recordId;
+    if (unpinError != null) throw unpinError!;
+  }
+}
+
+PinSummary _pin(String id, {String? topic}) => PinSummary(
+      recordId: id,
+      pinName: 'Pin $id',
+      topicLabel: topic,
+      createdAt: DateTime.utc(2026, 6, 15),
+    );
+
+Future<void> _pump(WidgetTester tester, PinsRepository repo) async {
+  final router = GoRouter(
+    initialLocation: '/chat/pins',
+    routes: [
+      GoRoute(
+        path: '/chat/pins',
+        builder: (context, state) => const PinsScreen(),
+        routes: [
+          GoRoute(
+            path: ':id',
+            builder: (context, state) => Scaffold(
+              body: Text('Detail ${state.pathParameters['id']}'),
+            ),
+          ),
+        ],
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [pinsRepositoryProvider.overrideWithValue(repo)],
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('PinsScreen', () {
+    testWidgets('renders the Pins app bar title', (tester) async {
+      await _pump(tester, _StubRepository(pins: [_pin('a')]));
+
+      expect(
+        find.descendant(of: find.byType(AppBar), matching: find.text('Pins')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders a tile per pin', (tester) async {
+      await _pump(
+        tester,
+        _StubRepository(pins: [_pin('a'), _pin('b')]),
+      );
+
+      expect(find.byKey(const Key('pin-tile-a')), findsOneWidget);
+      expect(find.byKey(const Key('pin-tile-b')), findsOneWidget);
+    });
+
+    testWidgets('shows the empty state when there are no pins',
+        (tester) async {
+      await _pump(tester, _StubRepository(pins: const []));
+
+      expect(find.textContaining('No pins yet'), findsOneWidget);
+    });
+
+    testWidgets('shows the error state with retry on fetch failure',
+        (tester) async {
+      await _pump(
+        tester,
+        _StubRepository()..fetchError = Exception('network'),
+      );
+
+      expect(find.byKey(const Key('pins-retry-button')), findsOneWidget);
+    });
+
+    testWidgets('By topic groups pins under labels with a No topic section',
+        (tester) async {
+      await _pump(
+        tester,
+        _StubRepository(pins: [
+          _pin('a', topic: 'Electronics'),
+          _pin('b'),
+        ]),
+      );
+
+      await tester.tap(find.text('By topic'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Electronics'), findsOneWidget);
+      expect(find.text('No topic'), findsOneWidget);
+    });
+
+    testWidgets('tapping a pin navigates to its detail route', (tester) async {
+      await _pump(tester, _StubRepository(pins: [_pin('a')]));
+
+      await tester.tap(find.byKey(const Key('pin-tile-a')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Detail a'), findsOneWidget);
+    });
+
+    testWidgets('unpin via the tile menu calls the repository',
+        (tester) async {
+      final repo = _StubRepository(pins: [_pin('a')]);
+      await _pump(tester, repo);
+
+      await tester.tap(find.byKey(const Key('pin-menu-a')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Unpin').last);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('pin-unpin-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(repo.lastUnpinId, 'a');
+      expect(find.byKey(const Key('pin-tile-a')), findsNothing);
+    });
+  });
+}

--- a/test/features/pins/presentation/pins_screen_test.dart
+++ b/test/features/pins/presentation/pins_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:voice_agent/core/models/pin.dart';
 import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+import 'package:voice_agent/features/pins/presentation/pin_detail_screen.dart';
 import 'package:voice_agent/features/pins/presentation/pins_providers.dart';
 import 'package:voice_agent/features/pins/presentation/pins_screen.dart';
 
@@ -33,6 +34,8 @@ class _StubRepository implements PinsRepository {
   Future<void> unpin(String recordId) async {
     lastUnpinId = recordId;
     if (unpinError != null) throw unpinError!;
+    // Reflect the backend soft-delete so a subsequent re-fetch omits the row.
+    pins = pins.where((p) => p.recordId != recordId).toList();
   }
 }
 
@@ -149,6 +152,52 @@ void main() {
 
       expect(repo.lastUnpinId, 'a');
       expect(find.byKey(const Key('pin-tile-a')), findsNothing);
+    });
+
+    // ADR-ARCH-011 seam: unpinning from the detail screen must drop the row
+    // from the list on return (via the tile's awaited-push + refresh()).
+    testWidgets('unpinning from the detail screen removes the row on return',
+        (tester) async {
+      final repo = _StubRepository(pins: [_pin('a'), _pin('b')]);
+      final router = GoRouter(
+        initialLocation: '/chat/pins',
+        routes: [
+          GoRoute(
+            path: '/chat/pins',
+            builder: (context, state) => const PinsScreen(),
+            routes: [
+              GoRoute(
+                path: ':id',
+                builder: (context, state) =>
+                    PinDetailScreen(recordId: state.pathParameters['id']!),
+              ),
+            ],
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [pinsRepositoryProvider.overrideWithValue(repo)],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Open detail for pin a.
+      await tester.tap(find.byKey(const Key('pin-tile-a')));
+      await tester.pumpAndSettle();
+
+      // Unpin from the detail screen and confirm.
+      await tester.tap(find.byKey(const Key('pin-detail-unpin')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('pin-detail-unpin-confirm')));
+      await tester.pumpAndSettle();
+
+      // Back on the list, the row is gone (refresh re-fetched the reduced set).
+      expect(repo.lastUnpinId, 'a');
+      expect(find.byKey(const Key('pin-tile-a')), findsNothing);
+      expect(find.byKey(const Key('pin-tile-b')), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## P045 — Pins (Saved References) Screen

Implements proposal [045](docs/proposals/045-pins-screen.md) (merged to `main` in #329).

### What
A mobile screen to browse the personal-agent **pinboard** — the verbatim
references saved by voice in chat ("zapamiętaj ten pinout / przepis"). Until now
those were only reachable from the web UI; the phone — the device in hand at the
workbench/kitchen — couldn't show them.

### Behaviour
- **Read + unpin only.** The backend has no write path for pins by design, so the
  app never creates/edits them.
- New `features/pins/` (domain/data/presentation) over the deployed contract:
  `GET /api/v1/pins?view=recent|topic`, `GET /api/v1/pins/{id}`,
  `DELETE /api/v1/pins/{id}` (data envelope, Bearer auth). New
  `core/models/pin.dart`. Reuses the shared `ApiClient` — no ApiClient change.
- **Entry point:** a keyed push-pin icon on `ConversationsScreen`'s app bar →
  `/chat/pins`. Child routes `/chat/pins` and `/chat/pins/:id` are registered
  **before** `/chat/:id` so "pins" isn't parsed as a conversation id.
- **List:** Recent / By-topic toggle; null-topic pins grouped under a trailing
  "No topic" section. Unpin from the row menu removes it (confirm dialog).
- **Detail:** renders the markdown body via the existing `flutter_markdown_plus`
  (as the chat thread does); copy-to-clipboard + unpin (ADR-ARCH-011 list refresh
  on return). No new dependency.

### Process / tests
- Tier 2. Proposal reviewed via `/proposal-review` (P1/P2 fixed before the
  proposal merged).
- New tests: model parsing, repository (envelope/404/transient/not-configured),
  both notifiers, both screens; extended the chat-screen test for the new icon.
- **`make verify` green — 1105 tests pass, `flutter analyze` clean.**
- No device-only contracts → no manual test plan (stated in the proposal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
