### PR TITLE
feat(api_sync): report installed app version via X-App-Version header

### DIFF
--- a/docs/decisions/ADR-NET-004-app-version-sync-header.md
+++ b/docs/decisions/ADR-NET-004-app-version-sync-header.md
@@ -1,0 +1,43 @@
+# ADR-NET-004: Report the installed app version via the X-App-Version sync header
+
+Status: Accepted
+
+## Context
+
+There was no way to tell which voice-agent build was installed on a device
+without a rebuild+reinstall. The in-app Settings tile was hardcoded (fixed in
+#345), and nothing the app sent to personal-agent carried the version, so the
+backend could not answer "what build is on the phone?" either.
+
+The app already makes an authenticated `POST` to personal-agent on every
+transcript sync (ADR-NET-002). That request is the natural carrier for a
+version signal — no new endpoint, no polling.
+
+## Decision
+
+`ApiClient` attaches an `X-App-Version` header, valued with the installed
+version in wire form `<version>+<build>` (e.g. `1.3.0+6`, mirroring
+`pubspec.yaml`'s `version:` line), to **every** request it makes — the
+transcript `POST`, `testConnection`, and the generic `request()` path.
+
+- The value flows from `appVersionProvider` (the runtime `package_info_plus`
+  read added in #345) through `apiClientProvider`, which passes
+  `AppVersion.wire` into `ApiClient(appVersion: …)`.
+- The provider is a `FutureProvider`; until it resolves, `appVersion` is null
+  and the header is **omitted**. The client rebuilds with the header set once
+  the value is available. Absence is a valid state, never an error.
+- Header construction is centralised in `ApiClient._headers()` so Auth,
+  Content-Type, and version stay consistent across call sites.
+
+The backend side (capture, persistence, exposure) is the sibling change in
+personal-agent (thought-agent#492, ADR there).
+
+## Consequences
+
+- **Backward-compatible both ways.** Old servers ignore the unknown header;
+  old clients (no header) are recorded as "unknown" server-side. No coordinated
+  deploy is required — the header is inert until the backend reads it.
+- The version leaves the device on every sync. It is non-sensitive (the build
+  number of an app the user installed) and goes only to the user's own
+  configured backend over the existing authenticated channel.
+- Cited by #346. Backend contract half: thought-agent#492.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -80,6 +80,8 @@ and focused on a single decision. See any existing ADR for reference.
 | --- | ----- | ------ |
 | [ADR-NET-001](ADR-NET-001-dio-sealed-error-classification.md) | Dio HTTP client with sealed ApiResult error classification | Accepted |
 | [ADR-NET-002](ADR-NET-002-foreground-only-sync.md) | Foreground-only sync with no background processing | Accepted |
+| [ADR-NET-003](ADR-NET-003-sse-streaming-client.md) | SSE streaming client | Accepted |
+| [ADR-NET-004](ADR-NET-004-app-version-sync-header.md) | Report installed app version via X-App-Version sync header | Accepted |
 
 ### PLATFORM — Mobile Platform & UX
 

--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -28,12 +28,25 @@ class ApiNotConfigured extends ApiResult {
 }
 
 class ApiClient {
-  ApiClient({Dio? dio, this.baseUrl, this.token})
+  ApiClient({Dio? dio, this.baseUrl, this.token, this.appVersion})
       : _dio = dio ?? _createDefaultDio();
 
   final Dio _dio;
   final String? baseUrl;
   final String? token;
+
+  /// Installed app version in wire form (e.g. `1.2.1+5`), reported to the
+  /// backend via the `X-App-Version` header so the build on this device is
+  /// queryable server-side. Null when not yet resolved — the header is simply
+  /// omitted, and the backend treats its absence as unknown.
+  final String? appVersion;
+
+  Map<String, String> _headers({String? token}) => {
+        'Content-Type': 'application/json',
+        if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
+        if (appVersion != null && appVersion!.isNotEmpty)
+          'X-App-Version': appVersion!,
+      };
 
   static Dio _createDefaultDio() {
     return Dio(BaseOptions(
@@ -59,13 +72,7 @@ class ApiClient {
           'language': transcript.language,
           'deviceId': transcript.deviceId,
         },
-        options: Options(
-          headers: {
-            'Content-Type': 'application/json',
-            if (token != null && token.isNotEmpty)
-              'Authorization': 'Bearer $token',
-          },
-        ),
+        options: Options(headers: _headers(token: token)),
       );
 
       final statusCode = response.statusCode ?? 0;
@@ -91,13 +98,7 @@ class ApiClient {
       final response = await _dio.post<dynamic>(
         url,
         data: {'test': true},
-        options: Options(
-          headers: {
-            'Content-Type': 'application/json',
-            if (token != null && token.isNotEmpty)
-              'Authorization': 'Bearer $token',
-          },
-        ),
+        options: Options(headers: _headers(token: token)),
       );
 
       final statusCode = response.statusCode ?? 0;
@@ -151,11 +152,7 @@ class ApiClient {
         queryParameters: queryParameters,
         options: Options(
           method: method,
-          headers: {
-            'Content-Type': 'application/json',
-            if (token != null && token!.isNotEmpty)
-              'Authorization': 'Bearer $token',
-          },
+          headers: _headers(token: token),
         ),
       );
 

--- a/lib/core/providers/api_client_provider.dart
+++ b/lib/core/providers/api_client_provider.dart
@@ -2,12 +2,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:voice_agent/core/config/app_config_provider.dart';
 import 'package:voice_agent/core/network/api_client.dart';
 import 'package:voice_agent/core/network/sse_client.dart';
+import 'package:voice_agent/core/providers/app_version_provider.dart';
 
 final apiClientProvider = Provider<ApiClient>((ref) {
   final config = ref.watch(appConfigProvider);
+  // Reports the installed build to the backend via X-App-Version. Null until
+  // the version future resolves; the client then rebuilds with it set.
+  final appVersion = ref.watch(appVersionProvider).valueOrNull;
   return ApiClient(
     baseUrl: deriveBaseUrl(config.apiUrl),
     token: config.apiToken,
+    appVersion: appVersion?.wire,
   );
 });
 

--- a/lib/core/providers/app_version_provider.dart
+++ b/lib/core/providers/app_version_provider.dart
@@ -1,13 +1,29 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
-/// The installed app version read from the bundle at runtime, formatted as
-/// `<version> (<build>)` — e.g. `1.2.0 (4)`. This is sourced from
-/// `pubspec.yaml`'s `version:` line (the single source of truth), so the
-/// Settings screen always reflects the build that is actually installed.
-///
-/// Overridable in tests to avoid the platform channel.
-final appVersionProvider = FutureProvider<String>((ref) async {
+/// The installed app version, read from the bundle at runtime. Sourced from
+/// `pubspec.yaml`'s `version:` line (the single source of truth), so anything
+/// that surfaces the version reflects the build actually installed.
+class AppVersion {
+  const AppVersion({required this.version, required this.build});
+
+  /// The semantic version, e.g. `1.2.1`.
+  final String version;
+
+  /// The build number, e.g. `5`.
+  final String build;
+
+  /// Human-readable form for UI, e.g. `1.2.1 (5)`.
+  String get display => '$version ($build)';
+
+  /// Compact wire form for the `X-App-Version` sync header, e.g. `1.2.1+5` —
+  /// mirrors the `pubspec.yaml` `version:` format so the backend can parse it.
+  String get wire => '$version+$build';
+}
+
+/// Reads the installed [AppVersion] at runtime. Overridable in tests to avoid
+/// the platform channel.
+final appVersionProvider = FutureProvider<AppVersion>((ref) async {
   final info = await PackageInfo.fromPlatform();
-  return '${info.version} (${info.buildNumber})';
+  return AppVersion(version: info.version, build: info.buildNumber);
 });

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -302,7 +302,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             title: const Text('Version'),
             trailing: Text(
               appVersion.maybeWhen(
-                data: (v) => v,
+                data: (v) => v.display,
                 orElse: () => '…',
               ),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Single source of truth for the app version. Format: MAJOR.MINOR.PATCH+BUILD.
 # Bump it in the same PR as the change, and tag `vMAJOR.MINOR.PATCH` after merge.
 # See "Versioning & Releases" in CLAUDE.md for the rules.
-version: 1.2.1+5
+version: 1.3.0+6
 
 environment:
   sdk: ^3.11.1

--- a/test/core/network/api_client_test.dart
+++ b/test/core/network/api_client_test.dart
@@ -177,6 +177,41 @@ void main() {
       expect(_MockAdapter.lastHeaders?['Authorization'], isNull);
     });
 
+    test('sends X-App-Version header when appVersion provided', () async {
+      _MockAdapter.nextStatusCode = 200;
+      _MockAdapter.lastHeaders = null;
+      final versioned = ApiClient(dio: dio, appVersion: '1.2.1+5');
+
+      await versioned.post(
+        transcript,
+        url: 'https://example.com/api',
+      );
+
+      expect(_MockAdapter.lastHeaders?['X-App-Version'], '1.2.1+5');
+    });
+
+    test('omits X-App-Version header when appVersion is null', () async {
+      _MockAdapter.nextStatusCode = 200;
+      _MockAdapter.lastHeaders = null;
+
+      await client.post(
+        transcript,
+        url: 'https://example.com/api',
+      );
+
+      expect(_MockAdapter.lastHeaders?['X-App-Version'], isNull);
+    });
+
+    test('testConnection also carries X-App-Version', () async {
+      _MockAdapter.nextStatusCode = 200;
+      _MockAdapter.lastHeaders = null;
+      final versioned = ApiClient(dio: dio, appVersion: '1.2.1+5');
+
+      await versioned.testConnection(url: 'https://example.com/api');
+
+      expect(_MockAdapter.lastHeaders?['X-App-Version'], '1.2.1+5');
+    });
+
     test('body in ApiSuccess is valid JSON when server returns JSON object',
         () async {
       _MockAdapter.nextStatusCode = 200;

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -84,7 +84,9 @@ class _StubAudioFeedbackService implements AudioFeedbackService {
 }
 
 List<Override> _baseOverrides() => [
-  appVersionProvider.overrideWith((ref) async => '1.2.0 (4)'),
+  appVersionProvider.overrideWith(
+    (ref) async => const AppVersion(version: '1.2.0', build: '4'),
+  ),
   storageServiceProvider.overrideWithValue(_StubStorage()),
   connectivityServiceProvider.overrideWith((_) => _NoOpConnectivity()),
   ttsServiceProvider.overrideWithValue(_StubTtsService()),


### PR DESCRIPTION
## What

The phone now reports its installed build to personal-agent so the version on a device is queryable without a rebuild. Client half of the version-reporting contract.

**Sibling PR (backend half):** mjarco/thought-agent#493 (captures + persists + exposes). ADRs: this side ADR-NET-004, backend side ADR-API-076. Builds on #345 (runtime version read).

## Changes

- `appVersionProvider` now yields a structured `AppVersion` (`display` `1.3.0 (6)` for UI, `wire` `1.3.0+6` for the header).
- `apiClientProvider` feeds `AppVersion.wire` into `ApiClient`; header construction centralised in `ApiClient._headers()`, adding `X-App-Version` to the transcript POST, `testConnection`, and the generic `request()`.
- Version bump `1.2.1+5` → `1.3.0+6` (feature). ADR-NET-004.

## Verification

`make verify` — analyze clean, **1148 tests passed** (EXIT=0). New `ApiClient` tests: sends `X-App-Version` when set, omits when null, and `testConnection` carries it.

## Backward-compat

The header is omitted until the version future resolves, and old servers ignore it. Inert until the backend (#493) reads it — no coordinated deploy required.

Closes #346
