### PR TITLE
feat(pins): quick-access Pins button on the Record landing screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -619,6 +619,8 @@ placeholder screens within this structure — they do not add routes.
 | `/record/history/:id` | 020 (child of /record/history) | 007 (TranscriptDetailScreen) |
 | `/routines` | 020 (shell branch 3) | 022 (RoutinesPlaceholderScreen → real screen) |
 | `/chat` | 020 (shell branch 4) | 024 (ChatPlaceholderScreen → real screen) |
+| `/pins` | 045 (outside shell) | 045 (PinsScreen) — reached from Record + Chat app bars |
+| `/pins/:id` | 045 (child of /pins) | 045 (PinDetailScreen) |
 | `/settings` | 020 (outside shell) | 006 (SettingsScreen) |
 | `/settings/advanced` | 020 (child of /settings) | 013 (AdvancedSettingsScreen) |
 

--- a/docs/proposals/045-pins-screen.md
+++ b/docs/proposals/045-pins-screen.md
@@ -517,3 +517,25 @@ its own small design.
 ### Search across pins (deferred)
 V1 is browse + topic toggle. If the pinboard grows large, a client-side or
 backend search (`GET /api/v1/pins?q=…`, not yet implemented) becomes worthwhile.
+
+---
+
+## Addendum (2026-06-21) — quick-access entry point
+
+After dogfooding the shipped feature, the single Chat-app-bar entry point felt
+too buried. Two follow-up changes (same feature, no contract change to the
+backend):
+
+- **Pins promoted to a top-level route.** `/chat/pins` and `/chat/pins/:id`
+  moved to `/pins` and `/pins/:id`, registered outside the shell alongside
+  `/settings`. Rationale: pushing a Chat-branch-nested route from another branch
+  (e.g. the Record landing screen) is fragile under `StatefulShellRoute`; a
+  top-level route is reachable cleanly from anywhere via `context.push('/pins')`,
+  exactly like Settings. This supersedes the original §Route Integration table.
+- **Second entry point on the landing screen.** The Record screen
+  (`initialLocation`, the screen the app opens on) gains a keyed pin app-bar icon
+  (`record-pins-button`) → `/pins`. The Chat-app-bar icon remains and now also
+  pushes `/pins`.
+
+No change to the read/unpin behavior, models, repository, or the backend
+contract — only navigation placement.

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -91,21 +91,6 @@ GoRouter createRouter() => GoRouter(
               path: '/chat',
               builder: (_, _) => const ConversationsScreen(),
               routes: [
-                // Static 'pins' MUST precede the dynamic ':id' route so
-                // '/chat/pins' is not captured as a conversation id (P045).
-                GoRoute(
-                  path: 'pins',
-                  builder: (_, _) => const PinsScreen(),
-                  routes: [
-                    GoRoute(
-                      path: ':id',
-                      builder: (_, state) {
-                        final id = state.pathParameters['id']!;
-                        return PinDetailScreen(recordId: id);
-                      },
-                    ),
-                  ],
-                ),
                 GoRoute(
                   path: ':id',
                   builder: (_, state) {
@@ -116,6 +101,20 @@ GoRouter createRouter() => GoRouter(
               ],
             ),
           ],
+        ),
+      ],
+    ),
+    // Pins — top-level (full-screen, outside shell) so the saved-references
+    // screen is reachable from anywhere: the Record landing screen's app bar
+    // and the Chat app bar both push '/pins' (P045 + quick-access).
+    GoRoute(
+      path: '/pins',
+      builder: (context, state) => const PinsScreen(),
+      routes: [
+        GoRoute(
+          path: ':id',
+          builder: (context, state) =>
+              PinDetailScreen(recordId: state.pathParameters['id']!),
         ),
       ],
     ),

