### PR TITLE
feat(pins): P046 T1 — core PinWriter port + write DTOs

### DIFF
--- a/lib/app_main.dart
+++ b/lib/app_main.dart
@@ -25,6 +25,7 @@ import 'package:voice_agent/core/background/workmanager_core_boot.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/notifications/data/local_notification_service.dart';
 import 'package:voice_agent/core/notifications/notification_providers.dart';
+import 'package:voice_agent/core/network/pin_writer.dart';
 import 'package:voice_agent/core/providers/api_client_provider.dart';
 import 'package:voice_agent/core/providers/deep_link_providers.dart';
 import 'package:voice_agent/core/session_control/session_control_provider.dart';
@@ -32,6 +33,7 @@ import 'package:voice_agent/core/session_control/toaster.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 import 'package:voice_agent/core/storage/storage_service.dart';
 import 'package:voice_agent/features/agenda/presentation/agenda_providers.dart';
+import 'package:voice_agent/features/pins/data/api_pin_writer.dart';
 import 'package:voice_agent/features/recording/presentation/recording_providers.dart';
 
 /// Optional hook for the dev flavor to wire telemetry between the
@@ -111,6 +113,9 @@ Future<void> appMain({AfterStorageInit? afterStorageInit}) async {
         appConfigServiceProvider.overrideWithValue(core.configService),
         apiClientProvider.overrideWithValue(core.api),
         notificationServiceProvider.overrideWithValue(core.notifications),
+
+        // Pins write path (P046): core PinWriter port, feature-owned adapter.
+        pinWriterProvider.overrideWithValue(ApiPinWriter(core.api)),
 
         // Agenda feature wiring — same instance as the bg isolate will use.
         agendaRepositoryProvider.overrideWithValue(agenda.repository),

--- a/lib/core/models/pin.dart
+++ b/lib/core/models/pin.dart
@@ -1,9 +1,14 @@
-// Read-only DTOs for the personal-agent pins API (proposal 045).
+// DTOs for the personal-agent pins API.
 //
-// Two DTOs share this file — matching `agenda.dart`'s several-related-classes
-// layout — because they are a single read contract: the lean list row
-// (`PinSummary`) and the full reference (`PinDetail`). Pins are created only by
-// voice in chat; the client never writes them, so there is no `toMap`.
+// Read contract (proposal 045): the lean list row (`PinSummary`) and the full
+// reference (`PinDetail`).
+//
+// Write contract (proposal 046): pinning a chat message from the app —
+// `PinSuggestion` (proposed name + topic from `POST /pins/suggest`),
+// `PinCreateRequest` (the `POST /pins` body, the only `toMap` here), and
+// `PinCreateResult` (the create response wrapper). The write path is reached
+// through the `core` `PinWriter` port (`core/network/pin_writer.dart`), not by
+// `features/chat` importing `features/pins`.
 
 class PinSummary {
   const PinSummary({
@@ -72,4 +77,83 @@ class PinDetail {
 List<String> _stringList(dynamic value) {
   if (value == null) return const [];
   return (value as List<dynamic>).map((e) => e as String).toList();
+}
+
+/// Proposed name + best-matching existing topic for a message, from
+/// `POST /api/v1/pins/suggest`. Writes nothing on the backend.
+///
+/// `aliases` and `topic_ref` are intentionally ignored: the confirm dialog
+/// edits only name + topic, and the client sends back `topic_label`, not the
+/// ref (proposal 046 §Solution Design).
+class PinSuggestion {
+  const PinSuggestion({required this.name, this.topicLabel});
+
+  final String name;
+
+  /// Canonical name of a matching existing topic, or null/empty when the
+  /// backend found none similar enough.
+  final String? topicLabel;
+
+  factory PinSuggestion.fromMap(Map<String, dynamic> map) {
+    return PinSuggestion(
+      name: map['name'] as String? ?? '',
+      topicLabel: map['topic_label'] as String?,
+    );
+  }
+}
+
+/// Body for `POST /api/v1/pins` — pins a specific chat message by identity.
+///
+/// The client never sends pin content: the backend copies the verbatim body
+/// server-side from `(conversation_id, event_id)`. `topic_label` is omitted
+/// when null/empty to match the backend `omitempty`; `aliases` is out of scope
+/// for V1 and never sent.
+class PinCreateRequest {
+  const PinCreateRequest({
+    required this.conversationId,
+    required this.eventId,
+    required this.name,
+    this.topicLabel,
+  });
+
+  final String conversationId;
+  final String eventId;
+  final String name;
+  final String? topicLabel;
+
+  Map<String, dynamic> toMap() {
+    final map = <String, dynamic>{
+      'conversation_id': conversationId,
+      'event_id': eventId,
+      'name': name,
+    };
+    final topic = topicLabel;
+    if (topic != null && topic.isNotEmpty) {
+      map['topic_label'] = topic;
+    }
+    return map;
+  }
+}
+
+/// Result of `POST /api/v1/pins`: the created (or re-pinned) [PinDetail] plus
+/// idempotency metadata. `created` is false on an idempotent re-pin;
+/// `supersededRecordId` names a prior same-name pin that was replaced, or "".
+class PinCreateResult {
+  const PinCreateResult({
+    required this.pin,
+    required this.created,
+    this.supersededRecordId = '',
+  });
+
+  final PinDetail pin;
+  final bool created;
+  final String supersededRecordId;
+
+  factory PinCreateResult.fromMap(Map<String, dynamic> map) {
+    return PinCreateResult(
+      pin: PinDetail.fromMap(map['pin'] as Map<String, dynamic>),
+      created: map['created'] as bool? ?? false,
+      supersededRecordId: map['superseded_record_id'] as String? ?? '',
+    );
+  }
 }

--- a/lib/core/network/pin_writer.dart
+++ b/lib/core/network/pin_writer.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/models/pin.dart';
+
+/// Port for creating pins (proposal 046).
+///
+/// Lives in `core/` so `features/chat` can invoke the pin write path through a
+/// core provider instead of importing `features/pins` (ADR-ARCH-003). The
+/// adapter is `ApiPinWriter` in `features/pins/data/`, bound by an override in
+/// the app composition root (`app_main.dart`) — the same core-port /
+/// feature-adapter seam as [HandsFreeControlPort] (ADR-ARCH-006, amended P046).
+abstract class PinWriter {
+  /// Proposes a name + matching existing topic for a message. Writes nothing.
+  Future<PinSuggestion> suggestPin(String conversationId, String eventId);
+
+  /// Pins the message identified by [request].
+  Future<PinCreateResult> createPin(PinCreateRequest request);
+}
+
+/// Default-throws provider (ADR-ARCH-004): the real [PinWriter] is bound by an
+/// override on the root `ProviderScope` in `app_main.dart`; tests override it
+/// with a fake. Consumers depend only on this `core` provider.
+final pinWriterProvider = Provider<PinWriter>((ref) {
+  throw UnimplementedError(
+    'pinWriterProvider must be overridden in the app composition root',
+  );
+});

--- a/lib/features/pins/data/api_pin_writer.dart
+++ b/lib/features/pins/data/api_pin_writer.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+
+import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/core/network/pin_writer.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+
+/// `ApiClient`-backed [PinWriter] (proposal 046).
+///
+/// Mirrors `ApiPinsRepository`: unwraps the `{"data": ...}` envelope in feature
+/// code (P025 convention) and reuses the dio -> [ApiResult] error
+/// classification (ADR-NET-001) mapped onto the shared [PinsException]
+/// hierarchy. A `404` (message/conversation gone) becomes
+/// [PinNotFoundException]; everything else non-success becomes
+/// [PinsGeneralException].
+class ApiPinWriter implements PinWriter {
+  ApiPinWriter(this._apiClient);
+
+  final ApiClient _apiClient;
+
+  @override
+  Future<PinSuggestion> suggestPin(
+    String conversationId,
+    String eventId,
+  ) async {
+    final result = await _apiClient.postJson(
+      '/pins/suggest',
+      data: {'conversation_id': conversationId, 'event_id': eventId},
+    );
+    switch (result) {
+      case ApiSuccess(body: final body):
+        return PinSuggestion.fromMap(_dataMap(body));
+      case ApiPermanentFailure(statusCode: 404):
+        throw PinNotFoundException('Message not found');
+      case ApiPermanentFailure(message: final msg, statusCode: final code):
+        throw PinsGeneralException('Server error $code: $msg');
+      case ApiTransientFailure(reason: final reason):
+        throw PinsGeneralException(reason);
+      case ApiNotConfigured():
+        throw PinsGeneralException('API not configured');
+    }
+  }
+
+  @override
+  Future<PinCreateResult> createPin(PinCreateRequest request) async {
+    final result = await _apiClient.postJson('/pins', data: request.toMap());
+    switch (result) {
+      case ApiSuccess(body: final body):
+        return PinCreateResult.fromMap(_dataMap(body));
+      case ApiPermanentFailure(statusCode: 404):
+        throw PinNotFoundException('Message not found');
+      case ApiPermanentFailure(message: final msg, statusCode: final code):
+        throw PinsGeneralException('Server error $code: $msg');
+      case ApiTransientFailure(reason: final reason):
+        throw PinsGeneralException(reason);
+      case ApiNotConfigured():
+        throw PinsGeneralException('API not configured');
+    }
+  }
+
+  Map<String, dynamic> _dataMap(String? body) {
+    if (body == null) throw PinsGeneralException('Empty response');
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final data = json['data'];
+    if (data is! Map<String, dynamic>) {
+      throw PinsGeneralException('Missing data envelope');
+    }
+    return data;
+  }
+}

--- a/test/core/models/pin_test.dart
+++ b/test/core/models/pin_test.dart
@@ -67,4 +67,106 @@ void main() {
       expect(pin.sourceEventIds, isEmpty);
     });
   });
+
+  group('PinSuggestion.fromMap', () {
+    test('parses name and topic, ignoring aliases and topic_ref', () {
+      final s = PinSuggestion.fromMap({
+        'name': 'ESP32 GPIO pinout',
+        'aliases': ['pinout'],
+        'topic_label': 'Electronics',
+        'topic_ref': 'topic-1',
+      });
+
+      expect(s.name, 'ESP32 GPIO pinout');
+      expect(s.topicLabel, 'Electronics');
+    });
+
+    test('leaves topic null when the backend matched none', () {
+      final s = PinSuggestion.fromMap({'name': 'x', 'topic_label': ''});
+
+      expect(s.name, 'x');
+      expect(s.topicLabel, '');
+    });
+  });
+
+  group('PinCreateRequest.toMap', () {
+    test('emits identity + name + topic when topic is present', () {
+      const req = PinCreateRequest(
+        conversationId: 'conv-1',
+        eventId: 'event-9',
+        name: 'garage pinout',
+        topicLabel: 'Electronics',
+      );
+
+      expect(req.toMap(), {
+        'conversation_id': 'conv-1',
+        'event_id': 'event-9',
+        'name': 'garage pinout',
+        'topic_label': 'Electronics',
+      });
+    });
+
+    test('omits topic_label when null or empty (backend omitempty)', () {
+      const nullTopic = PinCreateRequest(
+        conversationId: 'conv-1',
+        eventId: 'event-9',
+        name: 'n',
+      );
+      const emptyTopic = PinCreateRequest(
+        conversationId: 'conv-1',
+        eventId: 'event-9',
+        name: 'n',
+        topicLabel: '',
+      );
+
+      expect(nullTopic.toMap().containsKey('topic_label'), isFalse);
+      expect(emptyTopic.toMap().containsKey('topic_label'), isFalse);
+    });
+
+    test('never sends aliases', () {
+      const req = PinCreateRequest(
+        conversationId: 'c',
+        eventId: 'e',
+        name: 'n',
+        topicLabel: 't',
+      );
+
+      expect(req.toMap().containsKey('aliases'), isFalse);
+    });
+  });
+
+  group('PinCreateResult.fromMap', () {
+    test('parses the nested pin and idempotency metadata', () {
+      final r = PinCreateResult.fromMap({
+        'pin': {
+          'record_id': 'abc123',
+          'pin_name': 'garage pinout',
+          'topic_label': 'Electronics',
+          'text': '# Pinout',
+          'created_at': '2026-06-15T10:30:00Z',
+        },
+        'created': true,
+        'superseded_record_id': 'old-1',
+      });
+
+      expect(r.pin.recordId, 'abc123');
+      expect(r.pin.text, '# Pinout');
+      expect(r.created, isTrue);
+      expect(r.supersededRecordId, 'old-1');
+    });
+
+    test('defaults created to false and superseded to empty', () {
+      final r = PinCreateResult.fromMap({
+        'pin': {
+          'record_id': 'abc123',
+          'pin_name': 'p',
+          'text': 'body',
+          'created_at': '2026-06-15T10:30:00Z',
+        },
+      });
+
+      expect(r.created, isFalse);
+      expect(r.supersededRecordId, '');
+    });
+  });
 }

--- a/test/features/pins/data/api_pin_writer_test.dart
+++ b/test/features/pins/data/api_pin_writer_test.dart
@@ -1,0 +1,185 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/features/pins/data/api_pin_writer.dart';
+import 'package:voice_agent/features/pins/domain/pins_repository.dart';
+
+class _StubApiClient extends ApiClient {
+  _StubApiClient() : super(baseUrl: 'https://test.com/api/v1');
+
+  ApiResult nextPostResult = const ApiSuccess(body: '{"data":{}}');
+
+  String? lastPostPath;
+  Map<String, dynamic>? lastPostData;
+
+  @override
+  Future<ApiResult> postJson(String path, {Map<String, dynamic>? data}) async {
+    lastPostPath = path;
+    lastPostData = data;
+    return nextPostResult;
+  }
+}
+
+String _suggestBody() => jsonEncode({
+      'data': {
+        'name': 'ESP32 GPIO pinout',
+        'aliases': ['pinout'],
+        'topic_label': 'Electronics',
+        'topic_ref': 'topic-1',
+      },
+    });
+
+String _createBody({bool created = true}) => jsonEncode({
+      'data': {
+        'pin': {
+          'record_id': 'abc123',
+          'pin_name': 'garage pinout',
+          'topic_label': 'Electronics',
+          'text': '# Pinout',
+          'created_at': '2026-06-15T10:30:00Z',
+        },
+        'created': created,
+        'superseded_record_id': '',
+      },
+    });
+
+void main() {
+  late _StubApiClient apiClient;
+  late ApiPinWriter writer;
+
+  setUp(() {
+    apiClient = _StubApiClient();
+    writer = ApiPinWriter(apiClient);
+  });
+
+  group('suggestPin', () {
+    test('posts identity and parses the suggestion', () async {
+      apiClient.nextPostResult = ApiSuccess(body: _suggestBody());
+
+      final s = await writer.suggestPin('conv-1', 'event-9');
+
+      expect(apiClient.lastPostPath, '/pins/suggest');
+      expect(apiClient.lastPostData,
+          {'conversation_id': 'conv-1', 'event_id': 'event-9'});
+      expect(s.name, 'ESP32 GPIO pinout');
+      expect(s.topicLabel, 'Electronics');
+    });
+
+    test('throws PinNotFoundException on 404', () async {
+      apiClient.nextPostResult =
+          const ApiPermanentFailure(statusCode: 404, message: 'gone');
+
+      expect(
+        () => writer.suggestPin('c', 'e'),
+        throwsA(isA<PinNotFoundException>()),
+      );
+    });
+
+    test('throws PinsGeneralException on other permanent failure', () async {
+      apiClient.nextPostResult =
+          const ApiPermanentFailure(statusCode: 400, message: 'bad');
+
+      expect(
+        () => writer.suggestPin('c', 'e'),
+        throwsA(isA<PinsGeneralException>()
+            .having((e) => e.message, 'message', contains('400'))),
+      );
+    });
+
+    test('throws PinsGeneralException on transient failure', () async {
+      apiClient.nextPostResult =
+          const ApiTransientFailure(reason: 'Timeout: connectionTimeout');
+
+      expect(
+        () => writer.suggestPin('c', 'e'),
+        throwsA(isA<PinsGeneralException>()
+            .having((e) => e.message, 'message', contains('Timeout'))),
+      );
+    });
+
+    test('throws PinsGeneralException on not configured', () async {
+      apiClient.nextPostResult = const ApiNotConfigured();
+
+      expect(
+        () => writer.suggestPin('c', 'e'),
+        throwsA(isA<PinsGeneralException>()
+            .having((e) => e.message, 'message', contains('not configured'))),
+      );
+    });
+
+    test('throws on missing data envelope', () async {
+      apiClient.nextPostResult = const ApiSuccess(body: '{"other":1}');
+
+      expect(
+        () => writer.suggestPin('c', 'e'),
+        throwsA(isA<PinsGeneralException>()),
+      );
+    });
+  });
+
+  group('createPin', () {
+    test('posts the request body and parses the result', () async {
+      apiClient.nextPostResult = ApiSuccess(body: _createBody());
+
+      final result = await writer.createPin(const PinCreateRequest(
+        conversationId: 'conv-1',
+        eventId: 'event-9',
+        name: 'garage pinout',
+        topicLabel: 'Electronics',
+      ));
+
+      expect(apiClient.lastPostPath, '/pins');
+      expect(apiClient.lastPostData, {
+        'conversation_id': 'conv-1',
+        'event_id': 'event-9',
+        'name': 'garage pinout',
+        'topic_label': 'Electronics',
+      });
+      expect(result.pin.recordId, 'abc123');
+      expect(result.created, isTrue);
+    });
+
+    test('omits topic_label when empty', () async {
+      apiClient.nextPostResult = ApiSuccess(body: _createBody());
+
+      await writer.createPin(const PinCreateRequest(
+        conversationId: 'conv-1',
+        eventId: 'event-9',
+        name: 'n',
+      ));
+
+      expect(apiClient.lastPostData!.containsKey('topic_label'), isFalse);
+    });
+
+    test('throws PinNotFoundException on 404', () async {
+      apiClient.nextPostResult =
+          const ApiPermanentFailure(statusCode: 404, message: 'gone');
+
+      expect(
+        () => writer.createPin(const PinCreateRequest(
+          conversationId: 'c',
+          eventId: 'e',
+          name: 'n',
+        )),
+        throwsA(isA<PinNotFoundException>()),
+      );
+    });
+
+    test('throws PinsGeneralException on 500', () async {
+      apiClient.nextPostResult =
+          const ApiPermanentFailure(statusCode: 500, message: 'boom');
+
+      expect(
+        () => writer.createPin(const PinCreateRequest(
+          conversationId: 'c',
+          eventId: 'e',
+          name: 'n',
+        )),
+        throwsA(isA<PinsGeneralException>()
+            .having((e) => e.message, 'message', contains('500'))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## P046 T1 — core PinWriter seam

First slice of [proposal 046](../blob/main/docs/proposals/046-pin-a-chat-message.md) (pin a chat message from the app). Adds the **core write seam** only — no UI yet (that's T2), so this is independently mergeable and behavior-preserving.

### Changes
- **`core/network/pin_writer.dart`** (new) — abstract `PinWriter` port (`suggestPin` / `createPin`) + default-throws `pinWriterProvider`. Lets `features/chat` (T2) reach the pin write path through a `core` provider instead of importing `features/pins` (ADR-ARCH-003). Same core-port / feature-adapter seam as `HandsFreeControlPort` (ADR-ARCH-006, amended P046).
- **`core/models/pin.dart`** — new write DTOs: `PinSuggestion`, `PinCreateRequest` (the only `toMap`; `topic_label` omitempty, no `aliases` in V1), `PinCreateResult`.
- **`features/pins/data/api_pin_writer.dart`** (new) — `ApiPinWriter` adapter, mirrors `ApiPinsRepository`: `{"data":…}` envelope unwrap + dio→`ApiResult`→`PinsException` classification (ADR-NET-001), `404`→`PinNotFoundException`.
- **`app_main.dart`** — bind `pinWriterProvider` → `ApiPinWriter(core.api)` at the root `ProviderScope`, beside the existing `apiClientProvider` override.

### Tests
- `test/core/models/pin_test.dart` — `PinSuggestion.fromMap`, `PinCreateRequest.toMap` (omitempty + no aliases), `PinCreateResult.fromMap`.
- `test/features/pins/data/api_pin_writer_test.dart` — suggest/create success + 400/404/500/transient/not-configured classification + envelope unwrap.

### Verification
`make verify` — analyzer clean, all 1128 tests pass. Dependency rule holds: `core/` imports no `features/`; the port has no consumer yet so the default-throws provider is never evaluated outside the app binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
