### PR TITLE
fix(pins): open the source conversation as a top-level route (v1.1.1)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -16,8 +16,8 @@ import 'package:voice_agent/features/settings/advanced_settings_screen.dart';
 import 'package:voice_agent/features/settings/settings_screen.dart';
 import 'package:voice_agent/features/usage/presentation/usage_screen.dart';
 
-GoRouter createRouter() => GoRouter(
-  initialLocation: '/record',
+GoRouter createRouter({String initialLocation = '/record'}) => GoRouter(
+  initialLocation: initialLocation,
   routes: [
     StatefulShellRoute.indexedStack(
       builder: (context, state, navigationShell) {
@@ -117,6 +117,17 @@ GoRouter createRouter() => GoRouter(
               PinDetailScreen(recordId: state.pathParameters['id']!),
         ),
       ],
+    ),
+    // Conversation thread — top-level (outside shell), so a specific thread
+    // can be opened from anywhere (e.g. a pin's "open source conversation").
+    // The in-shell `/chat/:id` cannot be pushed from outside the shell: pushing
+    // it builds the shell at the chat branch's *default* location (the
+    // conversations list), dropping the `:id`. This standalone route renders
+    // the same full-screen ThreadScreen with a back button to the caller.
+    GoRoute(
+      path: '/conversation/:id',
+      builder: (_, state) =>
+          ThreadScreen(conversationId: state.pathParameters['id']!),
     ),
     // Settings — outside shell (full-screen, no bottom nav)
     GoRoute(

--- a/lib/features/pins/presentation/pin_detail_screen.dart
+++ b/lib/features/pins/presentation/pin_detail_screen.dart
@@ -30,7 +30,7 @@ class PinDetailScreen extends ConsumerWidget {
                 key: const Key('pin-detail-open-conversation'),
                 icon: const Icon(Icons.forum_outlined),
                 tooltip: 'Open conversation',
-                onPressed: () => context.push('/chat/$conversationId'),
+                onPressed: () => context.push('/conversation/$conversationId'),
               ),
             IconButton(
               key: const Key('pin-detail-copy'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Single source of truth for the app version. Format: MAJOR.MINOR.PATCH+BUILD.
 # Bump it in the same PR as the change, and tag `vMAJOR.MINOR.PATCH` after merge.
 # See "Versioning & Releases" in CLAUDE.md for the rules.
-version: 1.1.0+2
+version: 1.1.1+3
 
 environment:
   sdk: ^3.11.1

--- a/test/features/pins/pin_to_conversation_nav_test.dart
+++ b/test/features/pins/pin_to_conversation_nav_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/app/router.dart';
+import 'package:voice_agent/core/models/conversation.dart';
+import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/network/sse_client.dart';
+import 'package:voice_agent/features/chat/domain/chat_repository.dart';
+import 'package:voice_agent/features/chat/presentation/chat_providers.dart';
+import 'package:voice_agent/features/chat/presentation/conversations_screen.dart';
+import 'package:voice_agent/features/chat/presentation/thread_screen.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+import 'package:voice_agent/features/pins/presentation/pins_providers.dart';
+import 'package:voice_agent/core/models/pin.dart';
+
+/// Regression test for the pin -> source-conversation navigation.
+///
+/// The pin detail screen lives on a top-level route OUTSIDE the StatefulShell;
+/// the chat thread (`/chat/:id`) lives INSIDE it. Pushing the in-shell route
+/// from outside builds the shell at the chat branch's default location (the
+/// conversations list), dropping the `:id` — the user lands on the list with no
+/// selected conversation. The fix routes the pin to the standalone
+/// `/conversation/:id` route, which renders ThreadScreen directly.
+///
+/// This drives the REAL `createRouter()` (not a hand-rolled flat router) so it
+/// exercises the actual shell structure that the bug depended on.
+class _StubPinsRepository implements PinsRepository {
+  @override
+  Future<List<PinSummary>> fetchPins(PinView view) async => [];
+
+  @override
+  Future<PinDetail> fetchPin(String recordId) async => PinDetail(
+        recordId: recordId,
+        pinName: 'garage pinout',
+        text: '# Pinout',
+        conversationId: 'conv-1',
+        createdAt: DateTime.utc(2026, 6, 15),
+      );
+
+  @override
+  Future<void> unpin(String recordId) async {}
+}
+
+class _StubChatRepository implements ChatRepository {
+  @override
+  Future<Conversation?> getConversation(String conversationId) async =>
+      Conversation(
+        conversationId: conversationId,
+        sessionId: 'sess-1',
+        status: ConversationStatus.open,
+        createdAt: DateTime.utc(2026, 6, 15),
+        eventCount: 0,
+      );
+
+  @override
+  Future<List<ConversationEvent>> getEvents(String conversationId) async => [];
+
+  @override
+  Future<List<ConversationRecord>> getRecords(String conversationId) async =>
+      [];
+
+  @override
+  Future<List<ModelInfo>> getModels({String? backend}) async => [];
+
+  @override
+  Future<BackendOptions> getBackends() async =>
+      const BackendOptions(backends: []);
+
+  @override
+  Future<List<Conversation>> listConversations() async => [];
+
+  @override
+  Stream<SseEvent> streamChat({
+    required String sessionId,
+    required String content,
+    required String idempotencyKey,
+    String? model,
+    String? backend,
+  }) =>
+      const Stream.empty();
+
+  @override
+  Future<void> cancelChat({
+    required String sessionId,
+    required String idempotencyKey,
+  }) async {}
+
+  @override
+  Future<bool> toggleEndorse(String recordId) async => false;
+}
+
+void main() {
+  testWidgets(
+    'opening a pin\'s source conversation lands on the thread, not the list',
+    (tester) async {
+      // Start the real router directly on the pin detail route so the test
+      // mirrors a user who navigated Pins -> a pin, then taps "open".
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            pinsRepositoryProvider.overrideWithValue(_StubPinsRepository()),
+            chatRepositoryProvider.overrideWithValue(_StubChatRepository()),
+          ],
+          child: MaterialApp.router(
+            routerConfig: createRouter(initialLocation: '/pins/abc'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The open-conversation action is present (pin has a conversation_id).
+      final action = find.byKey(const Key('pin-detail-open-conversation'));
+      expect(action, findsOneWidget);
+
+      await tester.tap(action);
+      await tester.pumpAndSettle();
+
+      // We must land on the specific thread, NOT the conversations list.
+      expect(find.byType(ThreadScreen), findsOneWidget);
+      expect(find.byType(ConversationsScreen), findsNothing);
+    },
+  );
+}

--- a/test/features/pins/presentation/pin_detail_screen_test.dart
+++ b/test/features/pins/presentation/pin_detail_screen_test.dart
@@ -54,7 +54,7 @@ Future<void> _pump(WidgetTester tester, PinsRepository repo) async {
         ],
       ),
       GoRoute(
-        path: '/chat/:id',
+        path: '/conversation/:id',
         builder: (context, state) =>
             Scaffold(body: Text('Thread ${state.pathParameters['id']}')),
       ),


### PR DESCRIPTION
## Bug

Tapping **"Open conversation"** on a pin navigated to the chat tab but with **no conversation selected** — the user landed on the conversations list, not the thread.

## Root cause

The pin detail screen is a **top-level route outside** the `StatefulShellRoute`; the chat thread (`/chat/:id`) lives **inside** it (branch 4). `context.push('/chat/<id>')` from outside the shell builds the shell at the chat branch's **default** location (`/chat` — the list) and drops the `:id`. It's the only outside-shell → inside-shell-nested navigation in the app, so nothing else exercised this path.

The original unit test passed because it used a hand-rolled flat `/chat/:id` route, which doesn't model the shell — false confidence.

## Fix

- Add a standalone top-level route **`/conversation/:id`** → `ThreadScreen` (alongside `/pins`, `/settings`). `ThreadScreen` is already self-contained (own `Scaffold`/`AppBar`, root-scoped providers), so it renders full-screen with a back button to the pin.
- Point the pin's action at `/conversation/$id`.
- `createRouter({String initialLocation})` is now parameterized for testing.

## Test

New **real-router** regression test (`pin_to_conversation_nav_test.dart`) drives `createRouter()` and asserts the pin action lands on `ThreadScreen`, not `ConversationsScreen`. Verified it **fails** against the old `/chat/` push and passes with the fix.

`make verify` green (analyze + 1111 tests).

## Version

Fix → `1.1.0+2` → **`1.1.1+3`** (tag `v1.1.1` after merge), per the new versioning policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