--- a/lib/features/chat/presentation/conversations_screen.dart
+++ b/lib/features/chat/presentation/conversations_screen.dart
@@ -30,7 +30,7 @@ class ConversationsScreen extends ConsumerWidget {
             key: const Key('conversations-pins-icon'),
             icon: const Icon(Icons.push_pin_outlined),
             tooltip: 'Pins',
-            onPressed: () => context.push('/chat/pins'),
+            onPressed: () => context.push('/pins'),
           ),
           IconButton(
             key: const Key('conversations-settings-icon'),

--- a/lib/features/pins/presentation/pins_screen.dart
+++ b/lib/features/pins/presentation/pins_screen.dart
@@ -119,7 +119,7 @@ class PinsScreen extends ConsumerWidget {
       pin: pin,
       showTopic: showTopic,
       onTap: () async {
-        await context.push('/chat/pins/${pin.recordId}');
+        await context.push('/pins/${pin.recordId}');
         // ADR-ARCH-011: refresh on return so an unpin done from the detail
         // screen is reflected in the list.
         notifier.refresh();

--- a/lib/features/recording/presentation/recording_screen.dart
+++ b/lib/features/recording/presentation/recording_screen.dart
@@ -273,6 +273,12 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
                   },
           ),
           IconButton(
+            key: const Key('record-pins-button'),
+            icon: const Icon(Icons.push_pin_outlined),
+            tooltip: 'Pins',
+            onPressed: () => context.push('/pins'),
+          ),
+          IconButton(
             icon: const Icon(Icons.history),
             onPressed: () => context.push('/record/history'),
           ),

--- a/test/features/pins/presentation/pin_detail_screen_test.dart
+++ b/test/features/pins/presentation/pin_detail_screen_test.dart
@@ -40,10 +40,10 @@ class _StubRepository implements PinsRepository {
 
 Future<void> _pump(WidgetTester tester, PinsRepository repo) async {
   final router = GoRouter(
-    initialLocation: '/chat/pins/abc',
+    initialLocation: '/pins/abc',
     routes: [
       GoRoute(
-        path: '/chat/pins',
+        path: '/pins',
         builder: (context, state) => const Scaffold(body: Text('Pins list')),
         routes: [
           GoRoute(

--- a/test/features/pins/presentation/pins_screen_test.dart
+++ b/test/features/pins/presentation/pins_screen_test.dart
@@ -48,10 +48,10 @@ PinSummary _pin(String id, {String? topic}) => PinSummary(
 
 Future<void> _pump(WidgetTester tester, PinsRepository repo) async {
   final router = GoRouter(
-    initialLocation: '/chat/pins',
+    initialLocation: '/pins',
     routes: [
       GoRoute(
-        path: '/chat/pins',
+        path: '/pins',
         builder: (context, state) => const PinsScreen(),
         routes: [
           GoRoute(
@@ -160,10 +160,10 @@ void main() {
         (tester) async {
       final repo = _StubRepository(pins: [_pin('a'), _pin('b')]);
       final router = GoRouter(
-        initialLocation: '/chat/pins',
+        initialLocation: '/pins',
         routes: [
           GoRoute(
-            path: '/chat/pins',
+            path: '/pins',
             builder: (context, state) => const PinsScreen(),
             routes: [
               GoRoute(

--- a/test/features/recording/presentation/recording_screen_new_conversation_test.dart
+++ b/test/features/recording/presentation/recording_screen_new_conversation_test.dart
@@ -34,6 +34,9 @@ import 'package:voice_agent/core/media_button/media_button_provider.dart';
 import 'package:voice_agent/features/recording/domain/recording_service.dart';
 import 'package:voice_agent/features/recording/domain/stt_service.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
+import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+import 'package:voice_agent/features/pins/presentation/pins_providers.dart';
 
 import 'package:timezone/data/latest_all.dart' as tz_data;
 
@@ -262,6 +265,16 @@ class _StubHandsFreeControlPort implements HandsFreeControlPort {
   Future<void> stopSession() async {}
 }
 
+class _StubPinsRepository implements PinsRepository {
+  @override
+  Future<List<PinSummary>> fetchPins(PinView view) async => [];
+  @override
+  Future<PinDetail> fetchPin(String recordId) async =>
+      throw UnimplementedError();
+  @override
+  Future<void> unpin(String recordId) async {}
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 void main() {
@@ -447,6 +460,38 @@ void main() {
       expect(coordinator.resetCount, 0);
       expect(toaster.messages, isEmpty);
       expect(haptic.lightImpactCount, 0);
+    });
+  });
+
+  group('Pins button (quick access from landing screen)', () {
+    testWidgets('exists in the Record AppBar', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: _baseOverrides(),
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('record-pins-button')), findsOneWidget);
+    });
+
+    testWidgets('tap navigates to the Pins screen', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ..._baseOverrides(),
+            pinsRepositoryProvider.overrideWithValue(_StubPinsRepository()),
+          ],
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('record-pins-button')));
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(AppBar, 'Pins'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Quick-access Pins entry point

Follow-up to P045 from dogfooding: the Pins screen was only reachable from the
Chat app bar, which felt buried. This adds a Pins button **on the Record landing
screen** (the screen the app opens on) and makes the route reachable from
anywhere.

### Changes
- **Pins promoted to a top-level route**: `/chat/pins`(`/:id`) → `/pins`(`/:id`),
  registered outside the shell alongside `/settings`. Pushing a Chat-branch-nested
  route from another branch is fragile under `StatefulShellRoute`; a top-level
  route is reachable cleanly from any screen via `context.push('/pins')`.
- **New pin icon on the Record app bar** (`record-pins-button`) → `/pins`.
- The Chat app-bar pin icon stays and now also pushes `/pins`.
- Docs: P045 addendum + CLAUDE.md route-ownership table.

No change to pins behavior, models, repository, or the backend contract — purely
navigation placement.

### Tests
- Updated the pins screen/detail test routers to `/pins`.
- New: Record app bar shows the pins icon; tapping it navigates to the Pins screen.
- **`make verify` green — 1108 tests, analyze clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
