### PR TITLE
feat(chat): P046 T2 — pin a chat message from the thread

### DIFF
--- a/lib/features/chat/presentation/chat_providers.dart
+++ b/lib/features/chat/presentation/chat_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:voice_agent/core/network/pin_writer.dart';
 import 'package:voice_agent/core/providers/api_client_provider.dart';
 import 'package:voice_agent/features/chat/data/api_chat_repository.dart';
 import 'package:voice_agent/features/chat/domain/chat_repository.dart';
@@ -23,5 +24,6 @@ final threadNotifierProvider =
   (ref, conversationId) => ThreadNotifier(
     conversationId: conversationId,
     repository: ref.watch(chatRepositoryProvider),
+    pinWriter: ref.watch(pinWriterProvider),
   ),
 );

--- a/lib/features/chat/presentation/thread_notifier.dart
+++ b/lib/features/chat/presentation/thread_notifier.dart
@@ -5,7 +5,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 import 'package:voice_agent/core/models/conversation.dart';
 import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/models/pin.dart';
 import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/core/network/pin_writer.dart';
 import 'package:voice_agent/core/network/sse_client.dart';
 import 'package:voice_agent/features/chat/domain/chat_repository.dart';
 import 'package:voice_agent/features/chat/domain/chat_state.dart';
@@ -14,14 +16,24 @@ class ThreadNotifier extends StateNotifier<ThreadState> {
   ThreadNotifier({
     required String conversationId,
     required ChatRepository repository,
+    required PinWriter pinWriter,
   })  : _conversationId = conversationId,
         _repository = repository,
+        _pinWriter = pinWriter,
         super(const ThreadLoading()) {
     load();
   }
 
   final String _conversationId;
   final ChatRepository _repository;
+  final PinWriter _pinWriter;
+
+  // Session-local pin view state (proposal 046). Held as notifier fields, not on
+  // the immutable Thread* states, so they survive a streaming->loaded transition
+  // without threading through every state rebuild. Not reconciled with the
+  // backend on reload — the pinboard is the source of truth.
+  final Set<String> _pinnedEventIds = {};
+  final Set<String> _pinInFlight = {};
 
   StreamSubscription<SseEvent>? _subscription;
   String? _currentIdempotencyKey;
@@ -415,6 +427,96 @@ class ThreadNotifier extends StateNotifier<ThreadState> {
           selectedBackend: refreshed.selectedBackend,
           pendingUserMessage: refreshed.pendingUserMessage,
           toolProgress: refreshed.toolProgress,
+        );
+      default:
+        break;
+    }
+  }
+
+  /// Whether [eventId] has been pinned this session (filled icon).
+  bool isPinned(String eventId) => _pinnedEventIds.contains(eventId);
+
+  /// Whether a pin flow for [eventId] is in progress (spinner + single-flight).
+  bool isPinInFlight(String eventId) => _pinInFlight.contains(eventId);
+
+  /// Starts a pin flow for a message: marks it in-flight (single-flight, drives
+  /// the spinner) while fetching a suggested name + topic. Returns null when a
+  /// flow is already running for this event or it is already pinned (the tap is
+  /// a no-op). Rethrows on failure for the screen to surface. The in-flight mark
+  /// spans only the suggest call — the confirm dialog runs behind a modal
+  /// barrier, so re-taps can't happen while it is open. The create step is
+  /// [confirmPin]; cancel with [cancelPin].
+  Future<PinSuggestion?> beginPin(
+    String conversationId,
+    String eventId,
+  ) async {
+    if (_pinInFlight.contains(eventId) || _pinnedEventIds.contains(eventId)) {
+      return null;
+    }
+    _pinInFlight.add(eventId);
+    _touch();
+    try {
+      return await _pinWriter.suggestPin(conversationId, eventId);
+    } finally {
+      _pinInFlight.remove(eventId);
+      _touch();
+    }
+  }
+
+  /// Creates the pin after the user confirms. On success marks the event pinned;
+  /// always clears the in-flight mark. Rethrows on failure for the screen.
+  Future<PinCreateResult> confirmPin(
+    String conversationId,
+    String eventId, {
+    required String name,
+    String? topicLabel,
+  }) async {
+    try {
+      final result = await _pinWriter.createPin(PinCreateRequest(
+        conversationId: conversationId,
+        eventId: eventId,
+        name: name,
+        topicLabel: topicLabel,
+      ));
+      _pinnedEventIds.add(eventId);
+      return result;
+    } finally {
+      _pinInFlight.remove(eventId);
+      _touch();
+    }
+  }
+
+  /// Abandons an in-flight pin flow (dialog cancelled).
+  void cancelPin(String eventId) {
+    if (_pinInFlight.remove(eventId)) _touch();
+  }
+
+  /// Re-emits the current state as a fresh instance so listeners rebuild after a
+  /// pin-set change (the sets are notifier fields, not state fields).
+  void _touch() {
+    final current = state;
+    switch (current) {
+      case ThreadLoaded():
+        state = ThreadLoaded(
+          conversation: current.conversation,
+          events: current.events,
+          records: current.records,
+          models: current.models,
+          backends: current.backends,
+          selectedModel: current.selectedModel,
+          selectedBackend: current.selectedBackend,
+        );
+      case ThreadStreaming():
+        state = ThreadStreaming(
+          conversation: current.conversation,
+          events: current.events,
+          records: current.records,
+          models: current.models,
+          backends: current.backends,
+          selectedModel: current.selectedModel,
+          selectedBackend: current.selectedBackend,
+          pendingUserMessage: current.pendingUserMessage,
+          toolProgress: current.toolProgress,
         );
       default:
         break;

--- a/lib/features/chat/presentation/thread_screen.dart
+++ b/lib/features/chat/presentation/thread_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:voice_agent/core/models/conversation.dart';
 import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/models/pin.dart';
 import 'package:voice_agent/features/chat/domain/chat_repository.dart';
 import 'package:voice_agent/features/chat/domain/chat_state.dart';
 import 'package:voice_agent/features/chat/presentation/chat_providers.dart';
@@ -24,6 +25,59 @@ class _ThreadScreenState extends ConsumerState<ThreadScreen> {
   void dispose() {
     _textController.dispose();
     super.dispose();
+  }
+
+  /// Pin flow for an agent message (proposal 046): suggest name+topic, confirm
+  /// in a dialog, then create. The notifier owns the network calls and the
+  /// in-flight / pinned sets; this method only drives the dialog and SnackBars.
+  Future<void> _startPin(ConversationEvent event) async {
+    final notifier =
+        ref.read(threadNotifierProvider(widget.conversationId).notifier);
+    final messenger = ScaffoldMessenger.of(context);
+
+    final PinSuggestion? suggestion;
+    try {
+      suggestion = await notifier.beginPin(event.conversationId, event.eventId);
+    } on Exception catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text('Could not prepare pin: $e')),
+      );
+      return;
+    }
+    // Already pinned or a flow is already running for this message.
+    if (suggestion == null) return;
+    if (!mounted) return;
+
+    final confirmed = await showDialog<_PinConfirmation>(
+      context: context,
+      builder: (_) => _PinConfirmDialog(suggestion: suggestion!),
+    );
+    if (confirmed == null) {
+      notifier.cancelPin(event.eventId);
+      return;
+    }
+
+    try {
+      final created = await notifier.confirmPin(
+        event.conversationId,
+        event.eventId,
+        name: confirmed.name,
+        topicLabel: confirmed.topicLabel,
+      );
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('Pinned as "${created.pin.pinName}"'),
+          action: SnackBarAction(
+            label: 'Open',
+            onPressed: () => context.push('/pins'),
+          ),
+        ),
+      );
+    } on Exception catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(SnackBar(content: Text('Could not pin: $e')));
+    }
   }
 
   @override
