### PR TITLE
feat(pins): open the source conversation from a pinned reference

### DIFF
--- a/lib/core/models/pin.dart
+++ b/lib/core/models/pin.dart
@@ -35,6 +35,7 @@ class PinDetail {
     this.topicLabel,
     required this.text,
     this.aliases = const [],
+    this.conversationId,
     this.sourceEventIds = const [],
     required this.createdAt,
   });
@@ -46,6 +47,11 @@ class PinDetail {
   /// Verbatim markdown body of the saved reference.
   final String text;
   final List<String> aliases;
+
+  /// Conversation the reference was pinned from. Null for legacy pins saved
+  /// before the backend recorded the source (`conversation_id` omitempty).
+  /// When present, the detail screen links back to that chat thread.
+  final String? conversationId;
   final List<String> sourceEventIds;
   final DateTime createdAt;
 
@@ -56,6 +62,7 @@ class PinDetail {
       topicLabel: map['topic_label'] as String?,
       text: map['text'] as String,
       aliases: _stringList(map['aliases']),
+      conversationId: map['conversation_id'] as String?,
       sourceEventIds: _stringList(map['source_event_ids']),
       createdAt: DateTime.parse(map['created_at'] as String),
     );

--- a/lib/features/pins/presentation/pin_detail_screen.dart
+++ b/lib/features/pins/presentation/pin_detail_screen.dart
@@ -25,6 +25,13 @@ class PinDetailScreen extends ConsumerWidget {
         title: Text(state is PinDetailLoaded ? state.pin.pinName : 'Pin'),
         actions: [
           if (state is PinDetailLoaded) ...[
+            if (_conversationId(state.pin) case final conversationId?)
+              IconButton(
+                key: const Key('pin-detail-open-conversation'),
+                icon: const Icon(Icons.forum_outlined),
+                tooltip: 'Open conversation',
+                onPressed: () => context.push('/chat/$conversationId'),
+              ),
             IconButton(
               key: const Key('pin-detail-copy'),
               icon: const Icon(Icons.copy),
@@ -48,6 +55,13 @@ class PinDetailScreen extends ConsumerWidget {
           _ErrorState(message: message, onRetry: notifier.refresh),
       },
     );
+  }
+
+  /// The source conversation id, or null when absent/empty (legacy pins) so
+  /// the "open conversation" action only shows when there is a thread to open.
+  String? _conversationId(PinDetail pin) {
+    final id = pin.conversationId;
+    return (id == null || id.isEmpty) ? null : id;
   }
 
   void _copy(BuildContext context, String text) {

--- a/test/core/models/pin_test.dart
+++ b/test/core/models/pin_test.dart
@@ -29,13 +29,15 @@ void main() {
   });
 
   group('PinDetail.fromMap', () {
-    test('parses a full detail with aliases and source events', () {
+    test('parses a full detail with aliases, source events and conversation',
+        () {
       final pin = PinDetail.fromMap({
         'record_id': 'abc123',
         'pin_name': 'garage pinout',
         'topic_label': 'Electronics',
         'text': '# Pinout\n\n| Pin | Signal |',
         'aliases': ['pinout', 'wiring'],
+        'conversation_id': 'conv-789',
         'source_event_ids': ['event-456'],
         'created_at': '2026-06-15T10:30:00Z',
       });
@@ -45,11 +47,13 @@ void main() {
       expect(pin.topicLabel, 'Electronics');
       expect(pin.text, '# Pinout\n\n| Pin | Signal |');
       expect(pin.aliases, ['pinout', 'wiring']);
+      expect(pin.conversationId, 'conv-789');
       expect(pin.sourceEventIds, ['event-456']);
       expect(pin.createdAt, DateTime.utc(2026, 6, 15, 10, 30));
     });
 
-    test('defaults optional lists to empty and topic to null', () {
+    test('defaults optional lists to empty, conversation and topic to null',
+        () {
       final pin = PinDetail.fromMap({
         'record_id': 'abc123',
         'pin_name': 'minimal',
@@ -59,6 +63,7 @@ void main() {
 
       expect(pin.topicLabel, isNull);
       expect(pin.aliases, isEmpty);
+      expect(pin.conversationId, isNull);
       expect(pin.sourceEventIds, isEmpty);
     });
   });

--- a/test/features/pins/presentation/pin_detail_screen_test.dart
+++ b/test/features/pins/presentation/pin_detail_screen_test.dart
@@ -53,6 +53,11 @@ Future<void> _pump(WidgetTester tester, PinsRepository repo) async {
           ),
         ],
       ),
+      GoRoute(
+        path: '/chat/:id',
+        builder: (context, state) =>
+            Scaffold(body: Text('Thread ${state.pathParameters['id']}')),
+      ),
     ],
   );
 
@@ -125,6 +130,44 @@ void main() {
       expect(
         find.byKey(const Key('pin-detail-retry-button')),
         findsOneWidget,
+      );
+    });
+
+    testWidgets('open-conversation action opens the source chat thread',
+        (tester) async {
+      final repo = _StubRepository()
+        ..pin = PinDetail(
+          recordId: 'abc',
+          pinName: 'pin abc',
+          text: '# Heading\n\nbody text',
+          conversationId: 'conv-789',
+          createdAt: DateTime.utc(2026, 6, 15),
+        );
+      await _pump(tester, repo);
+
+      final action = find.byKey(const Key('pin-detail-open-conversation'));
+      expect(action, findsOneWidget);
+
+      await tester.tap(action);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Thread conv-789'), findsOneWidget);
+    });
+
+    testWidgets('hides the open-conversation action when no source conversation',
+        (tester) async {
+      final repo = _StubRepository()
+        ..pin = PinDetail(
+          recordId: 'abc',
+          pinName: 'pin abc',
+          text: 'body',
+          createdAt: DateTime.utc(2026, 6, 15),
+        );
+      await _pump(tester, repo);
+
+      expect(
+        find.byKey(const Key('pin-detail-open-conversation')),
+        findsNothing,
       );
     });
   });


### PR DESCRIPTION
## What

Wires the voice-agent so a pinned reference can open the conversation it was captured from.

Personal-agent (note `N002`) now returns `conversation_id` in `GET /api/v1/pins/{id}`. This PR consumes that field:

- **`PinDetail`** parses `conversation_id` into a nullable `conversationId` (omitempty → null for legacy pins).
- **`PinDetailScreen`** gains an "Open conversation" app-bar action (`forum_outlined`) that pushes `/chat/:id`, reusing the existing `ThreadScreen` route to open the source thread.
- The action only renders when `conversationId` is present and non-empty, so legacy pins without a recorded source show no broken affordance.

## Why

A pin is a verbatim slice of a chat. Being able to jump back to the full conversation is the natural next step once the backend records the link.

## Contract

| Field | Source | Endpoint |
|-------|--------|----------|
| `conversation_id` (omitempty) | personal-agent N002 | `GET /api/v1/pins/{id}` |

No new routes — `/chat/:id` already exists (owner: proposal 024). No backend change in this repo.

## Tests

- `pin_test.dart`: parses `conversation_id`; defaults to null when absent.
- `pin_detail_screen_test.dart`: action opens the thread when a source conversation exists; action hidden when it does not.
- `make verify` green (analyze + 1110 tests).

## Scope / tier

Tier 1 — UI-only change consuming an already-shipped, additive API field. No storage, sync, or navigation-structure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
