### PR TITLE
fix(settings): show real app version instead of hardcoded 1.0.0

### DIFF
--- a/lib/core/providers/app_version_provider.dart
+++ b/lib/core/providers/app_version_provider.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// The installed app version read from the bundle at runtime, formatted as
+/// `<version> (<build>)` — e.g. `1.2.0 (4)`. This is sourced from
+/// `pubspec.yaml`'s `version:` line (the single source of truth), so the
+/// Settings screen always reflects the build that is actually installed.
+///
+/// Overridable in tests to avoid the platform channel.
+final appVersionProvider = FutureProvider<String>((ref) async {
+  final info = await PackageInfo.fromPlatform();
+  return '${info.version} (${info.buildNumber})';
+});

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -8,6 +8,7 @@ import 'package:voice_agent/core/config/app_config.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/network/api_client.dart';
 import 'package:voice_agent/core/providers/api_client_provider.dart';
+import 'package:voice_agent/core/providers/app_version_provider.dart';
 import 'package:voice_agent/core/storage/storage_provider.dart';
 
 class SettingsScreen extends ConsumerStatefulWidget {
@@ -114,6 +115,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     final config = ref.watch(appConfigProvider);
+    final appVersion = ref.watch(appVersionProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
@@ -298,7 +300,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           _buildSectionHeader('About'),
           ListTile(
             title: const Text('Version'),
-            trailing: const Text('1.0.0'),
+            trailing: Text(
+              appVersion.maybeWhen(
+                data: (v) => v,
+                orElse: () => '…',
+              ),
+            ),
           ),
           FutureBuilder<String>(
             future: ref.read(storageServiceProvider).getDeviceId(),

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import flutter_local_notifications
 import flutter_secure_storage_macos
 import flutter_timezone
 import flutter_tts
+import package_info_plus
 import record_macos
 import shared_preferences_foundation
 import sqflite_darwin
@@ -22,6 +23,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   FlutterTtsPlugin.register(with: registry.registrar(forPlugin: "FlutterTtsPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -488,6 +488,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.18.11"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Single source of truth for the app version. Format: MAJOR.MINOR.PATCH+BUILD.
 # Bump it in the same PR as the change, and tag `vMAJOR.MINOR.PATCH` after merge.
 # See "Versioning & Releases" in CLAUDE.md for the rules.
-version: 1.2.0+4
+version: 1.2.1+5
 
 environment:
   sdk: ^3.11.1
@@ -35,6 +35,7 @@ dependencies:
   flutter_markdown_plus: ^1.0.4
   opentelemetry: ^0.18.11
   http: ^1.1.0
+  package_info_plus: ^8.0.0
 
 dev_dependencies:
   flutter_test:

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -19,6 +19,7 @@ import 'package:voice_agent/core/tts/tts_provider.dart';
 import 'package:voice_agent/core/tts/tts_service.dart';
 import 'package:voice_agent/features/api_sync/sync_provider.dart';
 import 'package:voice_agent/core/background/background_service_provider.dart';
+import 'package:voice_agent/core/providers/app_version_provider.dart';
 
 import '../../helpers/stub_background_service.dart';
 import '../../helpers/stub_notifications.dart';
@@ -83,6 +84,7 @@ class _StubAudioFeedbackService implements AudioFeedbackService {
 }
 
 List<Override> _baseOverrides() => [
+  appVersionProvider.overrideWith((ref) async => '1.2.0 (4)'),
   storageServiceProvider.overrideWithValue(_StubStorage()),
   connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
   ttsServiceProvider.overrideWithValue(_StubTtsService()),
@@ -284,6 +286,31 @@ void main() {
       expect(find.byKey(const Key('picovoice-key-field')), findsNothing);
       expect(find.byKey(const Key('wake-word-sensitivity-slider')), findsNothing);
       expect(find.byKey(const Key('wake-word-keyword-dropdown')), findsNothing);
+    });
+
+    testWidgets('Version tile shows the runtime app version, not a hardcode',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: _baseOverrides(),
+          child: const App(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await _navigateToSettings(tester);
+
+      // The About → Version tile is at the bottom of the list; scroll it in.
+      await tester.scrollUntilVisible(
+        find.text('1.2.0 (4)'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+
+      // It renders the value from appVersionProvider (overridden to 1.2.0 (4)),
+      // never the old hardcoded '1.0.0'.
+      expect(find.text('1.2.0 (4)'), findsOneWidget);
+      expect(find.text('1.0.0'), findsNothing);
     });
 
     testWidgets('Groq API Key field saves on focus lost', (tester) async {


### PR DESCRIPTION
## What

Settings → About → Version was hardcoded to `1.0.0` (`settings_screen.dart:301`) and never reflected the installed build — so you couldn't tell from the phone which version was on it.

This reads the version + build number at runtime via `package_info_plus`, exposed through a new `appVersionProvider` (core layer), and renders it in the Version tile as `<version> (<build>)` (e.g. `1.2.0 (4)`).

## Changes

- `lib/core/providers/app_version_provider.dart` — `FutureProvider<String>` reading `PackageInfo.fromPlatform()`, overridable in tests.
- `lib/features/settings/settings_screen.dart` — Version tile now watches the provider (`…` while loading, real value once resolved).
- `package_info_plus: ^8.0.0` added; `pubspec.lock` + macOS plugin registrant regenerated.
- Version bump `1.2.0+4` → `1.2.1+5` (fix + build).
- Widget test asserting the tile renders the runtime value, never `1.0.0`.

## Verification

`make verify` — analyze clean, **1145 tests passed** (EXIT=0). New test `SettingsScreen Version tile shows the runtime app version, not a hardcode` green.

## Notes

Prerequisite for #346 (report app version to personal-agent). Device check: after install, Settings → About → Version should read the real build.

Closes #345