@@ -173,10 +227,18 @@ class _ThreadScreenState extends ConsumerState<ThreadScreen> {
                   final widgets = <Widget>[];
                   for (var i = 0; i < reversed.length; i++) {
                     final event = reversed[i];
+                    final canPin = event.role == EventRole.agent &&
+                        event.conversationId.isNotEmpty;
                     widgets.add(_MessageBubble(
                       key: Key('thread-event-${event.eventId}'),
                       content: event.content,
                       role: event.role,
+                      eventId: event.eventId,
+                      canPin: canPin,
+                      pinned: canPin && notifier.isPinned(event.eventId),
+                      pinInFlight:
+                          canPin && notifier.isPinInFlight(event.eventId),
+                      onPin: canPin ? () => _startPin(event) : null,
                     ));
                     final isLastAgent = event.role == EventRole.agent &&
                         reversed
@@ -235,11 +297,26 @@ class _MessageBubble extends StatelessWidget {
     required this.content,
     required this.role,
     this.pending = false,
+    this.eventId,
+    this.canPin = false,
+    this.pinned = false,
+    this.pinInFlight = false,
+    this.onPin,
   });
 
   final String content;
   final EventRole role;
   final bool pending;
+
+  /// Backend event id — present only for persisted messages (proposal 046).
+  final String? eventId;
+
+  /// Whether the pin affordance is shown. True only for agent messages that
+  /// have a real server identity (an [eventId] + conversation id).
+  final bool canPin;
+  final bool pinned;
+  final bool pinInFlight;
+  final VoidCallback? onPin;
 
   @override
   Widget build(BuildContext context) {
@@ -269,6 +346,28 @@ class _MessageBubble extends StatelessWidget {
       );
     }
 
+    final Widget content0;
+    if (canPin) {
+      content0 = Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          body,
+          Align(
+            alignment: Alignment.centerRight,
+            child: _PinButton(
+              eventId: eventId,
+              pinned: pinned,
+              inFlight: pinInFlight,
+              onPin: onPin,
+            ),
+          ),
+        ],
+      );
+    } else {
+      content0 = body;
+    }
+
     return Align(
       alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
       child: Container(
@@ -285,8 +384,136 @@ class _MessageBubble extends StatelessWidget {
           color: bubbleColor,
           borderRadius: BorderRadius.circular(14),
         ),
-        child: body,
+        child: content0,
       ),
+    );
+  }
+}
+
+/// Pin affordance on an agent bubble: a spinner while a pin flow runs, a filled
+/// pin once saved, an outlined pin otherwise (proposal 046).
+class _PinButton extends StatelessWidget {
+  const _PinButton({
+    required this.eventId,
+    required this.pinned,
+    required this.inFlight,
+    required this.onPin,
+  });
+
+  final String? eventId;
+  final bool pinned;
+  final bool inFlight;
+  final VoidCallback? onPin;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    if (inFlight) {
+      return const Padding(
+        padding: EdgeInsets.all(8),
+        child: SizedBox(
+          width: 16,
+          height: 16,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    return IconButton(
+      key: eventId != null ? Key('pin-button-$eventId') : null,
+      visualDensity: VisualDensity.compact,
+      iconSize: 18,
+      tooltip: pinned ? 'Pinned' : 'Pin this message',
+      color: pinned ? cs.primary : cs.onSurfaceVariant,
+      icon: Icon(pinned ? Icons.push_pin : Icons.push_pin_outlined),
+      onPressed: pinned ? null : onPin,
+    );
+  }
+}
+
+/// User's confirmed pin name + optional topic from [_PinConfirmDialog].
+class _PinConfirmation {
+  const _PinConfirmation({required this.name, this.topicLabel});
+  final String name;
+  final String? topicLabel;
+}
+
+/// Confirm dialog seeded from the backend suggestion. Edits name + topic only;
+/// the pin body is the verbatim message, copied server-side (proposal 046).
+class _PinConfirmDialog extends StatefulWidget {
+  const _PinConfirmDialog({required this.suggestion});
+
+  final PinSuggestion suggestion;
+
+  @override
+  State<_PinConfirmDialog> createState() => _PinConfirmDialogState();
+}
+
+class _PinConfirmDialogState extends State<_PinConfirmDialog> {
+  late final TextEditingController _nameController =
+      TextEditingController(text: widget.suggestion.name);
+  late final TextEditingController _topicController =
+      TextEditingController(text: widget.suggestion.topicLabel ?? '');
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _topicController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return;
+    final topic = _topicController.text.trim();
+    Navigator.of(context).pop(
+      _PinConfirmation(name: name, topicLabel: topic.isEmpty ? null : topic),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      key: const Key('pin-confirm-dialog'),
+      title: const Text('Pin this message'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            key: const Key('pin-name-field'),
+            controller: _nameController,
+            autofocus: true,
+            textCapitalization: TextCapitalization.sentences,
+            decoration: const InputDecoration(
+              labelText: 'Name',
+              hintText: 'What to call this reference',
+            ),
+            onChanged: (_) => setState(() {}),
+            onSubmitted: (_) => _submit(),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            key: const Key('pin-topic-field'),
+            controller: _topicController,
+            decoration: const InputDecoration(
+              labelText: 'Topic (optional)',
+              hintText: 'Group under a topic',
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          key: const Key('pin-cancel-button'),
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          key: const Key('pin-confirm-button'),
+          onPressed:
+              _nameController.text.trim().isEmpty ? null : _submit,
+          child: const Text('Pin'),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/chat/presentation/thread_screen.dart
+++ b/lib/features/chat/presentation/thread_screen.dart
@@ -47,10 +47,11 @@ class _ThreadScreenState extends ConsumerState<ThreadScreen> {
     // Already pinned or a flow is already running for this message.
     if (suggestion == null) return;
     if (!mounted) return;
+    final picked = suggestion;
 
     final confirmed = await showDialog<_PinConfirmation>(
       context: context,
-      builder: (_) => _PinConfirmDialog(suggestion: suggestion!),
+      builder: (_) => _PinConfirmDialog(suggestion: picked),
     );
     if (confirmed == null) {
       notifier.cancelPin(event.eventId);
@@ -346,9 +347,9 @@ class _MessageBubble extends StatelessWidget {
       );
     }
 
-    final Widget content0;
+    final Widget bubbleContent;
     if (canPin) {
-      content0 = Column(
+      bubbleContent = Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -365,7 +366,7 @@ class _MessageBubble extends StatelessWidget {
         ],
       );
     } else {
-      content0 = body;
+      bubbleContent = body;
     }
 
     return Align(
@@ -384,7 +385,7 @@ class _MessageBubble extends StatelessWidget {
           color: bubbleColor,
           borderRadius: BorderRadius.circular(14),
         ),
-        child: content0,
+        child: bubbleContent,
       ),
     );
   }

--- a/test/features/chat/presentation/thread_notifier_test.dart
+++ b/test/features/chat/presentation/thread_notifier_test.dart
@@ -3,7 +3,9 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:voice_agent/core/models/conversation.dart';
 import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/models/pin.dart';
 import 'package:voice_agent/core/network/api_client.dart';
+import 'package:voice_agent/core/network/pin_writer.dart';
 import 'package:voice_agent/core/network/sse_client.dart';
 import 'package:voice_agent/features/chat/domain/chat_repository.dart';
 import 'package:voice_agent/features/chat/domain/chat_state.dart';
@@ -88,6 +90,46 @@ class _StubRepository implements ChatRepository {
   }
 }
 
+class _FakePinWriter implements PinWriter {
+  PinSuggestion suggestResult =
+      const PinSuggestion(name: 'Suggested', topicLabel: 'Topic');
+  Object? suggestError;
+  Object? createError;
+
+  final List<(String, String)> suggestCalls = [];
+  final List<PinCreateRequest> createdRequests = [];
+
+  @override
+  Future<PinSuggestion> suggestPin(
+    String conversationId,
+    String eventId,
+  ) async {
+    suggestCalls.add((conversationId, eventId));
+    if (suggestError != null) throw suggestError!;
+    return suggestResult;
+  }
+
+  @override
+  Future<PinCreateResult> createPin(PinCreateRequest request) async {
+    createdRequests.add(request);
+    if (createError != null) throw createError!;
+    return PinCreateResult(
+      pin: PinDetail(
+        recordId: 'pin-1',
+        pinName: request.name,
+        topicLabel: request.topicLabel,
+        text: 'body',
+        createdAt: DateTime(2026, 1, 1),
+      ),
+      created: true,
+    );
+  }
+}
+
+/// Shared no-op pin writer for the pre-existing tests that never pin. Pin flow
+/// tests build their own `_FakePinWriter` so they can inspect calls.
+final _pinWriter = _FakePinWriter();
+
 Conversation _conv({
   String id = 'conv-1',
   String sessionId = 'sess-1',
@@ -161,7 +203,7 @@ void main() {
     test('transitions to empty state with generated sessionId', () async {
       final repo = _StubRepository();
       final notifier =
-          ThreadNotifier(conversationId: 'new', repository: repo);
+          ThreadNotifier(conversationId: 'new', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -177,7 +219,7 @@ void main() {
           defaultBackend: 'b1',
         );
       final notifier =
-          ThreadNotifier(conversationId: 'new', repository: repo);
+          ThreadNotifier(conversationId: 'new', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -193,7 +235,7 @@ void main() {
         ..eventsResult = [_event()]
         ..recordsResult = [_record()];
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -207,7 +249,7 @@ void main() {
     test('emits error when getConversation returns null', () async {
       final repo = _StubRepository()..conversationResult = null;
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -219,7 +261,7 @@ void main() {
     test('emits error on load failure', () async {
       final repo = _StubRepository()..throwOnLoad = true;
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -234,7 +276,7 @@ void main() {
           defaultBackend: 'b2',
         );
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -247,7 +289,7 @@ void main() {
     test('is no-op when state is streaming', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -263,7 +305,7 @@ void main() {
         ..conversationResult =
             _conv(status: ConversationStatus.closed);
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -274,7 +316,7 @@ void main() {
     test('transitions loaded → streaming with pendingUserMessage', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -288,7 +330,7 @@ void main() {
     test('transitions empty → streaming for new conversation', () async {
       final repo = _StubRepository();
       final notifier =
-          ThreadNotifier(conversationId: 'new', repository: repo);
+          ThreadNotifier(conversationId: 'new', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -303,7 +345,7 @@ void main() {
     test('tool_use event updates toolProgress', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -321,7 +363,7 @@ void main() {
         ..conversationResult = _conv()
         ..eventsResult = [_event(), _event(id: 'evt-2')];
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -340,7 +382,7 @@ void main() {
     test('SSE error event emits error with preSendState', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -358,7 +400,7 @@ void main() {
     test('stream Dart error maps ApiNotConfigured', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -374,7 +416,7 @@ void main() {
     test('stream Dart error maps ApiPermanentFailure', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -391,7 +433,7 @@ void main() {
     test('stream Dart error maps ApiTransientFailure', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -408,7 +450,7 @@ void main() {
     test('post-result fetch failure emits error with streaming state', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -433,7 +475,7 @@ void main() {
     test('is no-op when not streaming', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -444,7 +486,7 @@ void main() {
     test('reverts to preSendState and calls cancelChat', () async {
       final repo = _StubRepository()..conversationResult = _conv(sessionId: 'sess-abc');
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -467,7 +509,7 @@ void main() {
         ..recordsResult = [_record(id: 'rec-1', endorsed: false)]
         ..toggleResult = true;
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -482,7 +524,7 @@ void main() {
         ..conversationResult = _conv()
         ..recordsResult = [_record(id: 'rec-42')];
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -496,7 +538,7 @@ void main() {
     test('selectModel updates loaded state', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -509,7 +551,7 @@ void main() {
     test('selectModel updates empty state', () async {
       final repo = _StubRepository();
       final notifier =
-          ThreadNotifier(conversationId: 'new', repository: repo);
+          ThreadNotifier(conversationId: 'new', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -522,7 +564,7 @@ void main() {
     test('selectModel during loading stores as pending', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       // Immediately after creation, state is ThreadLoading
       expect(notifier.state, isA<ThreadLoading>());
 
@@ -538,7 +580,7 @@ void main() {
     test('selectBackend updates loaded state', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -552,7 +594,7 @@ void main() {
         () async {
       final repo = _StubRepository();
       final notifier =
-          ThreadNotifier(conversationId: 'new', repository: repo);
+          ThreadNotifier(conversationId: 'new', repository: repo, pinWriter: _pinWriter);
       expect(notifier.state, isA<ThreadLoading>());
 
       notifier.selectBackend('backend-b');
@@ -567,7 +609,7 @@ void main() {
     test('selectModel updates streaming state', () async {
       final repo = _StubRepository()..conversationResult = _conv();
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -583,7 +625,7 @@ void main() {
     test('selectModel during error state is a no-op', () async {
       final repo = _StubRepository()..conversationResult = null;
       final notifier =
-          ThreadNotifier(conversationId: 'conv-1', repository: repo);
+          ThreadNotifier(conversationId: 'conv-1', repository: repo, pinWriter: _pinWriter);
       await Future.microtask(() {});
       await Future.microtask(() {});
 
@@ -591,6 +633,138 @@ void main() {
       notifier.selectModel('model-ignored');
 
       expect(notifier.state, isA<ThreadError>());
+    });
+  });
+
+  group('pin flow (P046)', () {
+    Future<ThreadNotifier> loadedNotifier(
+      _StubRepository repo,
+      _FakePinWriter pin,
+    ) async {
+      repo.conversationResult = _conv();
+      repo.eventsResult = [_event(id: 'evt-agent', role: EventRole.agent)];
+      final notifier = ThreadNotifier(
+        conversationId: 'conv-1',
+        repository: repo,
+        pinWriter: pin,
+      );
+      await Future.microtask(() {});
+      await Future.microtask(() {});
+      return notifier;
+    }
+
+    test('beginPin marks in-flight during suggest, clears when it settles',
+        () async {
+      final pin = _FakePinWriter();
+      final notifier = await loadedNotifier(_StubRepository(), pin);
+
+      final future = notifier.beginPin('conv-1', 'evt-agent');
+      // In-flight while the suggest call is pending (drives the spinner).
+      expect(notifier.isPinInFlight('evt-agent'), isTrue);
+
+      final suggestion = await future;
+      expect(suggestion?.name, 'Suggested');
+      expect(pin.suggestCalls.single, ('conv-1', 'evt-agent'));
+      // Cleared once suggest resolves — the dialog runs behind a modal barrier.
+      expect(notifier.isPinInFlight('evt-agent'), isFalse);
+    });
+
+    test('a second beginPin while in-flight is a no-op (single-flight)',
+        () async {
+      final pin = _FakePinWriter();
+      final notifier = await loadedNotifier(_StubRepository(), pin);
+
+      final first = notifier.beginPin('conv-1', 'evt-agent');
+      final second = await notifier.beginPin('conv-1', 'evt-agent');
+      await first;
+
+      expect(second, isNull);
+      expect(pin.suggestCalls, hasLength(1));
+    });
+
+    test('beginPin clears in-flight and rethrows on suggest failure', () async {
+      final pin = _FakePinWriter()..suggestError = Exception('boom');
+      final notifier = await loadedNotifier(_StubRepository(), pin);
+
+      await expectLater(
+        notifier.beginPin('conv-1', 'evt-agent'),
+        throwsA(isA<Exception>()),
+      );
+      expect(notifier.isPinInFlight('evt-agent'), isFalse);
+    });
+
+    test('confirmPin creates with the exact payload and marks pinned',
+        () async {
+      final pin = _FakePinWriter();
+      final notifier = await loadedNotifier(_StubRepository(), pin);
+      await notifier.beginPin('conv-1', 'evt-agent');
+
+      final result = await notifier.confirmPin(
+        'conv-1',
+        'evt-agent',
+        name: 'Garage pinout',
+        topicLabel: 'Electronics',
+      );
+
+      final req = pin.createdRequests.single;
+      expect(req.conversationId, 'conv-1');
+      expect(req.eventId, 'evt-agent');
+      expect(req.name, 'Garage pinout');
+      expect(req.topicLabel, 'Electronics');
+      expect(req.toMap().containsKey('aliases'), isFalse);
+      expect(result.created, isTrue);
+      expect(notifier.isPinned('evt-agent'), isTrue);
+      expect(notifier.isPinInFlight('evt-agent'), isFalse);
+    });
+
+    test('confirmPin clears in-flight and rethrows on create failure',
+        () async {
+      final pin = _FakePinWriter()..createError = Exception('server 500');
+      final notifier = await loadedNotifier(_StubRepository(), pin);
+      await notifier.beginPin('conv-1', 'evt-agent');
+
+      await expectLater(
+        notifier.confirmPin('conv-1', 'evt-agent', name: 'n'),
+        throwsA(isA<Exception>()),
+      );
+      expect(notifier.isPinned('evt-agent'), isFalse);
+      expect(notifier.isPinInFlight('evt-agent'), isFalse);
+    });
+
+    test('cancelPin clears the in-flight mark', () async {
+      final pin = _FakePinWriter();
+      final notifier = await loadedNotifier(_StubRepository(), pin);
+      await notifier.beginPin('conv-1', 'evt-agent');
+
+      notifier.cancelPin('evt-agent');
+
+      expect(notifier.isPinInFlight('evt-agent'), isFalse);
+      expect(notifier.isPinned('evt-agent'), isFalse);
+    });
+
+    test('beginPin on an already-pinned event is a no-op', () async {
+      final pin = _FakePinWriter();
+      final notifier = await loadedNotifier(_StubRepository(), pin);
+      await notifier.beginPin('conv-1', 'evt-agent');
+      await notifier.confirmPin('conv-1', 'evt-agent', name: 'n');
+
+      final again = await notifier.beginPin('conv-1', 'evt-agent');
+
+      expect(again, isNull);
+      expect(pin.suggestCalls, hasLength(1));
+    });
+
+    test('pinned state survives a send (streaming) transition', () async {
+      final pin = _FakePinWriter();
+      final repo = _StubRepository();
+      final notifier = await loadedNotifier(repo, pin);
+      await notifier.beginPin('conv-1', 'evt-agent');
+      await notifier.confirmPin('conv-1', 'evt-agent', name: 'n');
+
+      notifier.send('another message');
+
+      expect(notifier.state, isA<ThreadStreaming>());
+      expect(notifier.isPinned('evt-agent'), isTrue);
     });
   });
 }

--- a/test/features/chat/presentation/thread_screen_test.dart
+++ b/test/features/chat/presentation/thread_screen_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:voice_agent/core/models/conversation.dart';
 import 'package:voice_agent/core/models/conversation_record.dart';
+import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/core/network/pin_writer.dart';
 import 'package:voice_agent/core/network/sse_client.dart';
 import 'package:voice_agent/features/chat/domain/chat_repository.dart';
 import 'package:voice_agent/features/chat/presentation/chat_providers.dart';
@@ -115,10 +117,44 @@ ConversationRecord _record({String id = 'rec-1', bool endorsed = false, String s
   );
 }
 
+class _FakePinWriter implements PinWriter {
+  PinSuggestion suggestResult =
+      const PinSuggestion(name: 'ESP32 pinout', topicLabel: 'Electronics');
+  Object? suggestError;
+  Object? createError;
+  final List<PinCreateRequest> created = [];
+
+  @override
+  Future<PinSuggestion> suggestPin(
+    String conversationId,
+    String eventId,
+  ) async {
+    if (suggestError != null) throw suggestError!;
+    return suggestResult;
+  }
+
+  @override
+  Future<PinCreateResult> createPin(PinCreateRequest request) async {
+    created.add(request);
+    if (createError != null) throw createError!;
+    return PinCreateResult(
+      pin: PinDetail(
+        recordId: 'pin-1',
+        pinName: request.name,
+        topicLabel: request.topicLabel,
+        text: 'body',
+        createdAt: DateTime(2026, 1, 1),
+      ),
+      created: true,
+    );
+  }
+}
+
 Future<void> _pumpScreen(
   WidgetTester tester, {
   required _StubRepository repository,
   String conversationId = 'conv-1',
+  _FakePinWriter? pinWriter,
 }) async {
   final router = GoRouter(
     initialLocation: '/chat/$conversationId',
@@ -132,6 +168,10 @@ Future<void> _pumpScreen(
         path: '/settings',
         builder: (_, _) => const Scaffold(body: Text('Settings')),
       ),
+      GoRoute(
+        path: '/pins',
+        builder: (_, _) => const Scaffold(body: Text('Pins screen')),
+      ),
     ],
   );
 
@@ -139,6 +179,7 @@ Future<void> _pumpScreen(
     ProviderScope(
       overrides: [
         chatRepositoryProvider.overrideWithValue(repository),
+        pinWriterProvider.overrideWithValue(pinWriter ?? _FakePinWriter()),
       ],
       child: MaterialApp.router(routerConfig: router),
     ),
@@ -166,7 +207,10 @@ void main() {
       );
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [chatRepositoryProvider.overrideWithValue(repo)],
+          overrides: [
+            chatRepositoryProvider.overrideWithValue(repo),
+            pinWriterProvider.overrideWithValue(_FakePinWriter()),
+          ],
           child: MaterialApp.router(routerConfig: router),
         ),
       );
@@ -404,6 +448,146 @@ void main() {
       await _pumpScreen(tester, repository: repo, conversationId: 'new');
 
       expect(find.text('New Chat'), findsOneWidget);
+    });
+  });
+
+  group('pin a message (P046)', () {
+    _StubRepository agentRepo() => _StubRepository()
+      ..conversationResult = _conv()
+      ..eventsResult = [
+        _event(id: 'evt-agent', role: EventRole.agent, content: 'Agent reply'),
+      ];
+
+    testWidgets('agent bubble shows a pin button, user bubble does not',
+        (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [
+          _event(id: 'evt-user', role: EventRole.user, content: 'Hi'),
+          _event(id: 'evt-agent', role: EventRole.agent, content: 'Reply'),
+        ];
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.byKey(const Key('pin-button-evt-agent')), findsOneWidget);
+      expect(find.byKey(const Key('pin-button-evt-user')), findsNothing);
+    });
+
+    testWidgets('no pin button when the event has no server conversation id',
+        (tester) async {
+      final repo = _StubRepository()
+        ..conversationResult = _conv()
+        ..eventsResult = [
+          ConversationEvent(
+            eventId: 'evt-agent',
+            conversationId: '',
+            sequence: 1,
+            role: EventRole.agent,
+            content: 'Reply',
+            receivedAt: DateTime(2026, 1, 1),
+          ),
+        ];
+      await _pumpScreen(tester, repository: repo);
+
+      expect(find.byKey(const Key('pin-button-evt-agent')), findsNothing);
+    });
+
+    testWidgets('tapping the pin button opens a dialog seeded from suggestion',
+        (tester) async {
+      final pin = _FakePinWriter()
+        ..suggestResult =
+            const PinSuggestion(name: 'Garage pinout', topicLabel: 'Wiring');
+      await _pumpScreen(tester, repository: agentRepo(), pinWriter: pin);
+
+      await tester.tap(find.byKey(const Key('pin-button-evt-agent')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('pin-confirm-dialog')), findsOneWidget);
+      expect(find.text('Garage pinout'), findsOneWidget);
+      expect(find.text('Wiring'), findsOneWidget);
+    });
+
+    testWidgets('confirming creates the pin with the exact payload',
+        (tester) async {
+      final pin = _FakePinWriter()
+        ..suggestResult =
+            const PinSuggestion(name: 'Garage pinout', topicLabel: 'Wiring');
+      await _pumpScreen(tester, repository: agentRepo(), pinWriter: pin);
+
+      await tester.tap(find.byKey(const Key('pin-button-evt-agent')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('pin-confirm-button')));
+      await tester.pumpAndSettle();
+
+      final req = pin.created.single;
+      expect(req.conversationId, 'conv-1');
+      expect(req.eventId, 'evt-agent');
+      expect(req.name, 'Garage pinout');
+      expect(req.topicLabel, 'Wiring');
+      expect(find.text('Pinned as "Garage pinout"'), findsOneWidget);
+    });
+
+    testWidgets('the pin button becomes filled after a successful pin',
+        (tester) async {
+      await _pumpScreen(tester, repository: agentRepo());
+
+      await tester.tap(find.byKey(const Key('pin-button-evt-agent')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('pin-confirm-button')));
+      await tester.pumpAndSettle();
+
+      final icon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byKey(const Key('pin-button-evt-agent')),
+          matching: find.byType(Icon),
+        ),
+      );
+      expect(icon.icon, Icons.push_pin);
+    });
+
+    testWidgets('the Open snackbar action navigates to the pinboard',
+        (tester) async {
+      await _pumpScreen(tester, repository: agentRepo());
+
+      await tester.tap(find.byKey(const Key('pin-button-evt-agent')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('pin-confirm-button')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Pins screen'), findsOneWidget);
+    });
+
+    testWidgets('cancelling the dialog pins nothing', (tester) async {
+      final pin = _FakePinWriter();
+      await _pumpScreen(tester, repository: agentRepo(), pinWriter: pin);
+
+      await tester.tap(find.byKey(const Key('pin-button-evt-agent')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('pin-cancel-button')));
+      await tester.pumpAndSettle();
+
+      expect(pin.created, isEmpty);
+      final icon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byKey(const Key('pin-button-evt-agent')),
+          matching: find.byType(Icon),
+        ),
+      );
+      expect(icon.icon, Icons.push_pin_outlined);
+    });
+
+    testWidgets('a suggest failure shows a snackbar and opens no dialog',
+        (tester) async {
+      final pin = _FakePinWriter()..suggestError = Exception('offline');
+      await _pumpScreen(tester, repository: agentRepo(), pinWriter: pin);
+
+      await tester.tap(find.byKey(const Key('pin-button-evt-agent')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('pin-confirm-dialog')), findsNothing);
+      expect(find.textContaining('Could not prepare pin'), findsOneWidget);
     });
   });
 }

--- a/test/features/pins/pin_to_conversation_nav_test.dart
+++ b/test/features/pins/pin_to_conversation_nav_test.dart
@@ -12,6 +12,7 @@ import 'package:voice_agent/features/chat/presentation/thread_screen.dart';
 import 'package:voice_agent/features/pins/domain/pins_repository.dart';
 import 'package:voice_agent/features/pins/presentation/pins_providers.dart';
 import 'package:voice_agent/core/models/pin.dart';
+import 'package:voice_agent/core/network/pin_writer.dart';
 
 /// Regression test for the pin -> source-conversation navigation.
 ///
@@ -89,6 +90,24 @@ class _StubChatRepository implements ChatRepository {
   Future<bool> toggleEndorse(String recordId) async => false;
 }
 
+class _NoopPinWriter implements PinWriter {
+  @override
+  Future<PinSuggestion> suggestPin(String conversationId, String eventId) async =>
+      const PinSuggestion(name: 'stub');
+
+  @override
+  Future<PinCreateResult> createPin(PinCreateRequest request) async =>
+      PinCreateResult(
+        pin: PinDetail(
+          recordId: 'pin-1',
+          pinName: request.name,
+          text: 'body',
+          createdAt: DateTime(2026, 1, 1),
+        ),
+        created: true,
+      );
+}
+
 void main() {
   testWidgets(
     'opening a pin\'s source conversation lands on the thread, not the list',
@@ -100,6 +119,7 @@ void main() {
           overrides: [
             pinsRepositoryProvider.overrideWithValue(_StubPinsRepository()),
             chatRepositoryProvider.overrideWithValue(_StubChatRepository()),
+            pinWriterProvider.overrideWithValue(_NoopPinWriter()),
           ],
           child: MaterialApp.router(
             routerConfig: createRouter(initialLocation: '/pins/abc'),


### PR DESCRIPTION
## P046 T2 — pin a chat message from the thread

Second slice of [proposal 046](../blob/main/docs/proposals/046-pin-a-chat-message.md). Wires the chat UI to the `core` `PinWriter` seam from T1 (#337), so a user can pin any agent message.

### Changes
- **`ThreadNotifier`** — `beginPin` / `confirmPin` / `cancelPin` + session-local `_pinInFlight` / `_pinnedEventIds`. Both are **notifier fields**, not on the immutable `Thread*` states, so they survive a streaming→loaded transition without threading through every rebuild (a `_touch()` helper re-emits current state so listeners refresh). Network calls + state live in the notifier, mirroring `toggleEndorse`. In-flight spans only the suggest call (the confirm dialog runs behind a modal barrier).
- **`chat_providers`** — injects `pinWriterProvider` into `ThreadNotifier`.
- **`_MessageBubble` / `_PinButton`** — pin icon on agent bubbles that have a real server conversation id (spinner while suggesting, filled once pinned). User bubbles unchanged.
- **`ThreadScreen`** — drives suggest → `_PinConfirmDialog` (editable name + topic) → create; success SnackBar (`Pinned as "…"` + **Open** → `/pins`) and error SnackBars. Errors caught generically (message via `toString`) so **chat never imports `features/pins`**.

### Guard
The effective conversation id comes from the **event**, not the `'new'` route param (which stays `'new'` after the first send), so the icon appears on conversations created in-app.

### Tests
- `thread_notifier_test` — begin/confirm/cancel, single-flight, in-flight lifecycle, exact create payload (no `aliases`), suggest/create failure cleanup, pinned survives a streaming transition.
- `thread_screen_test` — icon by role + real-id guard, dialog seeded from suggestion, create payload, filled-after-pin, Open→pinboard nav, cancel pins nothing, suggest-failure SnackBar + no dialog.

### Verification
`make verify` — analyzer clean, all 1144 tests pass. Dependency-rule gates: `features/chat` imports no `features/pins`; `core` imports no `features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
